### PR TITLE
chore: update allowed bots to include renovate in code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          allowed_bots: ['dependabot']
+          allowed_bots: "dependabot[bot],renovate[bot]"
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
This pull request updates the configuration for the code review workflow to expand the list of allowed bots. Now, both `dependabot[bot]` and `renovate[bot]` are permitted to trigger the workflow, instead of only `dependabot`.

Workflow configuration update:

* Updated the `allowed_bots` setting in `.github/workflows/claude-code-review.yml` to include both `dependabot[bot]` and `renovate[bot]`, allowing automated pull requests from both bots to trigger code review actions.