### PR TITLE
feat: auto-install Firefox extension via mise run install

### DIFF
--- a/extension/firefox/README.md
+++ b/extension/firefox/README.md
@@ -17,16 +17,7 @@ This creates:
 
 ### 2. Install Extension in Firefox Developer Edition
 
-#### Build the .xpi
-
-```bash
-cd extension/firefox
-npx web-ext build --overwrite-dest
-```
-
-This creates `web-ext-artifacts/hippo_browser_capture-0.2.0.zip`.
-
-#### Enable unsigned extension install (one-time)
+#### One-time: enable unsigned extension install
 
 1. Open `about:config` in Firefox Developer Edition
 2. Search for `xpinstall.signatures.required`
@@ -35,14 +26,18 @@ This creates `web-ext-artifacts/hippo_browser_capture-0.2.0.zip`.
 This setting is only available in Developer Edition and Nightly — it allows installing
 locally-built extensions without Mozilla signing.
 
-#### Install permanently
+#### Automated install
 
-1. Open `about:addons` (or Cmd+Shift+A)
-2. Click the gear icon → **Install Add-on From File...**
-3. Select `extension/firefox/web-ext-artifacts/hippo_browser_capture-0.2.0.zip`
-4. Click **Add** when prompted
+```bash
+mise run install:ext
+```
 
-The extension persists across Firefox restarts. No more temporary loading via `about:debugging`.
+This builds the extension, packages it as an .xpi, and side-loads it into the
+`dev-edition-default` Firefox profile at
+`~/Library/Application Support/Firefox/Profiles/*.dev-edition-default/extensions/hippo-browser@local.xpi`.
+
+`mise run install` (the full hippo installer) invokes this automatically. If Firefox is
+running when the task completes, restart it to pick up changes.
 
 #### Alternative: temporary loading (for development)
 

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,11 @@ fi
 
 if [ ! -d node_modules ]; then
     echo "==> Installing extension dependencies..."
-    npm ci --silent 2>/dev/null || npm install --silent
+    if [ -f package-lock.json ]; then
+        npm ci --silent
+    else
+        npm install --silent
+    fi
 fi
 
 echo "==> Building extension..."
@@ -61,37 +65,76 @@ run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Find the dev-edition profile path by parsing profiles.ini.
-PROFILES_INI="$HOME/Library/Application Support/Firefox/profiles.ini"
+FIREFOX_ROOT="$HOME/Library/Application Support/Firefox"
+PROFILES_INI="$FIREFOX_ROOT/profiles.ini"
 if [ ! -f "$PROFILES_INI" ]; then
     echo "Firefox profiles.ini not found; skipping extension install"
     exit 0
 fi
 
-# Extract the Path= line for the [Profile*] block whose Name=dev-edition-default.
-PROFILE_REL=$(awk '
-    /^\\[Profile/ { in_block=1; name=""; path=""; next }
-    /^\\[/ { in_block=0 }
-    in_block && /^Name=/ { name=substr($0, 6) }
-    in_block && /^Path=/ { path=substr($0, 6) }
-    in_block && name=="dev-edition-default" && path!="" { print path; exit }
-' "$PROFILES_INI")
+# Resolve the Firefox Developer Edition profile directory. Strategy:
+#   1. Parse profiles.ini with Python's configparser (handles IsRelative=0/1
+#      and all the edge cases awk would miss).
+#   2. Prefer the profile with Name=dev-edition-default.
+#   3. Fall back to any profile whose path contains "dev-edition".
+#   4. Bail if none found.
+PROFILE_DIR=$(FIREFOX_ROOT="$FIREFOX_ROOT" PROFILES_INI="$PROFILES_INI" python3 - <<'PY'
+import configparser, os, sys
+cp = configparser.ConfigParser()
+try:
+    cp.read(os.environ["PROFILES_INI"])
+except Exception as e:
+    print(f"ERROR parsing profiles.ini: {e}", file=sys.stderr)
+    sys.exit(0)
 
-if [ -z "$PROFILE_REL" ]; then
-    echo "No dev-edition-default profile found in profiles.ini; skipping extension install"
+root = os.environ["FIREFOX_ROOT"]
+def resolve(section):
+    path = cp[section].get("Path", "")
+    if not path: return ""
+    is_rel = cp[section].get("IsRelative", "1") == "1"
+    return os.path.join(root, path) if is_rel else path
+
+# Pass 1: exact name match.
+for s in cp.sections():
+    if not s.startswith("Profile"): continue
+    if cp[s].get("Name", "") == "dev-edition-default":
+        print(resolve(s)); sys.exit(0)
+
+# Pass 2: any profile whose path looks like dev-edition.
+for s in cp.sections():
+    if not s.startswith("Profile"): continue
+    if "dev-edition" in cp[s].get("Path", ""):
+        print(resolve(s)); sys.exit(0)
+PY
+)
+
+if [ -z "$PROFILE_DIR" ]; then
+    echo "No Firefox Developer Edition profile found in profiles.ini; skipping extension install"
     exit 0
 fi
-
-PROFILE_DIR="$HOME/Library/Application Support/Firefox/$PROFILE_REL"
 if [ ! -d "$PROFILE_DIR" ]; then
-    echo "Profile directory not found: $PROFILE_DIR"
+    echo "Profile directory not found: $PROFILE_DIR; skipping extension install"
     exit 0
 fi
 
-# Extract the gecko extension ID from manifest.json (no jq dependency).
-EXT_ID=$(python3 -c "import json; print(json.load(open('extension/firefox/manifest.json'))['browser_specific_settings']['gecko']['id'])")
+# Extract the gecko extension ID from manifest.json. Handle missing file or
+# malformed structure with a concise error rather than a Python stack trace.
+MANIFEST="extension/firefox/manifest.json"
+if [ ! -f "$MANIFEST" ]; then
+    echo "ERROR: $MANIFEST not found"
+    exit 1
+fi
+EXT_ID=$(python3 - "$MANIFEST" <<'PY' 2>/dev/null
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f)["browser_specific_settings"]["gecko"]["id"])
+except (OSError, ValueError, KeyError):
+    sys.exit(1)
+PY
+)
 if [ -z "$EXT_ID" ]; then
-    echo "Could not read extension ID from manifest.json"
+    echo "ERROR: could not read browser_specific_settings.gecko.id from $MANIFEST"
     exit 1
 fi
 

--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,108 @@ run = "uv sync --project brain"
 description = "Build everything"
 depends = ["build", "build:brain"]
 
+[tasks."build:ext"]
+description = "Build and package the Firefox extension as an .xpi"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd extension/firefox
+
+if ! command -v npm >/dev/null 2>&1; then
+    echo "npm not found; skipping extension build"
+    exit 0
+fi
+
+if [ ! -d node_modules ]; then
+    echo "==> Installing extension dependencies..."
+    npm ci --silent 2>/dev/null || npm install --silent
+fi
+
+echo "==> Building extension..."
+npm run package --silent
+
+# web-ext emits a .zip; Firefox loads it just fine as an .xpi.
+ARTIFACT=$(ls -t web-ext-artifacts/*.zip 2>/dev/null | head -1)
+if [ -z "$ARTIFACT" ]; then
+    echo "ERROR: web-ext did not produce an artifact"
+    exit 1
+fi
+echo "  Built: $ARTIFACT"
+"""
+
+[tasks."install:ext"]
+description = "Side-load the Firefox extension into Firefox Developer Edition"
+depends = ["build:ext"]
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find the dev-edition profile path by parsing profiles.ini.
+PROFILES_INI="$HOME/Library/Application Support/Firefox/profiles.ini"
+if [ ! -f "$PROFILES_INI" ]; then
+    echo "Firefox profiles.ini not found; skipping extension install"
+    exit 0
+fi
+
+# Extract the Path= line for the [Profile*] block whose Name=dev-edition-default.
+PROFILE_REL=$(awk '
+    /^\\[Profile/ { in_block=1; name=""; path=""; next }
+    /^\\[/ { in_block=0 }
+    in_block && /^Name=/ { name=substr($0, 6) }
+    in_block && /^Path=/ { path=substr($0, 6) }
+    in_block && name=="dev-edition-default" && path!="" { print path; exit }
+' "$PROFILES_INI")
+
+if [ -z "$PROFILE_REL" ]; then
+    echo "No dev-edition-default profile found in profiles.ini; skipping extension install"
+    exit 0
+fi
+
+PROFILE_DIR="$HOME/Library/Application Support/Firefox/$PROFILE_REL"
+if [ ! -d "$PROFILE_DIR" ]; then
+    echo "Profile directory not found: $PROFILE_DIR"
+    exit 0
+fi
+
+# Extract the gecko extension ID from manifest.json (no jq dependency).
+EXT_ID=$(python3 -c "import json; print(json.load(open('extension/firefox/manifest.json'))['browser_specific_settings']['gecko']['id'])")
+if [ -z "$EXT_ID" ]; then
+    echo "Could not read extension ID from manifest.json"
+    exit 1
+fi
+
+ARTIFACT=$(ls -t extension/firefox/web-ext-artifacts/*.zip 2>/dev/null | head -1)
+if [ -z "$ARTIFACT" ]; then
+    echo "No extension artifact found; run 'mise run build:ext' first"
+    exit 1
+fi
+
+DEST="$PROFILE_DIR/extensions/${EXT_ID}.xpi"
+mkdir -p "$PROFILE_DIR/extensions"
+cp "$ARTIFACT" "$DEST"
+echo "==> Installed extension: $DEST"
+
+# Verify xpinstall.signatures.required is set to false. If it isn't,
+# Firefox will silently delete the unsigned .xpi on startup.
+PREFS="$PROFILE_DIR/prefs.js"
+if [ -f "$PREFS" ]; then
+    # Match: user_pref("xpinstall.signatures.required", false);
+    if ! grep -Eq '^user_pref\\("xpinstall\\.signatures\\.required",[[:space:]]*false\\)' "$PREFS"; then
+        echo ""
+        echo "  WARN: xpinstall.signatures.required is not set to false in prefs.js."
+        echo "        Firefox will reject this unsigned extension on startup."
+        echo "        In about:config, set xpinstall.signatures.required = false, then restart Firefox."
+    fi
+fi
+
+# Warn if Firefox is running — it won't re-scan the extensions dir until restart.
+if pgrep -f "Firefox Developer Edition" >/dev/null 2>&1 || pgrep -f "Firefox.app/Contents/MacOS/firefox" >/dev/null 2>&1; then
+    echo ""
+    echo "  NOTE: Firefox is running. Restart it for the updated extension to load."
+fi
+"""
+
 [tasks."stamp:version"]
 description = "Stamp brain _version.py with git metadata (matches Rust build.rs)"
 run = """
@@ -346,6 +448,10 @@ mkdir -p "$DATA_DIR"
 echo "==> Starting services..."
 launchctl bootstrap "$DOMAIN" "$DAEMON_PLIST" && echo "  Loaded daemon" || echo "  Failed to load daemon"
 launchctl bootstrap "$DOMAIN" "$BRAIN_PLIST" && echo "  Loaded brain" || echo "  Failed to load brain"
+
+# ── 8b. Install Firefox extension (side-load into Developer Edition) ────
+echo "==> Installing Firefox extension..."
+mise run install:ext || echo "  WARN: extension install failed (non-fatal)"
 
 # ── 9. Verify ────────────────────────────────────────────────────────
 echo "==> Verifying..."


### PR DESCRIPTION
## Summary

- Adds `mise run build:ext` — installs npm deps, builds TS via esbuild, packages as .xpi via web-ext
- Adds `mise run install:ext` — auto-detects the Firefox Developer Edition `dev-edition-default` profile from `profiles.ini` and side-loads the .xpi into its `extensions/` directory
- `mise run install` now invokes `install:ext` automatically (non-fatal on failure)
- Pre-flight check warns if `xpinstall.signatures.required` is not `false` in `prefs.js` — Firefox would otherwise silently delete the unsigned .xpi on startup
- Warns if Firefox is running when install completes (needs restart to pick up changes)
- Updated extension README to reflect the automated flow

## Test plan

- [x] `mise run build:ext` produces `extension/firefox/web-ext-artifacts/*.zip`
- [x] `mise run install:ext` copies .xpi to `Profiles/*.dev-edition-default/extensions/hippo-browser@local.xpi`
- [x] Pre-flight check warns when `xpinstall.signatures.required` is missing or true
- [x] Restart of Firefox Developer Edition loads the extension successfully
- [x] Test on a machine without node_modules already installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)