### PR TITLE
fix: mise install quoting

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -373,7 +373,7 @@ run = "cargo run --bin hippo -- entities"
 
 [tasks.install]
 description = "Full clean-install: stop, build, install, configure, start, verify"
-run = """
+run = '''
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -562,7 +562,7 @@ elif [ "$OTEL_ENABLED" = "0" ] && [ "$OTEL_COLLECTOR_UP" = "0" ]; then
     echo "        2. Edit ~/.config/hippo/config.toml and set [telemetry] enabled = true"
     echo "        3. Run: mise run restart"
 fi
-"""
+'''
 
 [tasks.start]
 description = "Start hippo services via launchd"


### PR DESCRIPTION
This pull request makes a minor update to the `mise.toml` file, changing the script block delimiters for the `install` task from triple double quotes (`"""`) to triple single quotes (`'''`). This is a formatting change and does not affect the functionality of the script. [[1]](diffhunk://#diff-3c9056799ce8e353b18de841a8b9c8492d46cb096e063c86fb0ce54cfcd117c2L376-R376) [[2]](diffhunk://#diff-3c9056799ce8e353b18de841a8b9c8492d46cb096e063c86fb0ce54cfcd117c2L565-R565)