### PR TITLE
fix: session hook tmux targeting and install process coverage

### DIFF
--- a/launchd/com.hippo.daemon.plist
+++ b/launchd/com.hippo.daemon.plist
@@ -16,6 +16,10 @@
         <string>__HOME__</string>
         <key>PATH</key>
         <string>__PATH__</string>
+        <key>HIPPO_OTEL_ENABLED</key>
+        <string>__HIPPO_OTEL_ENABLED__</string>
+        <key>OTEL_EXPORTER_OTLP_ENDPOINT</key>
+        <string>__OTEL_ENDPOINT__</string>
     </dict>
     <key>KeepAlive</key>
     <true/>

--- a/mise.toml
+++ b/mise.toml
@@ -257,21 +257,53 @@ wait_for_exit() {
 echo "==> Stopping services..."
 launchctl bootout "$DOMAIN" "$DAEMON_PLIST" 2>/dev/null && echo "  Unloaded daemon" || true
 launchctl bootout "$DOMAIN" "$BRAIN_PLIST" 2>/dev/null && echo "  Unloaded brain" || true
+
+# Kill ALL hippo processes — daemon, brain, session tailers, MCP servers.
+# After a clean install, nothing should be running from a previous build.
 DAEMON_PATTERN='hippo.*(daemon|send-event)'
+TAILER_PATTERN='hippo ingest claude-session'
 BRAIN_PATTERN='hippo-brain'
+MCP_PATTERN='hippo-mcp'
 pkill -f "$DAEMON_PATTERN" 2>/dev/null || true
+pkill -f "$TAILER_PATTERN" 2>/dev/null || true
 pkill -f "$BRAIN_PATTERN" 2>/dev/null || true
+pkill -f "$MCP_PATTERN" 2>/dev/null || true
 echo "  Waiting for processes to exit..."
 wait_for_exit "$DAEMON_PATTERN"
+wait_for_exit "$TAILER_PATTERN" 5
 wait_for_exit "$BRAIN_PATTERN"
+wait_for_exit "$MCP_PATTERN" 5
 echo "  All processes stopped"
 
-# ── 2. Clean stale artifacts ────────────────────────────────────────
-echo "==> Cleaning stale artifacts..."
-rm -f "$DATA_DIR/daemon.sock" /tmp/hippo-daemon.sock
-rm -f "$DAEMON_PLIST" "$BRAIN_PLIST"
-rm -f ~/.local/bin/hippo
-rm -f "$DATA_DIR"/*.log
+# ── 2. Clean artifacts ──────────────────────────────────────────────
+if [[ "${1:-}" == "--clean" ]]; then
+    echo "==> Purging ALL build and install artifacts (preserving data)..."
+    # Rust build
+    cargo clean 2>/dev/null && echo "  Cleaned cargo target/" || true
+    # Python
+    rm -rf brain/.venv brain/.pytest_cache brain/.ruff_cache
+    echo "  Cleaned brain venv + caches"
+    # Firefox extension
+    rm -rf extension/firefox/dist extension/firefox/node_modules extension/firefox/web-ext-artifacts
+    echo "  Cleaned firefox extension build artifacts"
+    # Installed files
+    rm -f ~/.local/bin/hippo
+    rm -f "$DAEMON_PLIST" "$BRAIN_PLIST"
+    NM_DIR="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts"
+    rm -f "$NM_DIR/hippo_daemon.json" "$NM_DIR/hippo-native-messaging"
+    echo "  Removed installed plists, symlink, native messaging manifest"
+    # Runtime artifacts (not data)
+    rm -f "$DATA_DIR/daemon.sock" /tmp/hippo-daemon.sock
+    rm -f "$DATA_DIR"/*.log
+    echo "  Cleaned runtime artifacts (socket, logs)"
+    echo "  Preserved: hippo.db, vectors/, fallback/, config/"
+else
+    echo "==> Cleaning stale artifacts..."
+    rm -f "$DATA_DIR/daemon.sock" /tmp/hippo-daemon.sock
+    rm -f "$DAEMON_PLIST" "$BRAIN_PLIST"
+    rm -f ~/.local/bin/hippo
+    rm -f "$DATA_DIR"/*.log
+fi
 
 # ── 3. Build release binary ─────────────────────────────────────────
 echo "==> Building release binary..."
@@ -289,7 +321,7 @@ echo "  venv ready at brain/.venv"
 
 # ── 5. Install plists + symlink ─────────────────────────────────────
 echo "==> Installing LaunchAgents + symlink..."
-cargo run --release --bin hippo -- daemon install --force
+cargo run --release --features otel --bin hippo -- daemon install --force
 
 # ── 6. Bootstrap config files (preserve existing) ───────────────────
 echo "==> Ensuring config files..."
@@ -387,7 +419,9 @@ launchctl bootout "$DOMAIN" ~/Library/LaunchAgents/com.hippo.brain.plist 2>/dev/
 
 echo "Killing all hippo processes (SIGKILL)..."
 pkill -9 -f 'hippo.*(daemon|send-event)' 2>/dev/null && echo "  Killed daemon processes" || echo "  No daemon processes found"
+pkill -9 -f 'hippo ingest claude-session' 2>/dev/null && echo "  Killed session tailers" || echo "  No session tailers found"
 pkill -9 -f 'hippo-brain' 2>/dev/null && echo "  Killed brain processes" || echo "  No brain processes found"
+pkill -9 -f 'hippo-mcp' 2>/dev/null && echo "  Killed MCP servers" || echo "  No MCP servers found"
 
 echo "Cleaning up socket..."
 rm -f ~/.local/share/hippo/daemon.sock /tmp/hippo-daemon.sock

--- a/shell/claude-session-hook.sh
+++ b/shell/claude-session-hook.sh
@@ -18,15 +18,27 @@ set -euo pipefail
 #     }
 #   }
 
+TMUX_SESSION="hippo"
+LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/hippo"
+DEBUG_LOG="$LOG_DIR/session-hook-debug.log"
+
+log() {
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*" >> "$DEBUG_LOG"
+}
+
 # Read hook JSON from stdin
 INPUT=$(cat)
+log "hook invoked, input=${INPUT}"
 
 # Extract transcript_path from the JSON
 TRANSCRIPT_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
 
 if [ -z "$TRANSCRIPT_PATH" ]; then
+    log "no transcript_path in input, exiting"
     exit 0
 fi
+
+log "transcript_path=$TRANSCRIPT_PATH"
 
 # Wait briefly for the transcript file to be created (Claude fires the hook before writing it)
 for i in 1 2 3 4 5; do
@@ -35,6 +47,7 @@ for i in 1 2 3 4 5; do
 done
 
 if [ ! -f "$TRANSCRIPT_PATH" ]; then
+    log "transcript file not found after waiting, exiting"
     exit 0
 fi
 
@@ -48,26 +61,37 @@ if [ ! -x "$HIPPO_BIN" ]; then
     HIPPO_BIN="$(command -v hippo 2>/dev/null || true)"
 fi
 if [ -z "$HIPPO_BIN" ]; then
+    log "hippo binary not found, exiting"
     exit 0
 fi
+
+log "hippo_bin=$HIPPO_BIN"
 
 # Derive a short window name from the session file
 SESSION_NAME="$(basename "$TRANSCRIPT_PATH" .jsonl)"
 SHORT_ID="${SESSION_NAME:0:8}"
 WINDOW_NAME="hippo:${SHORT_ID}"
 
+# Resolve Claude's PID. The hook runs as a direct child of Claude Code,
+# so $PPID is the Claude process PID.
+CLAUDE_PID="$PPID"
+log "claude_pid=$CLAUDE_PID window_name=$WINDOW_NAME"
+
 # Spawn the tailer in a detached tmux window.
 # tmux new-window -d returns immediately — the tail loop runs inside the new window,
 # so this hook never blocks Claude Code from launching.
-# Pass Claude's PID so the tailer exits when Claude does.
-# The hook script runs as a direct child of Claude (no intermediate wrapper),
-# so $PPID is the Claude process PID.
-CLAUDE_PID="$PPID"
-
-if tmux list-sessions &>/dev/null; then
-    tmux new-window -d -n "$WINDOW_NAME" "HIPPO_WATCH_PID=$CLAUDE_PID $HIPPO_BIN ingest claude-session --inline $TRANSCRIPT_PATH"
+if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+    tmux new-window -d -t "$TMUX_SESSION" -n "$WINDOW_NAME" \
+        "HIPPO_WATCH_PID=$CLAUDE_PID $HIPPO_BIN ingest claude-session --inline $TRANSCRIPT_PATH"
+    log "spawned tmux window in session=$TMUX_SESSION"
+elif tmux list-sessions &>/dev/null; then
+    # hippo session doesn't exist but tmux is running — create it
+    tmux new-session -d -s "$TMUX_SESSION" -n "$WINDOW_NAME" \
+        "HIPPO_WATCH_PID=$CLAUDE_PID $HIPPO_BIN ingest claude-session --inline $TRANSCRIPT_PATH"
+    log "created tmux session=$TMUX_SESSION with tailer window"
 else
     # No tmux server — batch-import what's already in the file and exit.
     # Use setsid to fully detach from the hook's process group.
     ("$HIPPO_BIN" ingest claude-session --batch "$TRANSCRIPT_PATH" &>/dev/null &)
+    log "no tmux server, batch-imported"
 fi

--- a/shell/claude-session-hook.sh
+++ b/shell/claude-session-hook.sh
@@ -22,8 +22,12 @@ TMUX_SESSION="hippo"
 LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/hippo"
 DEBUG_LOG="$LOG_DIR/session-hook-debug.log"
 
+# Ensure log directory exists; make logging best-effort so the hook
+# still runs if the directory can't be created.
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
 log() {
-    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*" >> "$DEBUG_LOG"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*" >> "$DEBUG_LOG" 2>/dev/null || true
 }
 
 # Read hook JSON from stdin
@@ -77,17 +81,18 @@ WINDOW_NAME="hippo:${SHORT_ID}"
 CLAUDE_PID="$PPID"
 log "claude_pid=$CLAUDE_PID window_name=$WINDOW_NAME"
 
+# Build the tmux command with properly quoted paths (handles spaces/metacharacters).
+TMUX_CMD="HIPPO_WATCH_PID=${CLAUDE_PID} $(printf '%q' "$HIPPO_BIN") ingest claude-session --inline $(printf '%q' "$TRANSCRIPT_PATH")"
+
 # Spawn the tailer in a detached tmux window.
 # tmux new-window -d returns immediately — the tail loop runs inside the new window,
 # so this hook never blocks Claude Code from launching.
 if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
-    tmux new-window -d -t "$TMUX_SESSION" -n "$WINDOW_NAME" \
-        "HIPPO_WATCH_PID=$CLAUDE_PID $HIPPO_BIN ingest claude-session --inline $TRANSCRIPT_PATH"
+    tmux new-window -d -t "$TMUX_SESSION" -n "$WINDOW_NAME" "$TMUX_CMD"
     log "spawned tmux window in session=$TMUX_SESSION"
 elif tmux list-sessions &>/dev/null; then
     # hippo session doesn't exist but tmux is running — create it
-    tmux new-session -d -s "$TMUX_SESSION" -n "$WINDOW_NAME" \
-        "HIPPO_WATCH_PID=$CLAUDE_PID $HIPPO_BIN ingest claude-session --inline $TRANSCRIPT_PATH"
+    tmux new-session -d -s "$TMUX_SESSION" -n "$WINDOW_NAME" "$TMUX_CMD"
     log "created tmux session=$TMUX_SESSION with tailer window"
 else
     # No tmux server — batch-import what's already in the file and exit.


### PR DESCRIPTION
## Summary
- Fix claude session hook spawning tailer windows in random tmux sessions by explicitly targeting the `hippo` session (creates it if missing)
- Add debug logging to session hook (`~/.local/share/hippo/session-hook-debug.log`) for diagnosing future failures
- Expand `mise run install` and `mise run nuke` to kill ALL hippo processes (session tailers, MCP servers) not just daemon/brain
- Add `--clean` flag to `mise run install` that purges all build and install artifacts (Rust target, brain venv, Firefox extension build, plists, NM manifest, symlink) while preserving data (hippo.db, vectors, fallback, config)
- Add OTel env vars to daemon plist template and pass `--features otel` to `cargo run` in install task to prevent silent feature stripping

## Test plan
- [x] All Rust tests pass (133 tests)
- [x] All Python tests pass (207 tests)
- [x] Clippy + ruff clean
- [x] Manual: verified hook spawns tailer in `hippo` tmux session on session start
- [x] Manual: verified `mise run install --clean` purges artifacts and rebuilds cleanly
- [x] Manual: verified brain recovers stale enrichment locks after install kills in-flight work

🤖 Generated with [Claude Code](https://claude.com/claude-code)