### PR TITLE
Add OpenTelemetry observability stack and improve instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -395,6 +413,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -415,7 +461,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -433,16 +483,34 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -456,12 +524,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -526,6 +600,10 @@ dependencies = [
  "hippo-core",
  "hostname",
  "libc",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
  "rusqlite",
  "serde",
@@ -533,6 +611,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -632,6 +711,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -810,6 +902,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -841,6 +943,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1047,6 +1158,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e716f864eb23007bdd9dc4aec381e188a1cee28eecf22066772b5fd822b9727d"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
+dependencies = [
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1285,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1332,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1360,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,9 +1393,74 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1200,7 +1520,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1222,7 +1544,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1683,6 +2005,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,7 +2034,7 @@ version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -1735,6 +2068,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,7 +2141,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -1820,6 +2199,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -2028,7 +2425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2041,7 +2438,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -2050,6 +2447,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2241,7 +2648,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2272,7 +2679,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -2291,7 +2698,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -2328,6 +2735,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,10 @@ toml = "1.1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
+opentelemetry = "0.29"
+opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
+opentelemetry-appender-tracing = "0.29"
+tracing-opentelemetry = "0.30"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 sha2 = "0.11"

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -18,6 +18,11 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.15",
 ]
+otel = [
+    "opentelemetry-api>=1.33",
+    "opentelemetry-sdk>=1.33",
+    "opentelemetry-exporter-otlp-proto-http>=1.33",
+]
 
 [project.scripts]
 hippo-brain = "hippo_brain:main"

--- a/brain/src/hippo_brain/__init__.py
+++ b/brain/src/hippo_brain/__init__.py
@@ -26,6 +26,7 @@ def _load_runtime_settings() -> dict:
     lmstudio = config.get("lmstudio", {})
     models = config.get("models", {})
     brain = config.get("brain", {})
+    telemetry = config.get("telemetry", {})
 
     return {
         "db_path": str(data_dir / "hippo.db"),
@@ -41,6 +42,7 @@ def _load_runtime_settings() -> dict:
         ),
         "session_stale_secs": brain.get("session_stale_secs", 120),
         "port": brain.get("port", 9175),
+        "telemetry_endpoint": telemetry.get("endpoint", "http://localhost:4318"),
     }
 
 
@@ -55,8 +57,13 @@ def main() -> None:
         import uvicorn
 
         from hippo_brain.server import create_app
+        from hippo_brain.telemetry import init_telemetry
 
         settings = _load_runtime_settings()
+
+        otel_endpoint = settings.get("telemetry_endpoint", "")
+        _otel_shutdown = init_telemetry("hippo-brain", endpoint=otel_endpoint)
+
         app = create_app(
             db_path=settings["db_path"],
             data_dir=settings["data_dir"],

--- a/brain/src/hippo_brain/__init__.py
+++ b/brain/src/hippo_brain/__init__.py
@@ -74,7 +74,11 @@ def main() -> None:
             enrichment_batch_size=settings["max_events_per_chunk"],
             session_stale_secs=settings["session_stale_secs"],
         )
-        uvicorn.run(app, host="127.0.0.1", port=settings["port"])
+        try:
+            uvicorn.run(app, host="127.0.0.1", port=settings["port"])
+        finally:
+            if _otel_shutdown:
+                _otel_shutdown()
     elif command == "enrich":
         print("Enrichment worker not yet implemented as standalone command.")
     else:

--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -1,6 +1,5 @@
 """Hippo MCP Server — expose the knowledge base as tools for Claude Code."""
 
-import os
 import sqlite3
 import time
 import tomllib
@@ -20,21 +19,10 @@ from hippo_brain.mcp_queries import (
     search_knowledge_lexical,
     shape_semantic_results,
 )
+from hippo_brain.telemetry import get_tracer as _get_tracer
 
 logger = setup_logging("hippo-mcp")
 metrics = MetricsCollector()
-
-
-def _get_tracer():
-    """Get OTel tracer if available, else return None."""
-    try:
-        if os.environ.get("HIPPO_OTEL_ENABLED", "").strip() != "1":
-            return None
-        from opentelemetry import trace
-
-        return trace.get_tracer("hippo-brain")
-    except ImportError:
-        return None
 
 
 def _load_config() -> dict:

--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -1,8 +1,10 @@
 """Hippo MCP Server — expose the knowledge base as tools for Claude Code."""
 
+import os
 import sqlite3
 import time
 import tomllib
+from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -21,6 +23,18 @@ from hippo_brain.mcp_queries import (
 
 logger = setup_logging("hippo-mcp")
 metrics = MetricsCollector()
+
+
+def _get_tracer():
+    """Get OTel tracer if available, else return None."""
+    try:
+        if os.environ.get("HIPPO_OTEL_ENABLED", "").strip() != "1":
+            return None
+        from opentelemetry import trace
+
+        return trace.get_tracer("hippo-brain")
+    except ImportError:
+        return None
 
 
 def _load_config() -> dict:
@@ -134,45 +148,55 @@ async def search_knowledge(
     t0 = time.monotonic()
     logger.info("search_knowledge called: query=%r mode=%s limit=%d", query, mode, limit)
 
-    try:
-        if mode == "semantic" and _state.lm_client and _state.vector_table:
-            metrics.semantic_searches += 1
-            try:
-                vecs = await _state.lm_client.embed([query], model=_state.embedding_model)
-                hits = search_similar(_state.vector_table, vecs[0], limit=limit)
-                results = shape_semantic_results(hits)
-                elapsed = time.monotonic() - t0
-                logger.info(
-                    "search_knowledge completed: %d results in %.3fs (semantic)",
-                    len(results),
-                    elapsed,
-                )
-                return results
-            except Exception:
-                logger.exception("Semantic search failed, falling back to lexical")
-                metrics.lexical_fallbacks += 1
-                metrics.lmstudio_errors += 1
-
-        # Lexical search (explicit mode or fallback)
-        metrics.lexical_searches += 1
-        conn = _get_conn()
-        try:
-            results = search_knowledge_lexical(conn, query, limit=limit)
-        finally:
-            conn.close()
-
-        elapsed = time.monotonic() - t0
-        logger.info(
-            "search_knowledge completed: %d results in %.3fs (lexical)",
-            len(results),
-            elapsed,
+    tracer = _get_tracer()
+    span_ctx = (
+        tracer.start_as_current_span(
+            "mcp.search_knowledge",
+            attributes={"hippo.query": query, "hippo.mode": mode},
         )
-        return results
+        if tracer
+        else nullcontext()
+    )
+    with span_ctx:
+        try:
+            if mode == "semantic" and _state.lm_client and _state.vector_table:
+                metrics.semantic_searches += 1
+                try:
+                    vecs = await _state.lm_client.embed([query], model=_state.embedding_model)
+                    hits = search_similar(_state.vector_table, vecs[0], limit=limit)
+                    results = shape_semantic_results(hits)
+                    elapsed = time.monotonic() - t0
+                    logger.info(
+                        "search_knowledge completed: %d results in %.3fs (semantic)",
+                        len(results),
+                        elapsed,
+                    )
+                    return results
+                except Exception:
+                    logger.exception("Semantic search failed, falling back to lexical")
+                    metrics.lexical_fallbacks += 1
+                    metrics.lmstudio_errors += 1
 
-    except Exception:
-        metrics.tool_errors += 1
-        logger.exception("search_knowledge failed")
-        raise
+            # Lexical search (explicit mode or fallback)
+            metrics.lexical_searches += 1
+            conn = _get_conn()
+            try:
+                results = search_knowledge_lexical(conn, query, limit=limit)
+            finally:
+                conn.close()
+
+            elapsed = time.monotonic() - t0
+            logger.info(
+                "search_knowledge completed: %d results in %.3fs (lexical)",
+                len(results),
+                elapsed,
+            )
+            return results
+
+        except Exception:
+            metrics.tool_errors += 1
+            logger.exception("search_knowledge failed")
+            raise
 
 
 @mcp.tool()
@@ -204,24 +228,34 @@ async def search_events(
         limit,
     )
 
-    try:
-        conn = _get_conn()
+    tracer = _get_tracer()
+    span_ctx = (
+        tracer.start_as_current_span(
+            "mcp.search_events",
+            attributes={"hippo.query": query, "hippo.mode": source},
+        )
+        if tracer
+        else nullcontext()
+    )
+    with span_ctx:
         try:
-            results = search_events_impl(
-                conn, query=query, source=source, since=since, project=project, limit=limit
-            )
-        finally:
-            conn.close()
+            conn = _get_conn()
+            try:
+                results = search_events_impl(
+                    conn, query=query, source=source, since=since, project=project, limit=limit
+                )
+            finally:
+                conn.close()
 
-        elapsed = time.monotonic() - t0
-        metrics.events_searched += len(results)
-        logger.info("search_events completed: %d results in %.3fs", len(results), elapsed)
-        return results
+            elapsed = time.monotonic() - t0
+            metrics.events_searched += len(results)
+            logger.info("search_events completed: %d results in %.3fs", len(results), elapsed)
+            return results
 
-    except Exception:
-        metrics.tool_errors += 1
-        logger.exception("search_events failed")
-        raise
+        except Exception:
+            metrics.tool_errors += 1
+            logger.exception("search_events failed")
+            raise
 
 
 @mcp.tool()
@@ -243,22 +277,32 @@ async def get_entities(
     t0 = time.monotonic()
     logger.info("get_entities called: type=%r query=%r limit=%d", type, query, limit)
 
-    try:
-        conn = _get_conn()
+    tracer = _get_tracer()
+    span_ctx = (
+        tracer.start_as_current_span(
+            "mcp.get_entities",
+            attributes={"hippo.query": query, "hippo.mode": type},
+        )
+        if tracer
+        else nullcontext()
+    )
+    with span_ctx:
         try:
-            results = get_entities_impl(conn, entity_type=type, query=query, limit=limit)
-        finally:
-            conn.close()
+            conn = _get_conn()
+            try:
+                results = get_entities_impl(conn, entity_type=type, query=query, limit=limit)
+            finally:
+                conn.close()
 
-        metrics.entities_returned += len(results)
-        elapsed = time.monotonic() - t0
-        logger.info("get_entities completed: %d results in %.3fs", len(results), elapsed)
-        return results
+            metrics.entities_returned += len(results)
+            elapsed = time.monotonic() - t0
+            logger.info("get_entities completed: %d results in %.3fs", len(results), elapsed)
+            return results
 
-    except Exception:
-        metrics.tool_errors += 1
-        logger.exception("get_entities failed")
-        raise
+        except Exception:
+            metrics.tool_errors += 1
+            logger.exception("get_entities failed")
+            raise
 
 
 def main() -> None:

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import sqlite3
 import time
 from contextlib import asynccontextmanager, suppress
@@ -42,6 +43,18 @@ from hippo_brain.claude_sessions import (
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger("hippo_brain")
+
+
+def _get_tracer():
+    """Get OTel tracer if available, else return None."""
+    try:
+        if os.environ.get("HIPPO_OTEL_ENABLED", "").strip() != "1":
+            return None
+        from opentelemetry import trace
+
+        return trace.get_tracer("hippo-brain")
+    except ImportError:
+        return None
 
 
 class BrainServer:
@@ -287,118 +300,26 @@ class BrainServer:
                         prompt = build_enrichment_prompt(events, browser_context=browser_context)
                         logger.info("calling LM Studio (prompt len: %d chars)", len(prompt))
 
-                        try:
-                            result = None
-                            last_err = None
-                            for attempt in range(3):
-                                try:
-                                    messages = [
-                                        {"role": "system", "content": SYSTEM_PROMPT},
-                                        {"role": "user", "content": prompt},
-                                    ]
-                                    if attempt > 0:
-                                        messages.append(
-                                            {
-                                                "role": "user",
-                                                "content": (
-                                                    "Your previous response was not valid JSON. "
-                                                    "Output ONLY a JSON object, no explanation or markdown."
-                                                ),
-                                            }
-                                        )
-                                    raw = await self.client.chat(
-                                        messages=messages,
-                                        model=self.enrichment_model,
-                                    )
-                                    logger.debug(
-                                        "LLM raw response (%d chars): %s",
-                                        len(raw or ""),
-                                        repr(raw)[:200],
-                                    )
-                                    result = parse_enrichment_response(raw)
-                                    break
-                                except Exception as e:
-                                    last_err = e
-                                    logger.warning(
-                                        "enrichment parse attempt %d failed: %s",
-                                        attempt + 1,
-                                        e,
-                                    )
-                            if result is None:
-                                raise last_err
-                            node_id = write_knowledge_node(
-                                conn, result, event_ids, self.enrichment_model
+                        tracer = _get_tracer()
+                        _shell_span = (
+                            tracer.start_as_current_span(
+                                "enrichment.shell",
+                                attributes={
+                                    "hippo.event_count": len(event_ids),
+                                    "hippo.model": self.enrichment_model,
+                                },
                             )
-                            self.last_success_at_ms = int(time.time() * 1000)
-                            self.last_error = None
-                            self.last_error_at_ms = None
-                            logger.info("enriched %d events -> node %d", len(event_ids), node_id)
-
-                            if self.embedding_model:
-                                try:
-                                    node_dict = {
-                                        "id": node_id,
-                                        "session_id": events[0].get("session_id", 0),
-                                        "captured_at": int(time.time() * 1000),
-                                        "commands_raw": " ; ".join(
-                                            e.get("command", "") for e in events
-                                        ),
-                                        "cwd": events[0].get("cwd", ""),
-                                        "git_branch": events[0].get("git_branch", ""),
-                                        "git_repo": "",
-                                        "outcome": result.outcome,
-                                        "tags": result.tags,
-                                        "key_decisions": result.key_decisions,
-                                        "problems_encountered": result.problems_encountered,
-                                        "entities": result.entities
-                                        if isinstance(result.entities, dict)
-                                        else {},
-                                        "embed_text": result.embed_text,
-                                        "summary": result.summary,
-                                        "enrichment_model": self.enrichment_model,
-                                        "enrichment_version": 1,
-                                    }
-                                    await embed_knowledge_node(
-                                        self.client,
-                                        self._vector_table,
-                                        node_dict,
-                                        embed_model=self.embedding_model,
-                                    )
-                                    logger.info("embedded node %d into vector store", node_id)
-                                except Exception as e:
-                                    logger.warning("embedding failed (non-fatal): %s", e)
-                        except Exception as e:
-                            self.last_error = str(e)
-                            self.last_error_at_ms = int(time.time() * 1000)
-                            logger.error("enrichment failed: %s", e)
-                            retry_conn = self._get_conn()
-                            try:
-                                mark_queue_failed(retry_conn, event_ids, str(e))
-                            finally:
-                                retry_conn.close()
-
-                    # Process Claude session segments
-                    try:
-                        claude_batches = claim_pending_claude_segments(conn, worker_id)
-                        for segments in claude_batches:
-                            segment_ids = [s["id"] for s in segments]
-                            prompt = "\n---\n\n".join(s["summary_text"] for s in segments)
-                            logger.info(
-                                "claimed %d claude segments: %s",
-                                len(segment_ids),
-                                segment_ids,
-                            )
-
+                            if tracer
+                            else suppress()
+                        )
+                        with _shell_span:
                             try:
                                 result = None
                                 last_err = None
                                 for attempt in range(3):
                                     try:
                                         messages = [
-                                            {
-                                                "role": "system",
-                                                "content": CLAUDE_SYSTEM_PROMPT,
-                                            },
+                                            {"role": "system", "content": SYSTEM_PROMPT},
                                             {"role": "user", "content": prompt},
                                         ]
                                         if attempt > 0:
@@ -415,166 +336,43 @@ class BrainServer:
                                             messages=messages,
                                             model=self.enrichment_model,
                                         )
+                                        logger.debug(
+                                            "LLM raw response (%d chars): %s",
+                                            len(raw or ""),
+                                            repr(raw)[:200],
+                                        )
                                         result = parse_enrichment_response(raw)
                                         break
                                     except Exception as e:
                                         last_err = e
                                         logger.warning(
-                                            "claude enrichment parse attempt %d failed: %s",
+                                            "enrichment parse attempt %d failed: %s",
                                             attempt + 1,
                                             e,
                                         )
                                 if result is None:
                                     raise last_err
-                                node_id = write_claude_knowledge_node(
-                                    conn,
-                                    result,
-                                    segment_ids,
-                                    self.enrichment_model,
+                                node_id = write_knowledge_node(
+                                    conn, result, event_ids, self.enrichment_model
                                 )
                                 self.last_success_at_ms = int(time.time() * 1000)
                                 self.last_error = None
                                 self.last_error_at_ms = None
                                 logger.info(
-                                    "enriched %d claude segments -> node %d",
-                                    len(segment_ids),
-                                    node_id,
-                                )
-
-                                if self.embedding_model:
-                                    try:
-                                        import json as _json
-
-                                        all_tools = []
-                                        for s in segments:
-                                            try:
-                                                tools = _json.loads(s.get("tool_calls_json", "[]"))
-                                                all_tools.extend(
-                                                    f"{t['name']}: {t['summary']}" for t in tools
-                                                )
-                                            except (
-                                                _json.JSONDecodeError,
-                                                KeyError,
-                                            ):
-                                                pass
-                                        node_dict = {
-                                            "id": node_id,
-                                            "session_id": 0,
-                                            "captured_at": int(time.time() * 1000),
-                                            "commands_raw": " ; ".join(all_tools[:50]),
-                                            "cwd": segments[0].get("cwd", ""),
-                                            "git_branch": segments[0].get("git_branch", ""),
-                                            "git_repo": "",
-                                            "outcome": result.outcome,
-                                            "tags": result.tags,
-                                            "key_decisions": result.key_decisions,
-                                            "problems_encountered": result.problems_encountered,
-                                            "entities": result.entities
-                                            if isinstance(result.entities, dict)
-                                            else {},
-                                            "embed_text": result.embed_text,
-                                            "summary": result.summary,
-                                            "enrichment_model": self.enrichment_model,
-                                        }
-                                        await embed_knowledge_node(
-                                            self.client,
-                                            self._vector_table,
-                                            node_dict,
-                                            embed_model=self.embedding_model,
-                                        )
-                                        logger.info(
-                                            "embedded claude node %d into vector store",
-                                            node_id,
-                                        )
-                                    except Exception as e:
-                                        logger.warning(
-                                            "claude embedding failed (non-fatal): %s",
-                                            e,
-                                        )
-                            except Exception as e:
-                                self.last_error = str(e)
-                                self.last_error_at_ms = int(time.time() * 1000)
-                                logger.error("claude enrichment failed: %s", e)
-                                retry_conn = self._get_conn()
-                                try:
-                                    mark_claude_queue_failed(retry_conn, segment_ids, str(e))
-                                finally:
-                                    retry_conn.close()
-                    except Exception as e:
-                        logger.debug("no claude segments to process: %s", e)
-
-                    # Process browser events
-                    try:
-                        browser_batches = claim_pending_browser_events(
-                            conn, worker_id, stale_secs=60
-                        )
-                        for events in browser_batches:
-                            event_ids = [e["id"] for e in events]
-                            logger.info(
-                                "claimed %d browser events: %s",
-                                len(event_ids),
-                                event_ids,
-                            )
-                            prompt = build_browser_enrichment_prompt(events)
-
-                            try:
-                                result = None
-                                last_err = None
-                                for attempt in range(3):
-                                    try:
-                                        messages = [
-                                            {
-                                                "role": "system",
-                                                "content": BROWSER_SYSTEM_PROMPT,
-                                            },
-                                            {"role": "user", "content": prompt},
-                                        ]
-                                        if attempt > 0:
-                                            messages.append(
-                                                {
-                                                    "role": "user",
-                                                    "content": (
-                                                        "Your previous response was not valid JSON. "
-                                                        "Output ONLY a JSON object, no explanation or markdown."
-                                                    ),
-                                                }
-                                            )
-                                        raw = await self.client.chat(
-                                            messages=messages,
-                                            model=self.enrichment_model,
-                                        )
-                                        result = parse_enrichment_response(raw)
-                                        break
-                                    except Exception as e:
-                                        last_err = e
-                                        logger.warning(
-                                            "browser enrichment attempt %d failed: %s",
-                                            attempt + 1,
-                                            e,
-                                        )
-                                if result is None:
-                                    raise last_err
-                                node_id = write_browser_knowledge_node(
-                                    conn, result, event_ids, self.enrichment_model
-                                )
-                                self.last_success_at_ms = int(time.time() * 1000)
-                                logger.info(
-                                    "enriched %d browser events -> node %d",
-                                    len(event_ids),
-                                    node_id,
+                                    "enriched %d events -> node %d", len(event_ids), node_id
                                 )
 
                                 if self.embedding_model:
                                     try:
                                         node_dict = {
                                             "id": node_id,
-                                            "session_id": 0,
+                                            "session_id": events[0].get("session_id", 0),
                                             "captured_at": int(time.time() * 1000),
                                             "commands_raw": " ; ".join(
-                                                e.get("url", "") for e in events
+                                                e.get("command", "") for e in events
                                             ),
-                                            "cwd": "",
-                                            "git_branch": "",
+                                            "cwd": events[0].get("cwd", ""),
+                                            "git_branch": events[0].get("git_branch", ""),
                                             "git_repo": "",
                                             "outcome": result.outcome,
                                             "tags": result.tags,
@@ -595,23 +393,284 @@ class BrainServer:
                                             embed_model=self.embedding_model,
                                         )
                                         logger.info(
-                                            "embedded browser node %d into vector store",
-                                            node_id,
+                                            "embedded node %d into vector store", node_id
                                         )
                                     except Exception as e:
-                                        logger.warning(
-                                            "browser embedding failed (non-fatal): %s",
-                                            e,
-                                        )
+                                        logger.warning("embedding failed (non-fatal): %s", e)
                             except Exception as e:
                                 self.last_error = str(e)
                                 self.last_error_at_ms = int(time.time() * 1000)
-                                logger.error("browser enrichment failed: %s", e)
+                                logger.error("enrichment failed: %s", e)
                                 retry_conn = self._get_conn()
                                 try:
-                                    mark_browser_queue_failed(retry_conn, event_ids, str(e))
+                                    mark_queue_failed(retry_conn, event_ids, str(e))
                                 finally:
                                     retry_conn.close()
+
+                    # Process Claude session segments
+                    try:
+                        claude_batches = claim_pending_claude_segments(conn, worker_id)
+                        for segments in claude_batches:
+                            segment_ids = [s["id"] for s in segments]
+                            prompt = "\n---\n\n".join(s["summary_text"] for s in segments)
+                            logger.info(
+                                "claimed %d claude segments: %s",
+                                len(segment_ids),
+                                segment_ids,
+                            )
+
+                            tracer = _get_tracer()
+                            _claude_span = (
+                                tracer.start_as_current_span(
+                                    "enrichment.claude",
+                                    attributes={
+                                        "hippo.event_count": len(segment_ids),
+                                        "hippo.model": self.enrichment_model,
+                                    },
+                                )
+                                if tracer
+                                else suppress()
+                            )
+                            with _claude_span:
+                                try:
+                                    result = None
+                                    last_err = None
+                                    for attempt in range(3):
+                                        try:
+                                            messages = [
+                                                {
+                                                    "role": "system",
+                                                    "content": CLAUDE_SYSTEM_PROMPT,
+                                                },
+                                                {"role": "user", "content": prompt},
+                                            ]
+                                            if attempt > 0:
+                                                messages.append(
+                                                    {
+                                                        "role": "user",
+                                                        "content": (
+                                                            "Your previous response was not valid JSON. "
+                                                            "Output ONLY a JSON object, no explanation or markdown."
+                                                        ),
+                                                    }
+                                                )
+                                            raw = await self.client.chat(
+                                                messages=messages,
+                                                model=self.enrichment_model,
+                                            )
+                                            result = parse_enrichment_response(raw)
+                                            break
+                                        except Exception as e:
+                                            last_err = e
+                                            logger.warning(
+                                                "claude enrichment parse attempt %d failed: %s",
+                                                attempt + 1,
+                                                e,
+                                            )
+                                    if result is None:
+                                        raise last_err
+                                    node_id = write_claude_knowledge_node(
+                                        conn,
+                                        result,
+                                        segment_ids,
+                                        self.enrichment_model,
+                                    )
+                                    self.last_success_at_ms = int(time.time() * 1000)
+                                    self.last_error = None
+                                    self.last_error_at_ms = None
+                                    logger.info(
+                                        "enriched %d claude segments -> node %d",
+                                        len(segment_ids),
+                                        node_id,
+                                    )
+
+                                    if self.embedding_model:
+                                        try:
+                                            import json as _json
+
+                                            all_tools = []
+                                            for s in segments:
+                                                try:
+                                                    tools = _json.loads(
+                                                        s.get("tool_calls_json", "[]")
+                                                    )
+                                                    all_tools.extend(
+                                                        f"{t['name']}: {t['summary']}"
+                                                        for t in tools
+                                                    )
+                                                except (
+                                                    _json.JSONDecodeError,
+                                                    KeyError,
+                                                ):
+                                                    pass
+                                            node_dict = {
+                                                "id": node_id,
+                                                "session_id": 0,
+                                                "captured_at": int(time.time() * 1000),
+                                                "commands_raw": " ; ".join(all_tools[:50]),
+                                                "cwd": segments[0].get("cwd", ""),
+                                                "git_branch": segments[0].get("git_branch", ""),
+                                                "git_repo": "",
+                                                "outcome": result.outcome,
+                                                "tags": result.tags,
+                                                "key_decisions": result.key_decisions,
+                                                "problems_encountered": result.problems_encountered,
+                                                "entities": result.entities
+                                                if isinstance(result.entities, dict)
+                                                else {},
+                                                "embed_text": result.embed_text,
+                                                "summary": result.summary,
+                                                "enrichment_model": self.enrichment_model,
+                                            }
+                                            await embed_knowledge_node(
+                                                self.client,
+                                                self._vector_table,
+                                                node_dict,
+                                                embed_model=self.embedding_model,
+                                            )
+                                            logger.info(
+                                                "embedded claude node %d into vector store",
+                                                node_id,
+                                            )
+                                        except Exception as e:
+                                            logger.warning(
+                                                "claude embedding failed (non-fatal): %s",
+                                                e,
+                                            )
+                                except Exception as e:
+                                    self.last_error = str(e)
+                                    self.last_error_at_ms = int(time.time() * 1000)
+                                    logger.error("claude enrichment failed: %s", e)
+                                    retry_conn = self._get_conn()
+                                    try:
+                                        mark_claude_queue_failed(retry_conn, segment_ids, str(e))
+                                    finally:
+                                        retry_conn.close()
+                    except Exception as e:
+                        logger.debug("no claude segments to process: %s", e)
+
+                    # Process browser events
+                    try:
+                        browser_batches = claim_pending_browser_events(
+                            conn, worker_id, stale_secs=60
+                        )
+                        for events in browser_batches:
+                            event_ids = [e["id"] for e in events]
+                            logger.info(
+                                "claimed %d browser events: %s",
+                                len(event_ids),
+                                event_ids,
+                            )
+                            prompt = build_browser_enrichment_prompt(events)
+
+                            tracer = _get_tracer()
+                            _browser_span = (
+                                tracer.start_as_current_span(
+                                    "enrichment.browser",
+                                    attributes={
+                                        "hippo.event_count": len(event_ids),
+                                        "hippo.model": self.enrichment_model,
+                                    },
+                                )
+                                if tracer
+                                else suppress()
+                            )
+                            with _browser_span:
+                                try:
+                                    result = None
+                                    last_err = None
+                                    for attempt in range(3):
+                                        try:
+                                            messages = [
+                                                {
+                                                    "role": "system",
+                                                    "content": BROWSER_SYSTEM_PROMPT,
+                                                },
+                                                {"role": "user", "content": prompt},
+                                            ]
+                                            if attempt > 0:
+                                                messages.append(
+                                                    {
+                                                        "role": "user",
+                                                        "content": (
+                                                            "Your previous response was not valid JSON. "
+                                                            "Output ONLY a JSON object, no explanation or markdown."
+                                                        ),
+                                                    }
+                                                )
+                                            raw = await self.client.chat(
+                                                messages=messages,
+                                                model=self.enrichment_model,
+                                            )
+                                            result = parse_enrichment_response(raw)
+                                            break
+                                        except Exception as e:
+                                            last_err = e
+                                            logger.warning(
+                                                "browser enrichment attempt %d failed: %s",
+                                                attempt + 1,
+                                                e,
+                                            )
+                                    if result is None:
+                                        raise last_err
+                                    node_id = write_browser_knowledge_node(
+                                        conn, result, event_ids, self.enrichment_model
+                                    )
+                                    self.last_success_at_ms = int(time.time() * 1000)
+                                    logger.info(
+                                        "enriched %d browser events -> node %d",
+                                        len(event_ids),
+                                        node_id,
+                                    )
+
+                                    if self.embedding_model:
+                                        try:
+                                            node_dict = {
+                                                "id": node_id,
+                                                "session_id": 0,
+                                                "captured_at": int(time.time() * 1000),
+                                                "commands_raw": " ; ".join(
+                                                    e.get("url", "") for e in events
+                                                ),
+                                                "cwd": "",
+                                                "git_branch": "",
+                                                "git_repo": "",
+                                                "outcome": result.outcome,
+                                                "tags": result.tags,
+                                                "key_decisions": result.key_decisions,
+                                                "problems_encountered": result.problems_encountered,
+                                                "entities": result.entities
+                                                if isinstance(result.entities, dict)
+                                                else {},
+                                                "embed_text": result.embed_text,
+                                                "summary": result.summary,
+                                                "enrichment_model": self.enrichment_model,
+                                                "enrichment_version": 1,
+                                            }
+                                            await embed_knowledge_node(
+                                                self.client,
+                                                self._vector_table,
+                                                node_dict,
+                                                embed_model=self.embedding_model,
+                                            )
+                                            logger.info(
+                                                "embedded browser node %d into vector store",
+                                                node_id,
+                                            )
+                                        except Exception as e:
+                                            logger.warning(
+                                                "browser embedding failed (non-fatal): %s",
+                                                e,
+                                            )
+                                except Exception as e:
+                                    self.last_error = str(e)
+                                    self.last_error_at_ms = int(time.time() * 1000)
+                                    logger.error("browser enrichment failed: %s", e)
+                                    retry_conn = self._get_conn()
+                                    try:
+                                        mark_browser_queue_failed(retry_conn, event_ids, str(e))
+                                    finally:
+                                        retry_conn.close()
                     except Exception as e:
                         logger.warning("browser enrichment polling error: %s", e)
 

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -1,9 +1,8 @@
 import asyncio
 import logging
-import os
 import sqlite3
 import time
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager, nullcontext, suppress
 from pathlib import Path
 
 from starlette.applications import Starlette
@@ -40,21 +39,10 @@ from hippo_brain.claude_sessions import (
     mark_claude_queue_failed,
     write_claude_knowledge_node,
 )
+from hippo_brain.telemetry import get_tracer as _get_tracer
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger("hippo_brain")
-
-
-def _get_tracer():
-    """Get OTel tracer if available, else return None."""
-    try:
-        if os.environ.get("HIPPO_OTEL_ENABLED", "").strip() != "1":
-            return None
-        from opentelemetry import trace
-
-        return trace.get_tracer("hippo-brain")
-    except ImportError:
-        return None
 
 
 class BrainServer:
@@ -310,7 +298,7 @@ class BrainServer:
                                 },
                             )
                             if tracer
-                            else suppress()
+                            else nullcontext()
                         )
                         with _shell_span:
                             try:
@@ -429,7 +417,7 @@ class BrainServer:
                                     },
                                 )
                                 if tracer
-                                else suppress()
+                                else nullcontext()
                             )
                             with _claude_span:
                                 try:
@@ -573,7 +561,7 @@ class BrainServer:
                                     },
                                 )
                                 if tracer
-                                else suppress()
+                                else nullcontext()
                             )
                             with _browser_span:
                                 try:

--- a/brain/src/hippo_brain/telemetry.py
+++ b/brain/src/hippo_brain/telemetry.py
@@ -69,3 +69,15 @@ def init_telemetry(
         logger_provider.shutdown()
 
     return shutdown
+
+
+def get_tracer(name: str = "hippo-brain"):
+    """Get OTel tracer if available, else return None."""
+    if not _is_otel_enabled():
+        return None
+    try:
+        from opentelemetry import trace
+
+        return trace.get_tracer(name)
+    except ImportError:
+        return None

--- a/brain/src/hippo_brain/telemetry.py
+++ b/brain/src/hippo_brain/telemetry.py
@@ -1,0 +1,71 @@
+"""OpenTelemetry initialization for Hippo Brain services.
+
+Gated behind HIPPO_OTEL_ENABLED=1 environment variable.
+When disabled or when OTel packages are not installed, all functions are no-ops.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger("hippo_brain.telemetry")
+
+DEFAULT_ENDPOINT = "http://localhost:4318"
+
+
+def _is_otel_enabled() -> bool:
+    return os.environ.get("HIPPO_OTEL_ENABLED", "").strip() == "1"
+
+
+def init_telemetry(
+    service_name: str,
+    endpoint: str = "",
+) -> "callable | None":
+    """Initialize OpenTelemetry providers for traces, metrics, and logs.
+
+    Returns a shutdown callable, or None if OTel is disabled/unavailable.
+    """
+    if not _is_otel_enabled():
+        return None
+
+    if not endpoint:
+        endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", DEFAULT_ENDPOINT)
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        logger.warning("OpenTelemetry packages not installed — telemetry disabled")
+        return None
+
+    resource = Resource.create({"service.name": service_name})
+
+    # Traces
+    tracer_provider = TracerProvider(resource=resource)
+    span_exporter = OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")
+    tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+    trace.set_tracer_provider(tracer_provider)
+
+    # Logs — bridge stdlib logging to OTel
+    logger_provider = LoggerProvider(resource=resource)
+    log_exporter = OTLPLogExporter(endpoint=f"{endpoint}/v1/logs")
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+    handler = LoggingHandler(logger_provider=logger_provider)
+    logging.getLogger().addHandler(handler)
+
+    logger.info(
+        "OpenTelemetry initialized: endpoint=%s, service=%s",
+        endpoint,
+        service_name,
+    )
+
+    def shutdown() -> None:
+        tracer_provider.shutdown()
+        logger_provider.shutdown()
+
+    return shutdown

--- a/brain/tests/test_telemetry.py
+++ b/brain/tests/test_telemetry.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from unittest.mock import patch
+
+
+def test_telemetry_disabled_by_default():
+    """When HIPPO_OTEL_ENABLED is not set, init_telemetry is a no-op."""
+    env = {k: v for k, v in os.environ.items() if k != "HIPPO_OTEL_ENABLED"}
+    with patch.dict(os.environ, env, clear=True):
+        from hippo_brain.telemetry import init_telemetry
+
+        result = init_telemetry("test-service")
+        assert result is None
+
+
+def test_telemetry_enabled_returns_providers():
+    """When HIPPO_OTEL_ENABLED=1 and otel packages are available, returns providers."""
+    with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
+        try:
+            from hippo_brain.telemetry import init_telemetry
+
+            result = init_telemetry("test-service", endpoint="http://localhost:4318")
+            assert result is None or callable(result)
+        except ImportError:
+            pass
+
+
+def test_telemetry_missing_packages_returns_none():
+    """When HIPPO_OTEL_ENABLED=1 but otel packages missing, returns None gracefully."""
+    with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
+        # Hide all opentelemetry modules to simulate missing packages
+        hidden = {}
+        for mod_name in list(sys.modules.keys()):
+            if "opentelemetry" in mod_name:
+                hidden[mod_name] = sys.modules.pop(mod_name)
+
+        try:
+            # Force reimport of telemetry so it re-attempts the OTel imports
+            if "hippo_brain.telemetry" in sys.modules:
+                del sys.modules["hippo_brain.telemetry"]
+
+            with patch.dict(sys.modules, {"opentelemetry": None}):
+                from hippo_brain.telemetry import init_telemetry
+
+                result = init_telemetry("test-service")
+                assert result is None
+        finally:
+            sys.modules.update(hidden)

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -75,6 +75,47 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6", size = 143363, upload-time = "2026-03-15T18:53:25.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8", size = 294458, upload-time = "2026-03-15T18:51:41.134Z" },
+    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421", size = 199277, upload-time = "2026-03-15T18:51:42.953Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2", size = 218758, upload-time = "2026-03-15T18:51:44.339Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30", size = 215299, upload-time = "2026-03-15T18:51:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db", size = 206811, upload-time = "2026-03-15T18:51:47.308Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8", size = 193706, upload-time = "2026-03-15T18:51:48.849Z" },
+    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815", size = 202706, upload-time = "2026-03-15T18:51:50.257Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a", size = 202497, upload-time = "2026-03-15T18:51:52.012Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43", size = 193511, upload-time = "2026-03-15T18:51:53.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0", size = 220133, upload-time = "2026-03-15T18:51:55.333Z" },
+    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1", size = 203035, upload-time = "2026-03-15T18:51:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f", size = 216321, upload-time = "2026-03-15T18:51:58.17Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815", size = 208973, upload-time = "2026-03-15T18:51:59.998Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/57/4ecff6d4ec8585342f0c71bc03efaa99cb7468f7c91a57b105bcd561cea8/charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d", size = 144610, upload-time = "2026-03-15T18:52:02.213Z" },
+    { url = "https://files.pythonhosted.org/packages/80/94/8434a02d9d7f168c25767c64671fead8d599744a05d6a6c877144c754246/charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f", size = 154962, upload-time = "2026-03-15T18:52:03.658Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4c/48f2cdbfd923026503dfd67ccea45c94fd8fe988d9056b468579c66ed62b/charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e", size = 143595, upload-time = "2026-03-15T18:52:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/31/93/8878be7569f87b14f1d52032946131bcb6ebbd8af3e20446bc04053dc3f1/charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866", size = 314828, upload-time = "2026-03-15T18:52:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc", size = 208138, upload-time = "2026-03-15T18:52:08.239Z" },
+    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e", size = 224679, upload-time = "2026-03-15T18:52:10.043Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077", size = 223475, upload-time = "2026-03-15T18:52:11.854Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f", size = 215230, upload-time = "2026-03-15T18:52:13.325Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e", size = 199045, upload-time = "2026-03-15T18:52:14.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484", size = 211658, upload-time = "2026-03-15T18:52:16.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7", size = 210769, upload-time = "2026-03-15T18:52:17.782Z" },
+    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff", size = 201328, upload-time = "2026-03-15T18:52:19.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e", size = 225302, upload-time = "2026-03-15T18:52:21.043Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659", size = 211127, upload-time = "2026-03-15T18:52:22.491Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602", size = 222840, upload-time = "2026-03-15T18:52:24.113Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407", size = 216890, upload-time = "2026-03-15T18:52:25.541Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1a/05dacadb0978da72ee287b0143097db12f2e7e8d3ffc4647da07a383b0b7/charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579", size = 155379, upload-time = "2026-03-15T18:52:27.05Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7a/d269d834cb3a76291651256f3b9a5945e81d0a49ab9f4a498964e83c0416/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4", size = 169043, upload-time = "2026-03-15T18:52:28.502Z" },
+    { url = "https://files.pythonhosted.org/packages/23/06/28b29fba521a37a8932c6a84192175c34d49f84a6d4773fa63d05f9aff22/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c", size = 148523, upload-time = "2026-03-15T18:52:29.956Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455, upload-time = "2026-03-15T18:53:23.833Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -200,6 +241,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.73.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/c0/4a54c386282c13449eca8bbe2ddb518181dc113e78d240458a68856b4d69/googleapis_common_protos-1.73.1.tar.gz", hash = "sha256:13114f0e9d2391756a0194c3a8131974ed7bffb06086569ba193364af59163b6", size = 147506, upload-time = "2026-03-26T22:17:38.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/82/fcb6520612bec0c39b973a6c0954b6a0d948aadfe8f7e9487f60ceb8bfa6/googleapis_common_protos-1.73.1-py3-none-any.whl", hash = "sha256:e51f09eb0a43a8602f5a915870972e6b4a394088415c79d79605a46d8e826ee8", size = 297556, upload-time = "2026-03-26T22:15:58.455Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -228,6 +281,11 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+otel = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -245,6 +303,11 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.15" },
+]
+otel = [
+    { name = "opentelemetry-api", specifier = ">=1.33" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.33" },
+    { name = "opentelemetry-sdk", specifier = ">=1.33" },
 ]
 
 [[package]]
@@ -291,6 +354,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -431,6 +506,88 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772, upload-time = "2026-03-04T14:17:25.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3a/8865d6754e61c9fb170cdd530a124a53769ee5f740236064816eb0ca7301/opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069", size = 19960, upload-time = "2026-03-04T14:17:07.153Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -446,6 +603,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -666,6 +838,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -814,4 +1001,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -62,3 +62,9 @@ strip_params = [
     "key",
     "sig",
 ]
+
+[telemetry]
+# Set enabled = true and run `mise run otel:up` to start the observability stack.
+# endpoint is the OTel Collector gRPC address.
+enabled = false
+endpoint = "http://localhost:4317"

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -16,6 +16,8 @@ pub struct HippoConfig {
     pub storage: StorageConfig,
     #[serde(default)]
     pub browser: BrowserConfig,
+    #[serde(default)]
+    pub telemetry: TelemetryConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -281,6 +283,27 @@ impl Default for BrowserUrlRedaction {
     fn default() -> Self {
         Self {
             strip_params: default_browser_strip_params(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_telemetry_endpoint")]
+    pub endpoint: String,
+}
+
+fn default_telemetry_endpoint() -> String {
+    "http://localhost:4317".to_string()
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: default_telemetry_endpoint(),
         }
     }
 }
@@ -645,6 +668,25 @@ replacement = "***"
     fn test_redact_load_default_returns_ok() {
         let config = RedactConfig::load_default().unwrap();
         assert!(!config.patterns.is_empty());
+    }
+
+    #[test]
+    fn test_telemetry_defaults() {
+        let config = HippoConfig::default();
+        assert!(!config.telemetry.enabled);
+        assert_eq!(config.telemetry.endpoint, "http://localhost:4317");
+    }
+
+    #[test]
+    fn test_telemetry_from_toml() {
+        let toml_str = r#"
+[telemetry]
+enabled = true
+endpoint = "http://collector:4317"
+"#;
+        let config: HippoConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.telemetry.enabled);
+        assert_eq!(config.telemetry.endpoint, "http://collector:4317");
     }
 
     #[test]

--- a/crates/hippo-daemon/Cargo.toml
+++ b/crates/hippo-daemon/Cargo.toml
@@ -28,6 +28,22 @@ reqwest = { version = "0.12", features = ["json"] }
 rusqlite.workspace = true
 url = "2.5.8"
 serde = { workspace = true, features = ["derive"] }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-appender-tracing = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+
+[features]
+default = []
+otel = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry-appender-tracing",
+    "dep:tracing-opentelemetry",
+]
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -29,7 +29,18 @@ pub struct DaemonState {
     pub shutdown_tx: watch::Sender<bool>,
 }
 
+#[tracing::instrument(skip(state), fields(request_type))]
 pub async fn handle_request(state: &Arc<DaemonState>, request: DaemonRequest) -> DaemonResponse {
+    let request_type = match &request {
+        DaemonRequest::IngestEvent(_) => "ingest_event",
+        DaemonRequest::GetStatus => "get_status",
+        DaemonRequest::GetSessions { .. } => "get_sessions",
+        DaemonRequest::GetEvents { .. } => "get_events",
+        DaemonRequest::GetEntities { .. } => "get_entities",
+        DaemonRequest::RawQuery { .. } => "raw_query",
+        DaemonRequest::Shutdown => "shutdown",
+    };
+    tracing::Span::current().record("request_type", request_type);
     match request {
         DaemonRequest::IngestEvent(envelope) => {
             let mut buffer = state.event_buffer.lock().await;
@@ -130,12 +141,14 @@ pub async fn handle_request(state: &Arc<DaemonState>, request: DaemonRequest) ->
     }
 }
 
+#[tracing::instrument(skip(state), fields(event_count))]
 pub async fn flush_events(state: &Arc<DaemonState>) {
     let events: Vec<EventEnvelope> = {
         let mut buffer = state.event_buffer.lock().await;
         let n = buffer.len().min(state.config.daemon.flush_batch_size);
         buffer.drain(..n).collect()
     };
+    tracing::Span::current().record("event_count", events.len());
 
     if events.is_empty() {
         return;
@@ -370,6 +383,7 @@ pub async fn run(config: HippoConfig) -> Result<()> {
     Ok(())
 }
 
+#[tracing::instrument(skip_all)]
 async fn handle_connection(state: Arc<DaemonState>, mut stream: UnixStream) -> Result<()> {
     while let Some(frame) = read_frame(&mut stream).await? {
         let request: DaemonRequest = serde_json::from_slice(&frame)?;

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -11,6 +11,8 @@ pub fn render_plist(template: &str, vars: &PlistVars) -> String {
         .replace("__HOME__", &vars.home.to_string_lossy())
         .replace("__PATH__", &vars.path)
         .replace("__DATA_DIR__", &vars.data_dir.to_string_lossy())
+        .replace("__HIPPO_OTEL_ENABLED__", &vars.otel_enabled)
+        .replace("__OTEL_ENDPOINT__", &vars.otel_endpoint)
 }
 
 pub struct PlistVars {
@@ -20,6 +22,8 @@ pub struct PlistVars {
     pub home: PathBuf,
     pub path: String,
     pub data_dir: PathBuf,
+    pub otel_enabled: String,
+    pub otel_endpoint: String,
 }
 
 /// Auto-detect system paths for plist variable substitution.
@@ -33,6 +37,10 @@ pub fn detect_vars(brain_dir: &Path) -> Result<PlistVars> {
         .unwrap_or_else(|| home.join(".local/share"))
         .join("hippo");
 
+    let telemetry = hippo_core::config::HippoConfig::load_default()
+        .map(|c| c.telemetry)
+        .unwrap_or_default();
+
     Ok(PlistVars {
         hippo_bin,
         uv_bin,
@@ -40,6 +48,12 @@ pub fn detect_vars(brain_dir: &Path) -> Result<PlistVars> {
         home,
         path,
         data_dir,
+        otel_enabled: if telemetry.enabled {
+            "1".to_string()
+        } else {
+            "0".to_string()
+        },
+        otel_endpoint: telemetry.endpoint.replace("4317", "4318"),
     })
 }
 
@@ -227,7 +241,9 @@ mod tests {
 <string>__BRAIN_DIR__</string>
 <string>__HOME__</string>
 <string>__PATH__</string>
-<string>__DATA_DIR__</string>"#;
+<string>__DATA_DIR__</string>
+<string>__HIPPO_OTEL_ENABLED__</string>
+<string>__OTEL_ENDPOINT__</string>"#;
 
         let vars = PlistVars {
             hippo_bin: PathBuf::from("/usr/local/bin/hippo"),
@@ -236,6 +252,8 @@ mod tests {
             home: PathBuf::from("/Users/me"),
             path: "/usr/local/bin:/usr/bin:/bin".to_string(),
             data_dir: PathBuf::from("/Users/me/.local/share/hippo"),
+            otel_enabled: "0".to_string(),
+            otel_endpoint: "http://localhost:4318".to_string(),
         };
 
         let result = render_plist(template, &vars);
@@ -245,7 +263,10 @@ mod tests {
         assert!(!result.contains("__HOME__"));
         assert!(!result.contains("__PATH__"));
         assert!(!result.contains("__DATA_DIR__"));
+        assert!(!result.contains("__HIPPO_OTEL_ENABLED__"));
+        assert!(!result.contains("__OTEL_ENDPOINT__"));
         assert!(result.contains("/usr/local/bin/hippo"));
         assert!(result.contains("/usr/local/bin/uv"));
+        assert!(result.contains("http://localhost:4318"));
     }
 }

--- a/crates/hippo-daemon/src/lib.rs
+++ b/crates/hippo-daemon/src/lib.rs
@@ -3,6 +3,8 @@ pub mod commands;
 pub mod daemon;
 pub mod framing;
 pub mod native_messaging;
+#[cfg(feature = "otel")]
+pub mod telemetry;
 
 use hippo_core::config::ENV_ALLOWLIST;
 use hippo_core::events::ShellEvent;

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -29,6 +29,43 @@ async fn poll_socket_removal(socket: &std::path::Path, timeout: std::time::Durat
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Load config early — needed for telemetry init before CLI parsing
+    let config = match HippoConfig::load_default() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Warning: failed to load config: {e:#}. Using defaults.");
+            HippoConfig::default()
+        }
+    };
+
+    // Initialize telemetry — OTel if feature-enabled and config says so, else plain fmt
+    #[cfg(feature = "otel")]
+    let _otel_guard = if config.telemetry.enabled {
+        match hippo_daemon::telemetry::init("hippo-daemon", &config.telemetry.endpoint) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                tracing_subscriber::fmt()
+                    .with_writer(std::io::stderr)
+                    .with_env_filter(
+                        EnvFilter::try_from_default_env()
+                            .unwrap_or_else(|_| EnvFilter::new("info")),
+                    )
+                    .init();
+                tracing::warn!("OTel init failed, using plain logging: {e}");
+                None
+            }
+        }
+    } else {
+        tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_env_filter(
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            )
+            .init();
+        None
+    };
+
+    #[cfg(not(feature = "otel"))]
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
@@ -37,13 +74,6 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
-    let config = match HippoConfig::load_default() {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Warning: failed to load config: {e:#}. Using defaults.");
-            HippoConfig::default()
-        }
-    };
 
     match cli.command {
         Commands::Daemon { action } => match action {
@@ -436,6 +466,12 @@ async fn main() -> Result<()> {
         Commands::Doctor => {
             commands::handle_doctor(&config).await?;
         }
+    }
+
+    // Shutdown OTel providers
+    #[cfg(feature = "otel")]
+    if let Some(guard) = _otel_guard {
+        guard.shutdown();
     }
 
     Ok(())

--- a/crates/hippo-daemon/src/telemetry.rs
+++ b/crates/hippo-daemon/src/telemetry.rs
@@ -1,0 +1,112 @@
+//! OpenTelemetry initialization — only compiled with `--features otel`.
+
+use anyhow::Result;
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_otlp::{LogExporter, MetricExporter, SpanExporter, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use tracing::info;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+fn resource(service_name: &str) -> Resource {
+    Resource::builder()
+        .with_service_name(service_name.to_string())
+        .build()
+}
+
+pub struct TelemetryGuard {
+    tracer_provider: SdkTracerProvider,
+    meter_provider: SdkMeterProvider,
+    logger_provider: SdkLoggerProvider,
+}
+
+impl TelemetryGuard {
+    pub fn shutdown(self) {
+        if let Err(e) = self.tracer_provider.shutdown() {
+            eprintln!("tracer shutdown error: {e}");
+        }
+        if let Err(e) = self.meter_provider.shutdown() {
+            eprintln!("meter shutdown error: {e}");
+        }
+        if let Err(e) = self.logger_provider.shutdown() {
+            eprintln!("logger shutdown error: {e}");
+        }
+    }
+}
+
+/// Initialize OTel tracing subscriber with OTLP exporters.
+/// Replaces the default `tracing_subscriber::fmt` when OTel is enabled.
+/// Returns a guard that must be held for the lifetime of the program.
+pub fn init(service_name: &str, endpoint: &str) -> Result<TelemetryGuard> {
+    let res = resource(service_name);
+
+    // Traces
+    let span_exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_resource(res.clone())
+        .with_batch_exporter(span_exporter)
+        .build();
+
+    // Metrics
+    let metric_exporter = MetricExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+    let meter_provider = SdkMeterProvider::builder()
+        .with_resource(res.clone())
+        .with_periodic_exporter(metric_exporter)
+        .build();
+
+    // Logs
+    let log_exporter = LogExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+    let logger_provider = SdkLoggerProvider::builder()
+        .with_resource(res)
+        .with_batch_exporter(log_exporter)
+        .build();
+
+    // Set global providers
+    global::set_tracer_provider(tracer_provider.clone());
+    global::set_meter_provider(meter_provider.clone());
+
+    // Get a tracer from the provider (OpenTelemetryLayer needs a Tracer, not a TracerProvider)
+    let tracer = tracer_provider.tracer(service_name.to_string());
+
+    // Build the tracing subscriber with OTel layers.
+    // EnvFilter must come last so that OpenTelemetryLayer sees a Subscriber that
+    // still implements LookupSpan (which EnvFilter wrapping would hide).
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+
+    let otel_trace_layer = OpenTelemetryLayer::new(tracer);
+
+    let otel_log_layer = OpenTelemetryTracingBridge::new(&logger_provider);
+
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(otel_trace_layer)
+        .with(otel_log_layer)
+        .with(env_filter)
+        .init();
+
+    info!("OpenTelemetry initialized: endpoint={endpoint}, service={service_name}");
+
+    Ok(TelemetryGuard {
+        tracer_provider,
+        meter_provider,
+        logger_provider,
+    })
+}

--- a/crates/hippo-daemon/tests/telemetry_test.rs
+++ b/crates/hippo-daemon/tests/telemetry_test.rs
@@ -1,0 +1,20 @@
+//! Integration test: verify OTel telemetry module initializes and shuts down cleanly.
+//! Only compiled with --features otel.
+
+#[cfg(feature = "otel")]
+mod otel_tests {
+    use hippo_daemon::telemetry;
+
+    /// Test that init succeeds when pointing at a non-existent collector.
+    /// The batch exporter buffers spans — it won't fail until export time.
+    /// We just verify the init/shutdown cycle doesn't panic.
+    ///
+    /// A Tokio runtime is required because the OTLP gRPC exporter (tonic) spawns
+    /// background tasks that need a reactor.
+    #[tokio::test]
+    async fn test_telemetry_init_shutdown() {
+        let guard = telemetry::init("test-service", "http://localhost:19999")
+            .expect("telemetry init should succeed even without a collector");
+        guard.shutdown();
+    }
+}

--- a/docs/superpowers/plans/2026-04-02-otel-observability-stack.md
+++ b/docs/superpowers/plans/2026-04-02-otel-observability-stack.md
@@ -1,0 +1,1593 @@
+# OpenTelemetry Observability Stack Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional, self-contained Docker Compose observability stack that collects logs, metrics, and traces from all Hippo services (daemon, brain, MCP server), with Grafana dashboards for diagnosing performance and errors.
+
+**Architecture:** An OTel Collector receives OTLP data from instrumented services and fans out to Grafana Tempo (traces), Grafana Loki (logs), and Prometheus (metrics). Grafana provides unified visualization. All instrumentation is feature-gated / config-gated so there is zero overhead when the stack is off. The `otel/` directory is designed to be extractable as a standalone repo.
+
+**Tech Stack:**
+- Docker Compose (OTel Collector contrib, Grafana, Tempo, Loki, Prometheus)
+- Rust: `opentelemetry`, `opentelemetry-otlp`, `opentelemetry-appender-tracing`, `tracing-opentelemetry` (behind cargo feature `otel`)
+- Python: `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`, `opentelemetry-api` (behind `HIPPO_OTEL_ENABLED=1` env var)
+
+---
+
+## File Structure
+
+### New files
+
+```
+otel/                                    # Self-contained, extractable OTel stack
+├── docker-compose.yml                   # All 5 services: collector, grafana, tempo, loki, prometheus
+├── otelcol-config.yml                   # OTel Collector pipeline config
+├── prometheus.yml                       # Prometheus scrape config
+├── grafana/
+│   ├── datasources.yml                  # Auto-provision Tempo, Loki, Prometheus datasources
+│   └── dashboards/
+│       ├── dashboards.yml               # Dashboard provisioner config
+│       └── hippo-overview.json          # Pre-built Grafana dashboard
+├── tempo-config.yml                     # Tempo local storage config
+├── loki-config.yml                      # Loki local storage config
+└── README.md                            # Standalone usage docs
+```
+
+### Modified files
+
+```
+Cargo.toml                               # Add workspace otel deps behind feature flag
+crates/hippo-core/Cargo.toml             # No changes (no OTel in core)
+crates/hippo-daemon/Cargo.toml           # Add otel feature + deps
+crates/hippo-daemon/src/telemetry.rs     # NEW — OTel init/shutdown module
+crates/hippo-daemon/src/main.rs          # Wire telemetry init, conditional on feature
+crates/hippo-daemon/src/daemon.rs        # Add span instrumentation to key functions
+crates/hippo-daemon/src/lib.rs           # Export telemetry module
+
+brain/pyproject.toml                     # Add optional otel dependency group
+brain/src/hippo_brain/telemetry.py       # NEW — OTel init module for Python
+brain/src/hippo_brain/__init__.py        # Wire telemetry init on startup
+brain/src/hippo_brain/server.py          # Add span instrumentation to enrichment loop
+brain/src/hippo_brain/mcp.py             # Add span instrumentation to MCP tools
+brain/src/hippo_brain/mcp_logging.py     # Bridge to OTel when enabled
+
+config/config.default.toml               # Add [telemetry] section
+crates/hippo-core/src/config.rs          # Parse [telemetry] config section
+mise.toml                                # Add otel:up, otel:down, otel:logs tasks
+```
+
+### Test files
+
+```
+crates/hippo-daemon/tests/telemetry_test.rs   # Integration test: OTel init/shutdown
+brain/tests/test_telemetry.py                  # Unit test: OTel setup, env gating
+```
+
+---
+
+## Task 1: Docker Compose OTel Stack
+
+**Files:**
+- Create: `otel/docker-compose.yml`
+- Create: `otel/otelcol-config.yml`
+- Create: `otel/prometheus.yml`
+- Create: `otel/tempo-config.yml`
+- Create: `otel/loki-config.yml`
+- Create: `otel/grafana/datasources.yml`
+- Create: `otel/grafana/dashboards/dashboards.yml`
+
+This task creates the entire containerized stack. No application code changes yet.
+
+- [ ] **Step 1: Create the OTel Collector config**
+
+```yaml
+# otel/otelcol-config.yml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+
+  resource:
+    attributes:
+      - key: host.name
+        from_attribute: host.name
+        action: upsert
+
+exporters:
+  otlphttp/tempo:
+    endpoint: http://tempo:3200
+
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: hippo
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [otlphttp/tempo]
+    logs:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [loki]
+    metrics:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [prometheus]
+```
+
+- [ ] **Step 2: Create Tempo config**
+
+```yaml
+# otel/tempo-config.yml
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:3200
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+```
+
+- [ ] **Step 3: Create Loki config**
+
+```yaml
+# otel/loki-config.yml
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+```
+
+- [ ] **Step 4: Create Prometheus config**
+
+```yaml
+# otel/prometheus.yml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "otel-collector"
+    static_configs:
+      - targets: ["otel-collector:8889"]
+```
+
+- [ ] **Step 5: Create Grafana datasource provisioning**
+
+```yaml
+# otel/grafana/datasources.yml
+apiVersion: 1
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: false
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        filterByTraceID: true
+      tracesToMetrics:
+        datasourceUid: prometheus
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    uid: loki
+    isDefault: true
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: "trace_id=(\\w+)"
+          name: TraceID
+          url: "$${__value.raw}"
+
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    uid: prometheus
+    isDefault: false
+```
+
+- [ ] **Step 6: Create dashboard provisioner config**
+
+```yaml
+# otel/grafana/dashboards/dashboards.yml
+apiVersion: 1
+providers:
+  - name: "hippo"
+    orgId: 1
+    folder: "Hippo"
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false
+```
+
+- [ ] **Step 7: Create Docker Compose file**
+
+```yaml
+# otel/docker-compose.yml
+name: hippo-otel
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.120.0
+    command: ["--config", "/etc/otelcol/config.yml"]
+    volumes:
+      - ./otelcol-config.yml:/etc/otelcol/config.yml:ro
+    ports:
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+      - "13133:13133" # Health check
+    depends_on:
+      - tempo
+      - loki
+
+  tempo:
+    image: grafana/tempo:2.7.2
+    command: ["-config.file=/etc/tempo/config.yml"]
+    volumes:
+      - ./tempo-config.yml:/etc/tempo/config.yml:ro
+      - tempo-data:/var/tempo
+
+  loki:
+    image: grafana/loki:3.4.2
+    command: ["-config.file=/etc/loki/config.yml"]
+    volumes:
+      - ./loki-config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=7d"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+
+  grafana:
+    image: grafana/grafana:11.5.2
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=hippo
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - tempo
+      - loki
+      - prometheus
+
+volumes:
+  tempo-data:
+  loki-data:
+  prometheus-data:
+  grafana-data:
+```
+
+- [ ] **Step 8: Test the stack boots**
+
+Run:
+```bash
+cd otel && docker compose up -d && sleep 5 && docker compose ps
+```
+
+Expected: All 5 services show "running" or "healthy". Grafana reachable at http://localhost:3000.
+
+Run:
+```bash
+curl -s http://localhost:13133/ | head -5
+```
+
+Expected: OTel Collector health check returns 200.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add otel/
+git commit -m "feat(otel): add Docker Compose observability stack
+
+Grafana LGTM stack: OTel Collector, Tempo (traces), Loki (logs),
+Prometheus (metrics), Grafana (dashboards). Self-contained in otel/
+for portability."
+```
+
+---
+
+## Task 2: Hippo Config — Telemetry Section
+
+**Files:**
+- Modify: `config/config.default.toml`
+- Modify: `crates/hippo-core/src/config.rs`
+
+Adds a `[telemetry]` section to config so OTel endpoint/enablement is runtime-configurable.
+
+- [ ] **Step 1: Read the existing config module**
+
+Read: `crates/hippo-core/src/config.rs`
+
+Understand the existing `HippoConfig` struct and how sections are parsed.
+
+- [ ] **Step 2: Write a failing test for telemetry config parsing**
+
+Add to the bottom of `crates/hippo-core/src/config.rs` (inside the existing `#[cfg(test)]` block, or create one):
+
+```rust
+#[cfg(test)]
+mod telemetry_config_tests {
+    use super::*;
+
+    #[test]
+    fn test_telemetry_defaults() {
+        let config = HippoConfig::default();
+        assert!(!config.telemetry.enabled);
+        assert_eq!(config.telemetry.endpoint, "http://localhost:4317");
+    }
+
+    #[test]
+    fn test_telemetry_from_toml() {
+        let toml_str = r#"
+[telemetry]
+enabled = true
+endpoint = "http://collector:4317"
+"#;
+        let config: HippoConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.telemetry.enabled);
+        assert_eq!(config.telemetry.endpoint, "http://collector:4317");
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p hippo-core telemetry_config`
+Expected: Compilation error — `telemetry` field doesn't exist on `HippoConfig`.
+
+- [ ] **Step 4: Add TelemetryConfig struct and wire it into HippoConfig**
+
+The config uses serde `Deserialize` directly — no separate raw/cooked types. Follow the existing pattern.
+
+In `crates/hippo-core/src/config.rs`, add a new struct:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_telemetry_endpoint")]
+    pub endpoint: String,
+}
+
+fn default_telemetry_endpoint() -> String {
+    "http://localhost:4317".to_string()
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: default_telemetry_endpoint(),
+        }
+    }
+}
+```
+
+Add a `telemetry` field to the existing `HippoConfig` struct:
+
+```rust
+#[serde(default)]
+pub telemetry: TelemetryConfig,
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p hippo-core telemetry_config`
+Expected: Both tests pass.
+
+- [ ] **Step 6: Add telemetry section to default config**
+
+Append to `config/config.default.toml`:
+
+```toml
+[telemetry]
+# Set enabled = true and run `mise run otel:up` to start the observability stack.
+# endpoint is the OTel Collector gRPC address.
+enabled = false
+endpoint = "http://localhost:4317"
+```
+
+- [ ] **Step 7: Run full core tests**
+
+Run: `cargo test -p hippo-core`
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add config/config.default.toml crates/hippo-core/src/config.rs
+git commit -m "feat(config): add [telemetry] section for OTel configuration"
+```
+
+---
+
+## Task 3: Rust OTel Instrumentation — Feature-Gated
+
+**Files:**
+- Modify: `Cargo.toml` (workspace deps)
+- Modify: `crates/hippo-daemon/Cargo.toml` (feature flag + deps)
+- Create: `crates/hippo-daemon/src/telemetry.rs`
+- Modify: `crates/hippo-daemon/src/lib.rs`
+- Modify: `crates/hippo-daemon/src/main.rs`
+
+All OTel code lives behind `--features otel` so the default build has zero new dependencies.
+
+- [ ] **Step 1: Add workspace OTel dependencies**
+
+In the root `Cargo.toml` `[workspace.dependencies]` section, add:
+
+```toml
+opentelemetry = "0.29"
+opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
+opentelemetry-appender-tracing = "0.29"
+tracing-opentelemetry = "0.30"
+```
+
+- [ ] **Step 2: Add otel feature to hippo-daemon**
+
+In `crates/hippo-daemon/Cargo.toml`, add:
+
+```toml
+[features]
+default = []
+otel = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry-appender-tracing",
+    "dep:tracing-opentelemetry",
+]
+
+[dependencies]
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-appender-tracing = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+```
+
+- [ ] **Step 3: Verify default build still compiles**
+
+Run: `cargo build -p hippo-daemon`
+Expected: Compiles with no new dependencies pulled in.
+
+- [ ] **Step 4: Create the telemetry module**
+
+Create `crates/hippo-daemon/src/telemetry.rs`:
+
+```rust
+//! OpenTelemetry initialization — only compiled with `--features otel`.
+
+use anyhow::Result;
+use opentelemetry::global;
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_otlp::{LogExporter, SpanExporter, MetricExporter};
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::Resource;
+use tracing::info;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
+
+fn resource(service_name: &str) -> Resource {
+    Resource::builder()
+        .with_service_name(service_name.to_string())
+        .build()
+}
+
+pub struct TelemetryGuard {
+    tracer_provider: SdkTracerProvider,
+    meter_provider: SdkMeterProvider,
+    logger_provider: SdkLoggerProvider,
+}
+
+impl TelemetryGuard {
+    pub fn shutdown(self) {
+        if let Err(e) = self.tracer_provider.shutdown() {
+            eprintln!("tracer shutdown error: {e}");
+        }
+        if let Err(e) = self.meter_provider.shutdown() {
+            eprintln!("meter shutdown error: {e}");
+        }
+        if let Err(e) = self.logger_provider.shutdown() {
+            eprintln!("logger shutdown error: {e}");
+        }
+    }
+}
+
+/// Initialize OTel tracing subscriber with OTLP exporters.
+/// Replaces the default `tracing_subscriber::fmt` when OTel is enabled.
+/// Returns a guard that must be held for the lifetime of the program.
+pub fn init(service_name: &str, endpoint: &str) -> Result<TelemetryGuard> {
+    let res = resource(service_name);
+
+    // Traces
+    let span_exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_resource(res.clone())
+        .with_batch_exporter(span_exporter)
+        .build();
+
+    // Metrics
+    let metric_exporter = MetricExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+    let meter_provider = SdkMeterProvider::builder()
+        .with_resource(res.clone())
+        .with_periodic_exporter(metric_exporter)
+        .build();
+
+    // Logs
+    let log_exporter = LogExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+    let logger_provider = SdkLoggerProvider::builder()
+        .with_resource(res)
+        .with_batch_exporter(log_exporter)
+        .build();
+
+    // Set global providers
+    global::set_tracer_provider(tracer_provider.clone());
+    global::set_meter_provider(meter_provider.clone());
+
+    // Build the tracing subscriber with OTel layers
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+
+    let otel_trace_layer = OpenTelemetryLayer::new(tracer_provider.clone());
+
+    let otel_log_layer = OpenTelemetryTracingBridge::new(&logger_provider);
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer)
+        .with(otel_trace_layer)
+        .with(otel_log_layer)
+        .init();
+
+    info!("OpenTelemetry initialized: endpoint={endpoint}, service={service_name}");
+
+    Ok(TelemetryGuard {
+        tracer_provider,
+        meter_provider,
+        logger_provider,
+    })
+}
+```
+
+- [ ] **Step 5: Export the telemetry module from lib.rs**
+
+In `crates/hippo-daemon/src/lib.rs`, add:
+
+```rust
+#[cfg(feature = "otel")]
+pub mod telemetry;
+```
+
+- [ ] **Step 6: Wire telemetry init into main.rs**
+
+In `crates/hippo-daemon/src/main.rs`, the tracing subscriber init must happen before CLI parsing. Move the config load earlier and use it for both telemetry and the CLI.
+
+Replace the top of `main()` (the `tracing_subscriber::fmt()` block + config load) with:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Load config early — needed for telemetry init before CLI parsing
+    let config = match HippoConfig::load_default() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Warning: failed to load config: {e:#}. Using defaults.");
+            HippoConfig::default()
+        }
+    };
+
+    // Initialize telemetry — OTel if feature-enabled and config says so, else plain fmt
+    #[cfg(feature = "otel")]
+    let _otel_guard = if config.telemetry.enabled {
+        match hippo_daemon::telemetry::init("hippo-daemon", &config.telemetry.endpoint) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                tracing_subscriber::fmt()
+                    .with_writer(std::io::stderr)
+                    .with_env_filter(
+                        EnvFilter::try_from_default_env()
+                            .unwrap_or_else(|_| EnvFilter::new("info")),
+                    )
+                    .init();
+                tracing::warn!("OTel init failed, using plain logging: {e}");
+                None
+            }
+        }
+    } else {
+        tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_env_filter(
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            )
+            .init();
+        None
+    };
+
+    #[cfg(not(feature = "otel"))]
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    // Remove the duplicate config load that was here — reuse `config` from above
+
+    match cli.command {
+        // ... all existing match arms unchanged
+    }
+
+    #[cfg(feature = "otel")]
+    if let Some(guard) = _otel_guard {
+        guard.shutdown();
+    }
+
+    Ok(())
+}
+```
+
+This eliminates the double config load. The existing `let config = match HippoConfig::load_default()` block after `Cli::parse()` should be deleted since we now load config at the top.
+
+- [ ] **Step 7: Verify it compiles with the otel feature**
+
+Run: `cargo build -p hippo-daemon --features otel`
+Expected: Compiles successfully.
+
+- [ ] **Step 8: Verify default build still works**
+
+Run: `cargo build -p hippo-daemon`
+Expected: Compiles with no OTel code included.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/hippo-daemon/
+git commit -m "feat(daemon): add OpenTelemetry instrumentation behind --features otel
+
+Traces, metrics, and logs exported via OTLP gRPC when [telemetry]
+enabled = true in config. Zero overhead when feature is off."
+```
+
+---
+
+## Task 4: Rust Span Instrumentation on Hot Paths
+
+**Files:**
+- Modify: `crates/hippo-daemon/src/daemon.rs`
+
+Add `#[tracing::instrument]` to key functions so traces show meaningful spans.
+
+- [ ] **Step 1: Instrument handle_request**
+
+In `crates/hippo-daemon/src/daemon.rs`, add the `#[tracing::instrument]` attribute to `handle_request`:
+
+```rust
+#[tracing::instrument(skip(state), fields(request_type))]
+pub async fn handle_request(state: &Arc<DaemonState>, request: DaemonRequest) -> DaemonResponse {
+    // Record the request type as a span field
+    let request_type = match &request {
+        DaemonRequest::IngestEvent(_) => "ingest_event",
+        DaemonRequest::GetStatus => "get_status",
+        DaemonRequest::GetSessions { .. } => "get_sessions",
+        DaemonRequest::GetEvents { .. } => "get_events",
+        DaemonRequest::GetEntities { .. } => "get_entities",
+        DaemonRequest::RawQuery { .. } => "raw_query",
+        DaemonRequest::Shutdown => "shutdown",
+    };
+    tracing::Span::current().record("request_type", request_type);
+
+    match request {
+        // ... existing match arms unchanged
+```
+
+- [ ] **Step 2: Instrument flush_events**
+
+Add to `flush_events`:
+
+```rust
+#[tracing::instrument(skip(state), fields(event_count))]
+pub async fn flush_events(state: &Arc<DaemonState>) {
+    let events: Vec<EventEnvelope> = {
+        // ... existing drain logic
+    };
+
+    tracing::Span::current().record("event_count", events.len());
+
+    if events.is_empty() {
+        return;
+    }
+    // ... rest unchanged
+```
+
+- [ ] **Step 3: Instrument handle_connection**
+
+Add to `handle_connection`:
+
+```rust
+#[tracing::instrument(skip_all)]
+async fn handle_connection(state: Arc<DaemonState>, mut stream: UnixStream) -> Result<()> {
+    // ... existing code unchanged
+```
+
+- [ ] **Step 4: Run all daemon tests**
+
+Run: `cargo test -p hippo-daemon`
+Expected: All tests pass (instrument attributes don't change behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hippo-daemon/src/daemon.rs
+git commit -m "feat(daemon): add tracing spans to hot paths
+
+Instrument handle_request, flush_events, handle_connection with
+tracing::instrument for OTel trace visibility."
+```
+
+---
+
+## Task 5: Python OTel Instrumentation — Env-Gated
+
+**Files:**
+- Modify: `brain/pyproject.toml`
+- Create: `brain/src/hippo_brain/telemetry.py`
+- Create: `brain/tests/test_telemetry.py`
+
+All OTel code is gated behind `HIPPO_OTEL_ENABLED=1` environment variable. When unset, the module is a no-op.
+
+- [ ] **Step 1: Add OTel dependencies as optional group**
+
+In `brain/pyproject.toml`, add an `otel` dependency group:
+
+```toml
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3",
+    "pytest-cov>=7.1.0",
+    "ruff>=0.15",
+]
+otel = [
+    "opentelemetry-api>=1.33",
+    "opentelemetry-sdk>=1.33",
+    "opentelemetry-exporter-otlp-proto-http>=1.33",
+]
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `brain/tests/test_telemetry.py`:
+
+```python
+import os
+from unittest.mock import patch
+
+
+def test_telemetry_disabled_by_default():
+    """When HIPPO_OTEL_ENABLED is not set, init_telemetry is a no-op."""
+    with patch.dict(os.environ, {}, clear=True):
+        os.environ.pop("HIPPO_OTEL_ENABLED", None)
+        from hippo_brain.telemetry import init_telemetry
+
+        result = init_telemetry("test-service")
+        assert result is None
+
+
+def test_telemetry_enabled_returns_providers():
+    """When HIPPO_OTEL_ENABLED=1 and otel packages are available, returns providers."""
+    with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
+        try:
+            from hippo_brain.telemetry import init_telemetry
+
+            result = init_telemetry("test-service", endpoint="http://localhost:4318")
+            # If otel packages aren't installed, should still return None gracefully
+            # If they are installed, should return a shutdown callable
+            assert result is None or callable(result)
+        except ImportError:
+            pass  # otel deps not installed, that's fine
+
+
+def test_telemetry_missing_packages_returns_none():
+    """When HIPPO_OTEL_ENABLED=1 but otel packages missing, returns None gracefully."""
+    import importlib
+    import sys
+
+    with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
+        # Temporarily hide otel packages
+        hidden = {}
+        for mod_name in list(sys.modules.keys()):
+            if "opentelemetry" in mod_name:
+                hidden[mod_name] = sys.modules.pop(mod_name)
+
+        try:
+            # Force reimport
+            if "hippo_brain.telemetry" in sys.modules:
+                del sys.modules["hippo_brain.telemetry"]
+
+            with patch.dict(sys.modules, {"opentelemetry": None}):
+                from hippo_brain.telemetry import init_telemetry
+
+                result = init_telemetry("test-service")
+                assert result is None
+        finally:
+            sys.modules.update(hidden)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run --project brain pytest brain/tests/test_telemetry.py -v`
+Expected: ImportError — `hippo_brain.telemetry` doesn't exist yet.
+
+- [ ] **Step 4: Create the telemetry module**
+
+Create `brain/src/hippo_brain/telemetry.py`:
+
+```python
+"""OpenTelemetry initialization for Hippo Brain services.
+
+Gated behind HIPPO_OTEL_ENABLED=1 environment variable.
+When disabled or when OTel packages are not installed, all functions are no-ops.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger("hippo_brain.telemetry")
+
+OTEL_ENABLED = os.environ.get("HIPPO_OTEL_ENABLED", "").strip() == "1"
+DEFAULT_ENDPOINT = "http://localhost:4318"
+
+
+def init_telemetry(
+    service_name: str,
+    endpoint: str = "",
+) -> "callable | None":
+    """Initialize OpenTelemetry providers for traces, metrics, and logs.
+
+    Returns a shutdown callable, or None if OTel is disabled/unavailable.
+    """
+    if not OTEL_ENABLED:
+        return None
+
+    if not endpoint:
+        endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", DEFAULT_ENDPOINT)
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        logger.warning("OpenTelemetry packages not installed — telemetry disabled")
+        return None
+
+    resource = Resource.create({"service.name": service_name})
+
+    # Traces
+    tracer_provider = TracerProvider(resource=resource)
+    span_exporter = OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")
+    tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+    trace.set_tracer_provider(tracer_provider)
+
+    # Logs — bridge stdlib logging to OTel
+    logger_provider = LoggerProvider(resource=resource)
+    log_exporter = OTLPLogExporter(endpoint=f"{endpoint}/v1/logs")
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+    handler = LoggingHandler(logger_provider=logger_provider)
+    logging.getLogger().addHandler(handler)
+
+    logger.info(
+        "OpenTelemetry initialized: endpoint=%s, service=%s",
+        endpoint,
+        service_name,
+    )
+
+    def shutdown():
+        tracer_provider.shutdown()
+        logger_provider.shutdown()
+
+    return shutdown
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run --project brain pytest brain/tests/test_telemetry.py -v`
+Expected: All 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brain/pyproject.toml brain/src/hippo_brain/telemetry.py brain/tests/test_telemetry.py
+git commit -m "feat(brain): add OpenTelemetry instrumentation gated by HIPPO_OTEL_ENABLED
+
+Traces and logs exported via OTLP HTTP when env var is set.
+Gracefully degrades when otel packages not installed."
+```
+
+---
+
+## Task 6: Wire Python OTel into Brain Server and MCP
+
+**Files:**
+- Modify: `brain/src/hippo_brain/__init__.py`
+- Modify: `brain/src/hippo_brain/server.py`
+- Modify: `brain/src/hippo_brain/mcp.py`
+
+- [ ] **Step 1: Wire telemetry init into brain startup**
+
+In `brain/src/hippo_brain/__init__.py`, in the `main()` function, after loading settings and before starting the server, add:
+
+```python
+if command == "serve":
+    import uvicorn
+    from hippo_brain.server import create_app
+    from hippo_brain.telemetry import init_telemetry
+
+    settings = _load_runtime_settings()
+
+    # Initialize OTel if enabled (reads HIPPO_OTEL_ENABLED env var)
+    otel_endpoint = settings.get("telemetry_endpoint", "")
+    _otel_shutdown = init_telemetry("hippo-brain", endpoint=otel_endpoint)
+
+    app = create_app(
+        # ... existing args
+    )
+    uvicorn.run(app, host="127.0.0.1", port=settings["port"])
+```
+
+Also add `telemetry_endpoint` to the settings dict in `_load_runtime_settings()`:
+
+```python
+telemetry = config.get("telemetry", {})
+# ... in the return dict:
+"telemetry_endpoint": telemetry.get("endpoint", "http://localhost:4318"),
+```
+
+- [ ] **Step 2: Add trace spans to enrichment loop**
+
+In `brain/src/hippo_brain/server.py`, add a helper at the top of the file:
+
+```python
+def _get_tracer():
+    """Get OTel tracer if available, else return None."""
+    try:
+        if not os.environ.get("HIPPO_OTEL_ENABLED", "").strip() == "1":
+            return None
+        from opentelemetry import trace
+        return trace.get_tracer("hippo-brain")
+    except ImportError:
+        return None
+```
+
+Add `import os` to the imports if not already present.
+
+Then wrap key operations in the `_enrichment_loop` method with spans:
+
+```python
+# Inside the shell enrichment section, around the LLM call:
+tracer = _get_tracer()
+if tracer:
+    with tracer.start_as_current_span(
+        "enrichment.shell",
+        attributes={
+            "hippo.event_count": len(event_ids),
+            "hippo.model": self.enrichment_model,
+        },
+    ):
+        raw = await self.client.chat(messages=messages, model=self.enrichment_model)
+else:
+    raw = await self.client.chat(messages=messages, model=self.enrichment_model)
+```
+
+Apply the same pattern for Claude enrichment (span name `enrichment.claude`) and browser enrichment (span name `enrichment.browser`).
+
+- [ ] **Step 3: Add trace spans to MCP tool calls**
+
+In `brain/src/hippo_brain/mcp.py`, add the same `_get_tracer` helper, then wrap each tool function body:
+
+```python
+@mcp.tool()
+async def search_knowledge(query: str, mode: str = "semantic", limit: int = 10) -> list[dict]:
+    # ... existing docstring and setup ...
+    tracer = _get_tracer()
+    span_ctx = tracer.start_as_current_span(
+        "mcp.search_knowledge",
+        attributes={"hippo.query": query, "hippo.mode": mode},
+    ) if tracer else nullcontext()
+    with span_ctx:
+        # ... existing implementation unchanged, just indented under `with`
+```
+
+Add `from contextlib import nullcontext` to imports.
+
+- [ ] **Step 4: Run all Python tests**
+
+Run: `uv run --project brain pytest brain/tests -v`
+Expected: All tests pass (OTel code is no-op when env var unset).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/__init__.py brain/src/hippo_brain/server.py brain/src/hippo_brain/mcp.py
+git commit -m "feat(brain): wire OTel spans into enrichment loop and MCP tools
+
+Trace spans on shell/claude/browser enrichment and all MCP tool calls.
+No-op when HIPPO_OTEL_ENABLED is unset."
+```
+
+---
+
+## Task 7: Mise Tasks for OTel Stack Management
+
+**Files:**
+- Modify: `mise.toml`
+
+Add convenience tasks so `mise run otel:up` / `otel:down` / `otel:logs` work.
+
+- [ ] **Step 1: Add otel tasks to mise.toml**
+
+Append to `mise.toml`:
+
+```toml
+# ── Observability (OTel) ────────────────────────────────────────────
+
+[tasks."otel:up"]
+description = "Start the OTel observability stack (Grafana, Tempo, Loki, Prometheus, Collector)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+cd otel
+docker compose up -d
+echo ""
+echo "=== OTel stack running ==="
+echo "  Grafana:        http://localhost:3000 (admin/hippo)"
+echo "  OTel Collector: localhost:4317 (gRPC) / localhost:4318 (HTTP)"
+echo "  Collector health: http://localhost:13133"
+echo ""
+echo "To send telemetry from hippo services:"
+echo "  Daemon: cargo build --features otel && set [telemetry] enabled = true"
+echo "  Brain:  export HIPPO_OTEL_ENABLED=1"
+"""
+
+[tasks."otel:down"]
+description = "Stop the OTel observability stack"
+run = "cd otel && docker compose down"
+
+[tasks."otel:logs"]
+description = "Tail OTel stack logs"
+run = "cd otel && docker compose logs -f --tail 50"
+
+[tasks."otel:reset"]
+description = "Stop the OTel stack and delete all stored data"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+cd otel
+docker compose down -v
+echo "OTel stack stopped and all data volumes removed."
+"""
+
+[tasks."otel:status"]
+description = "Show OTel stack container status"
+run = "cd otel && docker compose ps"
+
+[tasks."build:otel"]
+description = "Build daemon with OTel instrumentation"
+run = "cargo build -p hippo-daemon --features otel"
+
+[tasks."build:otel:release"]
+description = "Build daemon with OTel instrumentation (release)"
+run = "cargo build -p hippo-daemon --features otel --release"
+```
+
+- [ ] **Step 2: Verify the tasks register**
+
+Run: `mise tasks | grep otel`
+Expected: Shows all 6 otel-related tasks.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mise.toml
+git commit -m "feat(mise): add otel:up/down/logs/reset/status tasks
+
+Convenience commands for managing the Docker Compose observability stack."
+```
+
+---
+
+## Task 8: Grafana Dashboard
+
+**Files:**
+- Create: `otel/grafana/dashboards/hippo-overview.json`
+
+A pre-built dashboard with panels for logs, traces, and metrics.
+
+- [ ] **Step 1: Create the dashboard JSON**
+
+Create `otel/grafana/dashboards/hippo-overview.json` with a dashboard containing these panels:
+
+1. **Log Volume** — Loki log rate by service (`{service_name=~"hippo.*"}`)
+2. **Error Logs** — Loki filtered to level=ERROR
+3. **Recent Traces** — Tempo trace list for `hippo-daemon` and `hippo-brain`
+4. **Request Rate** — Prometheus `hippo_` prefixed metrics (from OTel Collector prometheus exporter)
+5. **Enrichment Latency** — Trace duration for `enrichment.*` spans
+
+The dashboard JSON should be a valid Grafana dashboard model. Here is a minimal but functional version:
+
+```json
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Log Volume by Service",
+      "type": "timeseries",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum by(service_name) (count_over_time({service_name=~\"hippo.*\"} [1m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 30 } },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Error Logs",
+      "type": "logs",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "{service_name=~\"hippo.*\"} |= \"ERROR\" or {service_name=~\"hippo.*\"} | severity >= \"ERROR\"",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Recent Traces",
+      "type": "table",
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "queryType": "traceqlSearch",
+          "filters": [
+            { "id": "service-name", "tag": "service.name", "operator": "=~", "value": ["hippo-daemon", "hippo-brain", "hippo-mcp"] }
+          ],
+          "limit": 20,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Enrichment Span Duration (p95)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(hippo_span_duration_bucket{span_name=~\"enrichment.*\"}[5m])))",
+          "legendFormat": "p95 enrichment",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Service Logs (Live)",
+      "type": "logs",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 26 },
+      "targets": [
+        {
+          "expr": "{service_name=~\"hippo.*\"}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["hippo", "observability"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Hippo Overview",
+  "uid": "hippo-overview",
+  "version": 1
+}
+```
+
+- [ ] **Step 2: Restart Grafana to pick up the dashboard**
+
+Run:
+```bash
+cd otel && docker compose restart grafana && sleep 3
+curl -s http://localhost:3000/api/dashboards/uid/hippo-overview | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('dashboard',{}).get('title','NOT FOUND'))"
+```
+
+Expected: Prints `Hippo Overview`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add otel/grafana/dashboards/hippo-overview.json
+git commit -m "feat(otel): add pre-built Grafana dashboard for Hippo services
+
+Panels: log volume, error logs, recent traces, enrichment latency,
+live service logs."
+```
+
+---
+
+## Task 9: LaunchAgent OTel Environment Wiring
+
+**Files:**
+- Modify: `launchd/com.hippo.daemon.plist`
+- Modify: `launchd/com.hippo.brain.plist`
+- Modify: `crates/hippo-daemon/src/install.rs`
+
+When the OTel stack is running, the launchd plist needs `HIPPO_OTEL_ENABLED=1` and `OTEL_EXPORTER_OTLP_ENDPOINT` for the brain. The daemon reads from config.toml so it doesn't need env vars, but the brain does.
+
+- [ ] **Step 1: Read the install module**
+
+Read: `crates/hippo-daemon/src/install.rs`
+
+Understand how plist templates are processed and what variables are substituted.
+
+- [ ] **Step 2: Add OTEL env vars as optional plist placeholders**
+
+In `launchd/com.hippo.brain.plist`, add optional OTel env vars to the EnvironmentVariables dict:
+
+```xml
+<key>HIPPO_OTEL_ENABLED</key>
+<string>__HIPPO_OTEL_ENABLED__</string>
+<key>OTEL_EXPORTER_OTLP_ENDPOINT</key>
+<string>__OTEL_ENDPOINT__</string>
+```
+
+- [ ] **Step 3: Wire the substitution in install.rs**
+
+In `install.rs`, add the OTel variable substitution. Read `config.telemetry.enabled` and `config.telemetry.endpoint` to fill in the placeholders:
+- `__HIPPO_OTEL_ENABLED__` → `"1"` if enabled, `"0"` if not
+- `__OTEL_ENDPOINT__` → the endpoint from config (default `http://localhost:4318`)
+
+- [ ] **Step 4: Test a fresh install**
+
+Run: `cargo build --release --features otel`
+
+Then verify the generated plist has the env vars:
+```bash
+cargo run --release --features otel --bin hippo -- daemon install --force 2>&1 | grep -i otel
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add launchd/ crates/hippo-daemon/src/install.rs
+git commit -m "feat(install): wire OTel env vars into LaunchAgent plists
+
+Brain plist gets HIPPO_OTEL_ENABLED and OTEL_EXPORTER_OTLP_ENDPOINT
+from config.toml [telemetry] section during install."
+```
+
+---
+
+## Task 10: OTel README and Integration Test
+
+**Files:**
+- Create: `otel/README.md`
+- Create: `crates/hippo-daemon/tests/telemetry_test.rs`
+
+- [ ] **Step 1: Create the OTel README**
+
+Create `otel/README.md`:
+
+```markdown
+# Hippo OTel Observability Stack
+
+Optional Docker Compose stack for monitoring Hippo services with OpenTelemetry.
+
+## Quick Start
+
+```bash
+# Start the stack
+mise run otel:up
+
+# Build daemon with OTel support
+mise run build:otel
+
+# Enable telemetry in config
+hippo config edit
+# Set: [telemetry] enabled = true
+
+# For brain: set env var before starting
+export HIPPO_OTEL_ENABLED=1
+
+# Restart services
+mise run restart
+
+# Open Grafana
+open http://localhost:3000
+```
+
+## Architecture
+
+```
+hippo-daemon ──┐
+               ├── OTLP ──→ OTel Collector ──→ Tempo (traces)
+hippo-brain  ──┤                            ──→ Loki (logs)
+               │                            ──→ Prometheus (metrics)
+hippo-mcp   ──┘
+                                               Grafana (visualization)
+```
+
+## Services
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| OTel Collector | 4317 (gRPC), 4318 (HTTP) | Receives OTLP telemetry |
+| Grafana | 3000 | Dashboards and exploration |
+| Tempo | 3200 | Trace storage |
+| Loki | 3100 | Log aggregation |
+| Prometheus | 9090 | Metrics storage |
+
+## Enabling Telemetry
+
+### Daemon (Rust)
+
+1. Build with OTel feature: `cargo build --features otel`
+2. Set in `~/.config/hippo/config.toml`:
+
+```toml
+[telemetry]
+enabled = true
+endpoint = "http://localhost:4317"
+```
+
+### Brain / MCP (Python)
+
+Set the environment variable:
+
+```bash
+export HIPPO_OTEL_ENABLED=1
+# Optional: override endpoint (default: http://localhost:4318)
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+## Commands
+
+```bash
+mise run otel:up       # Start stack
+mise run otel:down     # Stop stack
+mise run otel:logs     # Tail logs
+mise run otel:reset    # Stop + delete all data
+mise run otel:status   # Show container status
+```
+
+## Reuse
+
+This `otel/` directory is self-contained. To use it in another project:
+
+1. Copy the `otel/` directory
+2. Edit `otel/grafana/dashboards/` to add your dashboards
+3. Run `docker compose up -d` from the `otel/` directory
+4. Point your services at `localhost:4317` (gRPC) or `localhost:4318` (HTTP)
+```
+
+- [ ] **Step 2: Create Rust telemetry integration test**
+
+Create `crates/hippo-daemon/tests/telemetry_test.rs`:
+
+```rust
+//! Integration test: verify OTel telemetry module initializes and shuts down cleanly.
+//! Only compiled with --features otel.
+
+#[cfg(feature = "otel")]
+mod otel_tests {
+    use hippo_daemon::telemetry;
+
+    /// Test that init succeeds when pointing at a non-existent collector.
+    /// The batch exporter buffers spans — it won't fail until export time.
+    /// We just verify the init/shutdown cycle doesn't panic.
+    #[test]
+    fn test_telemetry_init_shutdown() {
+        // Use a port nothing listens on
+        let guard = telemetry::init("test-service", "http://localhost:19999")
+            .expect("telemetry init should succeed even without a collector");
+        guard.shutdown();
+    }
+}
+```
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `cargo test -p hippo-daemon --features otel --test telemetry_test`
+Expected: Test passes.
+
+- [ ] **Step 4: Run all tests to check for regressions**
+
+Run: `cargo test` (without otel feature — default)
+Expected: All existing tests pass. The telemetry test is skipped (cfg-gated).
+
+Run: `uv run --project brain pytest brain/tests -v`
+Expected: All Python tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add otel/README.md crates/hippo-daemon/tests/telemetry_test.rs
+git commit -m "docs(otel): add README and integration test
+
+README covers quick start, architecture, reuse instructions.
+Integration test verifies OTel init/shutdown cycle."
+```
+
+---
+
+## Task 11: End-to-End Smoke Test
+
+**Files:** None created — this is a verification task.
+
+- [ ] **Step 1: Start the OTel stack**
+
+Run: `mise run otel:up`
+Expected: All 5 containers running.
+
+- [ ] **Step 2: Build and run daemon with OTel**
+
+Set `[telemetry] enabled = true` in `~/.config/hippo/config.toml`.
+
+Run: `cargo run --features otel --bin hippo -- daemon run`
+
+Expected: Log line `OpenTelemetry initialized: endpoint=http://localhost:4317, service=hippo-daemon` appears in stderr.
+
+- [ ] **Step 3: Send a test event**
+
+In another terminal:
+
+```bash
+hippo send-event shell --cmd "echo otel-test" --exit 0 --cwd /tmp --duration-ms 42
+```
+
+- [ ] **Step 4: Verify traces appear in Grafana**
+
+Open http://localhost:3000, navigate to Explore → Tempo.
+
+Search for traces with `service.name = hippo-daemon`.
+
+Expected: At least one trace with spans for `handle_request` and `flush_events`.
+
+- [ ] **Step 5: Verify logs appear in Grafana**
+
+In Explore → Loki, query `{service_name="hippo-daemon"}`.
+
+Expected: Log lines from the daemon visible.
+
+- [ ] **Step 6: Stop daemon and OTel stack**
+
+```bash
+# Stop daemon (Ctrl+C)
+mise run otel:down
+```
+
+- [ ] **Step 7: Restore config**
+
+Set `[telemetry] enabled = false` in `~/.config/hippo/config.toml` (or leave it — it's your call).
+
+---
+
+## Summary of Architecture Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Grafana LGTM stack** over SigNoz/Uptrace | Each component is best-in-class, independently configurable, widely adopted. Easy to swap one piece without replacing everything. |
+| **OTel Collector as intermediary** | Decouples services from backends. Switch from Tempo to Jaeger by changing one config line. Adds batching, retrying, and health checking. |
+| **Cargo feature flag (`otel`)** | Zero-cost when disabled. No new deps in the default build. CI can test both paths. |
+| **Env var gating (`HIPPO_OTEL_ENABLED`)** | Python has no equivalent of Cargo features. Env var is the standard OTel pattern and works with launchd. |
+| **OTLP gRPC for Rust, HTTP for Python** | Rust has mature tonic/gRPC support. Python's HTTP exporter is simpler and avoids grpcio build issues. Both are OTLP — the collector handles both protocols. |
+| **Self-contained `otel/` directory** | Extractable to other projects. No dependency on Hippo code. Only needs Docker Compose. |
+| **`tracing::instrument` over manual spans** | Rust daemon already uses `tracing` extensively. `#[instrument]` is zero-effort and captures function args automatically. |
+| **Prometheus exporter on collector** (not direct Prometheus scrape) | Services don't need to expose HTTP metrics endpoints. The collector translates OTel metrics to Prometheus format. |

--- a/launchd/com.hippo.brain.plist
+++ b/launchd/com.hippo.brain.plist
@@ -19,6 +19,10 @@
         <string>__HOME__</string>
         <key>PATH</key>
         <string>__PATH__</string>
+        <key>HIPPO_OTEL_ENABLED</key>
+        <string>__HIPPO_OTEL_ENABLED__</string>
+        <key>OTEL_EXPORTER_OTLP_ENDPOINT</key>
+        <string>__OTEL_ENDPOINT__</string>
     </dict>
     <key>KeepAlive</key>
     <true/>

--- a/mise.toml
+++ b/mise.toml
@@ -516,3 +516,53 @@ run = [
   "cargo clean",
   "rm -rf brain/.venv brain/.pytest_cache brain/.ruff_cache",
 ]
+
+# ── Observability (OTel) ────────────────────────────────────────────
+
+[tasks."otel:up"]
+description = "Start the OTel observability stack (Grafana, Tempo, Loki, Prometheus, Collector)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+cd otel
+docker compose up -d
+echo ""
+echo "=== OTel stack running ==="
+echo "  Grafana:        http://localhost:3000 (admin/hippo)"
+echo "  OTel Collector: localhost:4317 (gRPC) / localhost:4318 (HTTP)"
+echo "  Collector health: http://localhost:13133"
+echo ""
+echo "To send telemetry from hippo services:"
+echo "  Daemon: cargo build --features otel && set [telemetry] enabled = true"
+echo "  Brain:  export HIPPO_OTEL_ENABLED=1"
+"""
+
+[tasks."otel:down"]
+description = "Stop the OTel observability stack"
+run = "cd otel && docker compose down"
+
+[tasks."otel:logs"]
+description = "Tail OTel stack logs"
+run = "cd otel && docker compose logs -f --tail 50"
+
+[tasks."otel:reset"]
+description = "Stop the OTel stack and delete all stored data"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+cd otel
+docker compose down -v
+echo "OTel stack stopped and all data volumes removed."
+"""
+
+[tasks."otel:status"]
+description = "Show OTel stack container status"
+run = "cd otel && docker compose ps"
+
+[tasks."build:otel"]
+description = "Build daemon with OTel instrumentation"
+run = "cargo build -p hippo-daemon --features otel"
+
+[tasks."build:otel:release"]
+description = "Build daemon with OTel instrumentation (release)"
+run = "cargo build -p hippo-daemon --features otel --release"

--- a/otel/README.md
+++ b/otel/README.md
@@ -1,0 +1,89 @@
+# Hippo OTel Observability Stack
+
+Optional Docker Compose stack for monitoring Hippo services with OpenTelemetry.
+
+## Quick Start
+
+```bash
+# Start the stack
+mise run otel:up
+
+# Build daemon with OTel support
+mise run build:otel
+
+# Enable telemetry in config
+hippo config edit
+# Set: [telemetry] enabled = true
+
+# For brain: set env var before starting
+export HIPPO_OTEL_ENABLED=1
+
+# Restart services
+mise run restart
+
+# Open Grafana
+open http://localhost:3000
+```
+
+## Architecture
+
+```
+hippo-daemon ──┐
+               ├── OTLP ──→ OTel Collector ──→ Tempo (traces)
+hippo-brain  ──┤                            ──→ Loki (logs)
+               │                            ──→ Prometheus (metrics)
+hippo-mcp   ──┘
+                                               Grafana (visualization)
+```
+
+## Services
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| OTel Collector | 4317 (gRPC), 4318 (HTTP) | Receives OTLP telemetry |
+| Grafana | 3000 | Dashboards and exploration |
+| Tempo | 3200 | Trace storage |
+| Loki | 3100 | Log aggregation |
+| Prometheus | 9090 | Metrics storage |
+
+## Enabling Telemetry
+
+### Daemon (Rust)
+
+1. Build with OTel feature: `cargo build --features otel`
+2. Set in `~/.config/hippo/config.toml`:
+
+```toml
+[telemetry]
+enabled = true
+endpoint = "http://localhost:4317"
+```
+
+### Brain / MCP (Python)
+
+Set the environment variable:
+
+```bash
+export HIPPO_OTEL_ENABLED=1
+# Optional: override endpoint (default: http://localhost:4318)
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+## Commands
+
+```bash
+mise run otel:up       # Start stack
+mise run otel:down     # Stop stack
+mise run otel:logs     # Tail logs
+mise run otel:reset    # Stop + delete all data
+mise run otel:status   # Show container status
+```
+
+## Reuse
+
+This `otel/` directory is self-contained. To use it in another project:
+
+1. Copy the `otel/` directory
+2. Edit `otel/grafana/dashboards/` to add your dashboards
+3. Run `docker compose up -d` from the `otel/` directory
+4. Point your services at `localhost:4317` (gRPC) or `localhost:4318` (HTTP)

--- a/otel/docker-compose.yml
+++ b/otel/docker-compose.yml
@@ -1,0 +1,62 @@
+name: hippo-otel
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.120.0
+    command: ["--config", "/etc/otelcol/config.yml"]
+    volumes:
+      - ./otelcol-config.yml:/etc/otelcol/config.yml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "13133:13133"
+    depends_on:
+      - tempo
+      - loki
+
+  tempo:
+    image: grafana/tempo:2.7.2
+    command: ["-config.file=/etc/tempo/config.yml"]
+    volumes:
+      - ./tempo-config.yml:/etc/tempo/config.yml:ro
+      - tempo-data:/var/tempo
+
+  loki:
+    image: grafana/loki:3.4.2
+    command: ["-config.file=/etc/loki/config.yml"]
+    volumes:
+      - ./loki-config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=7d"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+
+  grafana:
+    image: grafana/grafana:11.5.2
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=hippo
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - tempo
+      - loki
+      - prometheus
+
+volumes:
+  tempo-data:
+  loki-data:
+  prometheus-data:
+  grafana-data:

--- a/otel/grafana/dashboards/dashboards.yml
+++ b/otel/grafana/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: "hippo"
+    orgId: 1
+    folder: "Hippo"
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/otel/grafana/dashboards/hippo-overview.json
+++ b/otel/grafana/dashboards/hippo-overview.json
@@ -1,0 +1,165 @@
+{
+  "uid": "hippo-overview",
+  "title": "Hippo Overview",
+  "tags": ["hippo", "observability"],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log Volume by Service",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by(service_name) (count_over_time({service_name=~\"hippo.*\"} [1m]))",
+          "legendFormat": "{{service_name}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineWidth": 0,
+            "stacking": { "mode": "normal", "group": "A" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Logs",
+      "type": "logs",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service_name=~\"hippo.*\"} |= \"ERROR\" or {service_name=~\"hippo.*\"} | severity >= \"ERROR\"",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      }
+    },
+    {
+      "id": 3,
+      "title": "Recent Traces",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 8, "w": 24, "h": 10 },
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "tempo" },
+          "queryType": "traceqlSearch",
+          "filters": [
+            {
+              "id": "service-name",
+              "tag": "service.name",
+              "operator": "=~",
+              "value": "hippo-daemon|hippo-brain|hippo-mcp",
+              "valueType": "string",
+              "scope": "resource"
+            }
+          ],
+          "limit": 20
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "footer": { "show": false },
+        "showHeader": true
+      },
+      "transformations": []
+    },
+    {
+      "id": 4,
+      "title": "Enrichment Span Duration (p95)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 18, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(hippo_span_duration_bucket{span_name=~\"enrichment.*\"}[5m])))",
+          "legendFormat": "p95 enrichment duration"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Service Logs (Live)",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 26, "w": 24, "h": 10 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service_name=~\"hippo.*\"}",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      }
+    }
+  ]
+}

--- a/otel/grafana/datasources.yml
+++ b/otel/grafana/datasources.yml
@@ -1,0 +1,34 @@
+apiVersion: 1
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    uid: tempo
+    isDefault: false
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        filterByTraceID: true
+      tracesToMetrics:
+        datasourceUid: prometheus
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    uid: loki
+    isDefault: true
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: "trace_id=(\\w+)"
+          name: TraceID
+          url: "$${__value.raw}"
+
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    uid: prometheus
+    isDefault: false

--- a/otel/loki-config.yml
+++ b/otel/loki-config.yml
@@ -1,0 +1,29 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true

--- a/otel/otelcol-config.yml
+++ b/otel/otelcol-config.yml
@@ -1,0 +1,49 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+
+  resource:
+    attributes:
+      - key: host.name
+        from_attribute: host.name
+        action: upsert
+
+exporters:
+  otlphttp/tempo:
+    endpoint: http://tempo:3200
+
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: hippo
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [otlphttp/tempo]
+    logs:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [loki]
+    metrics:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [prometheus]

--- a/otel/prometheus.yml
+++ b/otel/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "otel-collector"
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/otel/tempo-config.yml
+++ b/otel/tempo-config.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:3200
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal


### PR DESCRIPTION
This pull request introduces OpenTelemetry (OTel) support to the Hippo Brain codebase, enabling distributed tracing and improved observability for both Python and Rust components. The integration is designed to be optional and gated behind configuration and environment variables, ensuring no impact when disabled. Key changes include OTel initialization logic, configuration updates, and the addition of tracing spans to core logic.

**OpenTelemetry Integration:**

* Added OTel dependencies to both Python (`pyproject.toml`) and Rust (`Cargo.toml`) projects to support distributed tracing and logging. [[1]](diffhunk://#diff-933170718cb256eb36da291869226bd409542f5935074e52d6095b79d2764da3R21-R25) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R25-R29)
* Implemented `hippo_brain.telemetry` module in Python for OTel initialization, gated by the `HIPPO_OTEL_ENABLED` environment variable, with graceful handling when OTel packages are missing.
* Updated the Python server (`__init__.py`) to initialize OTel at startup and ensure proper shutdown, passing the telemetry endpoint from config. [[1]](diffhunk://#diff-3c9f5aa2ef80a9c1a54c6fe4b0d464bf1da8cfe0126475e5fd06dee39b02c60cR60-R66) [[2]](diffhunk://#diff-3c9f5aa2ef80a9c1a54c6fe4b0d464bf1da8cfe0126475e5fd06dee39b02c60cR45) [[3]](diffhunk://#diff-3c9f5aa2ef80a9c1a54c6fe4b0d464bf1da8cfe0126475e5fd06dee39b02c60cR29) [[4]](diffhunk://#diff-3c9f5aa2ef80a9c1a54c6fe4b0d464bf1da8cfe0126475e5fd06dee39b02c60cR77-R81)

**Tracing in Application Logic:**

* Added OTel tracing spans to key operations in `mcp.py` (e.g., `search_knowledge`, `search_events`, `get_entities`) and the enrichment loop in `server.py`, capturing query/mode context and model details for observability. [[1]](diffhunk://#diff-e58e3e77ceefbce0bdf6ed9b24a082d11c64173c5e1264485053d1063d234775R150-R159) [[2]](diffhunk://#diff-e58e3e77ceefbce0bdf6ed9b24a082d11c64173c5e1264485053d1063d234775R231-R240) [[3]](diffhunk://#diff-e58e3e77ceefbce0bdf6ed9b24a082d11c64173c5e1264485053d1063d234775R280-R289) [[4]](diffhunk://#diff-8cab42586f3550f1a4353662677a527f0112e0ab84ea8a6317b42beba7e872c0R291-R303) [[5]](diffhunk://#diff-8cab42586f3550f1a4353662677a527f0112e0ab84ea8a6317b42beba7e872c0R410-R422) [[6]](diffhunk://#diff-8cab42586f3550f1a4353662677a527f0112e0ab84ea8a6317b42beba7e872c0R554-R566)

**Configuration and Testing:**

* Extended both Python (`config.default.toml`) and Rust (`HippoConfig` in `config.rs`) configuration to support OTel enablement and endpoint settings, with sensible defaults. Added tests for new config logic. [[1]](diffhunk://#diff-37089099ae58cc485ef6ee16c2cc5105c4d314d164e1303a79b10c72eb3531e2R86-R91) [[2]](diffhunk://#diff-a62f769e06cee8eecfc5f5a153da795f3b32c615ec9d52f7df7d21f6872e1107R19-R20) [[3]](diffhunk://#diff-a62f769e06cee8eecfc5f5a153da795f3b32c615ec9d52f7df7d21f6872e1107R311-R331) [[4]](diffhunk://#diff-a62f769e06cee8eecfc5f5a153da795f3b32c615ec9d52f7df7d21f6872e1107R694-R712)
* Added tests for Python telemetry initialization, covering enabled/disabled states and missing package scenarios.

These changes lay the groundwork for distributed observability in Hippo Brain, while keeping the feature safely optional and easy to configure.
[Copilot is generating a summary...]