### PR TITLE
fix(rag): route vanilla ask through hybrid retrieval (fixes #28)

### DIFF
--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 import time
 from datetime import datetime, timezone
 
@@ -36,6 +37,7 @@ _rag_degraded = (
 logger = logging.getLogger("hippo_brain.rag")
 
 DEFAULT_MAX_CONTEXT_CHARS = 8000
+DEFAULT_SOURCES_LIMIT = 10
 _MIN_PER_HIT_FIELD_CHARS = 80
 
 _SYSTEM_PROMPT = (
@@ -66,10 +68,12 @@ def _truncate(text: str, max_len: int) -> str:
     return text[: max(max_len - 1, 1)] + "…"
 
 
-def _shape_rag_sources(hits: list[dict], min_score: float = 0.0) -> list[dict]:
+def _shape_rag_sources(
+    hits: list[dict], min_score: float = 0.0, limit: int = DEFAULT_SOURCES_LIMIT
+) -> list[dict]:
     """Transform raw retrieval hits into the response source shape.
 
-    Filters out sources below ``min_score`` and caps at 5 results.
+    Filters out sources below ``min_score`` and caps at ``limit`` results.
     """
     sources = []
     for hit in hits:
@@ -88,7 +92,7 @@ def _shape_rag_sources(hits: list[dict], min_score: float = 0.0) -> list[dict]:
                 "linked_event_ids": list(hit.get("linked_event_ids", []) or []),
             }
         )
-    return sources[:5]
+    return sources[:limit]
 
 
 def _hit_lines(index: int, hit: dict, embed_cap: int, cmd_cap: int) -> list[str]:
@@ -405,11 +409,12 @@ async def ask(
 
     # 2. Retrieve relevant knowledge nodes.
     #
-    # Filter-aware route: if any filter is set (either a full ``Filters`` or
-    # any of the flat kwargs), we go through the new ``retrieval.search``
-    # pipeline (hybrid RRF + MMR + filter pushdown) over a sqlite connection.
-    # Otherwise we keep the legacy LanceDB-style ``search_similar`` path so
-    # the existing ``mcp.ask`` callsite keeps working unchanged.
+    # Prefer ``retrieval.search`` (hybrid RRF + FTS5 + MMR diversification)
+    # whenever we have a sqlite connection. This applies regardless of
+    # whether filters are set, so vanilla ``ask`` calls also benefit from
+    # MMR's lexical+temporal diversity instead of pure-semantic KNN. The
+    # legacy ``search_similar`` path is kept only for callers that pass a
+    # non-sqlite handle (e.g. test doubles).
     effective_filters = _resolve_filters(
         filters,
         project=project,
@@ -418,10 +423,13 @@ async def ask(
         branch=branch,
         entity=entity,
     )
+    retrieval_conn = conn if conn is not None else vector_table
+    use_retrieval_search = isinstance(retrieval_conn, sqlite3.Connection) or (
+        effective_filters is not None and retrieval_conn is not None
+    )
     try:
         _t1 = time.monotonic()
-        if effective_filters is not None:
-            retrieval_conn = conn if conn is not None else vector_table
+        if use_retrieval_search:
             if retrieval_conn is None:
                 return _degraded_response(
                     model=query_model,
@@ -443,6 +451,18 @@ async def ask(
                 limit=limit,
             )
             hits = [_result_to_hit(r) for r in results]
+        elif effective_filters is not None:
+            return _degraded_response(
+                model=query_model,
+                sources=[],
+                error=(
+                    "retrieve failed [ConfigError] model="
+                    f"{query_model!r} endpoint={endpoint}: filters were requested "
+                    "but no sqlite connection was supplied (pass conn=... or ensure "
+                    "vector_table is a sqlite3.Connection)"
+                ),
+                stage="retrieve",
+            )
         else:
             hits = search_similar(vector_table, query_vec, limit=limit)
         if _rag_duration:

--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -473,7 +473,7 @@ async def ask(
         }
 
     # 3. Shape sources (preserved even if synthesis fails).
-    sources = _shape_rag_sources(hits)
+    sources = _shape_rag_sources(hits, limit=limit)
     messages = _build_rag_prompt(question, hits, max_chars=max_context_chars)
 
     # 4. Synthesize.

--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -410,11 +410,11 @@ async def ask(
     # 2. Retrieve relevant knowledge nodes.
     #
     # Prefer ``retrieval.search`` (hybrid RRF + FTS5 + MMR diversification)
-    # whenever we have a sqlite connection. This applies regardless of
+    # whenever we have a real sqlite3.Connection. This applies regardless of
     # whether filters are set, so vanilla ``ask`` calls also benefit from
     # MMR's lexical+temporal diversity instead of pure-semantic KNN. The
-    # legacy ``search_similar`` path is kept only for callers that pass a
-    # non-sqlite handle (e.g. test doubles).
+    # legacy ``search_similar`` path is kept for non-sqlite handles (e.g.
+    # LanceDB tables on deploys without sqlite-vec).
     effective_filters = _resolve_filters(
         filters,
         project=project,
@@ -424,24 +424,10 @@ async def ask(
         entity=entity,
     )
     retrieval_conn = conn if conn is not None else vector_table
-    use_retrieval_search = isinstance(retrieval_conn, sqlite3.Connection) or (
-        effective_filters is not None and retrieval_conn is not None
-    )
+    use_retrieval_search = isinstance(retrieval_conn, sqlite3.Connection)
     try:
         _t1 = time.monotonic()
         if use_retrieval_search:
-            if retrieval_conn is None:
-                return _degraded_response(
-                    model=query_model,
-                    sources=[],
-                    error=(
-                        "retrieve failed [ConfigError] model="
-                        f"{query_model!r} endpoint={endpoint}: filters were requested "
-                        "but no sqlite connection was supplied (pass conn=... or ensure "
-                        "vector_table is a sqlite3.Connection)"
-                    ),
-                    stage="retrieve",
-                )
             results = retrieval_search(
                 retrieval_conn,
                 question,

--- a/brain/tests/test_rag.py
+++ b/brain/tests/test_rag.py
@@ -106,10 +106,17 @@ class TestShapeRagSources:
         assert len(sources) == 1
         assert sources[0]["summary"] == "good"
 
-    def test_caps_at_five_sources(self):
-        hits = [{"_distance": 0.1, "summary": f"hit {i}"} for i in range(10)]
+    def test_caps_at_default_limit(self):
+        from hippo_brain.rag import DEFAULT_SOURCES_LIMIT
+
+        hits = [{"_distance": 0.1, "summary": f"hit {i}"} for i in range(DEFAULT_SOURCES_LIMIT + 5)]
         sources = _shape_rag_sources(hits)
-        assert len(sources) == 5
+        assert len(sources) == DEFAULT_SOURCES_LIMIT
+
+    def test_respects_explicit_limit(self):
+        hits = [{"_distance": 0.1, "summary": f"hit {i}"} for i in range(10)]
+        sources = _shape_rag_sources(hits, limit=3)
+        assert len(sources) == 3
 
 
 class TestBuildRagPrompt:
@@ -490,21 +497,46 @@ class TestFilteredRetrievalRouting:
         assert retrieval_mock.call_args.kwargs["mode"] == "semantic"
 
     @pytest.mark.asyncio
-    async def test_no_filters_uses_legacy_search_similar(self):
-        """Backward-compat: with no filters set, legacy search_similar is called."""
+    async def test_no_filters_with_non_sqlite_handle_uses_legacy(self):
+        """Backward-compat: if the handle isn't a sqlite3.Connection, fall back to legacy."""
         client = _healthy_client(chat_return="legacy")
         table = MagicMock(name="lancedb_table")
 
         with (
-            patch("hippo_brain.rag.retrieval_search") as retrieval_mock,
+            patch("hippo_brain.rag.retrieval_search") as rs_mock,
             patch("hippo_brain.rag.search_similar", return_value=SAMPLE_HITS) as legacy_mock,
         ):
             result = await ask("q", client, table, "m", "e")
 
         assert result["answer"] == "legacy"
-        retrieval_mock.assert_not_called()
+        rs_mock.assert_not_called()
         legacy_mock.assert_called_once()
         assert legacy_mock.call_args.args[0] is table
+
+    @pytest.mark.asyncio
+    async def test_no_filters_with_sqlite_conn_uses_hybrid(self):
+        """Issue #28 fix: vanilla ask with a real sqlite3.Connection must route
+        through retrieval.search (hybrid RRF + MMR) so diverse nodes surface
+        even when no filters are supplied. Prior behavior was pure-semantic KNN,
+        which biased toward a single cluster for broad questions.
+        """
+        import sqlite3
+
+        client = _healthy_client(chat_return="hybrid")
+        conn = sqlite3.connect(":memory:")
+
+        with (
+            patch("hippo_brain.rag.retrieval_search") as rs_mock,
+            patch("hippo_brain.rag.search_similar") as legacy_mock,
+        ):
+            rs_mock.return_value = [_fake_search_result()]
+            result = await ask("q", client, conn, "m", "e")
+
+        assert result["answer"] == "hybrid"
+        legacy_mock.assert_not_called()
+        rs_mock.assert_called_once()
+        assert rs_mock.call_args.kwargs["filters"] is None
+        assert rs_mock.call_args.kwargs["mode"] == "hybrid"
 
     @pytest.mark.asyncio
     async def test_filters_path_surfaces_uuid_and_linked_events_in_sources(self):

--- a/brain/tests/test_rag.py
+++ b/brain/tests/test_rag.py
@@ -1,5 +1,6 @@
 """Tests for the Hippo RAG (retrieval-augmented generation) module."""
 
+import sqlite3
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -439,62 +440,66 @@ class TestFilteredRetrievalRouting:
     async def test_flat_kwargs_route_through_retrieval_search(self):
         """Passing flat filter kwargs routes via retrieval.search with a Filters."""
         client = _healthy_client(chat_return="answered")
-        sentinel_conn = MagicMock(name="sqlite_conn")
+        sentinel_conn = sqlite3.connect(":memory:")
+        try:
+            with (
+                patch("hippo_brain.rag.retrieval_search") as retrieval_mock,
+                patch("hippo_brain.rag.search_similar") as legacy_mock,
+            ):
+                retrieval_mock.return_value = [_fake_search_result()]
+                result = await ask(
+                    "q",
+                    client,
+                    None,
+                    "m",
+                    "e",
+                    project="/home/user/projects/hippo",
+                    since=1743292800000,
+                    source="claude",
+                    branch="postgres",
+                    conn=sentinel_conn,
+                )
 
-        with (
-            patch("hippo_brain.rag.retrieval_search") as retrieval_mock,
-            patch("hippo_brain.rag.search_similar") as legacy_mock,
-        ):
-            retrieval_mock.return_value = [_fake_search_result()]
-            result = await ask(
-                "q",
-                client,
-                None,
-                "m",
-                "e",
-                project="/home/user/projects/hippo",
-                since=1743292800000,
-                source="claude",
-                branch="postgres",
-                conn=sentinel_conn,
-            )
-
-        assert result["degraded"] is False
-        legacy_mock.assert_not_called()
-        retrieval_mock.assert_called_once()
-        kwargs = retrieval_mock.call_args.kwargs
-        assert retrieval_mock.call_args.args[0] is sentinel_conn
-        passed = kwargs["filters"]
-        assert isinstance(passed, Filters)
-        assert passed.project == "/home/user/projects/hippo"
-        assert passed.since_ms == 1743292800000
-        assert passed.source == "claude"
-        assert passed.branch == "postgres"
-        assert kwargs["mode"] == "hybrid"
-        assert kwargs["limit"] == 10
+            assert result["degraded"] is False
+            legacy_mock.assert_not_called()
+            retrieval_mock.assert_called_once()
+            kwargs = retrieval_mock.call_args.kwargs
+            assert retrieval_mock.call_args.args[0] is sentinel_conn
+            passed = kwargs["filters"]
+            assert isinstance(passed, Filters)
+            assert passed.project == "/home/user/projects/hippo"
+            assert passed.since_ms == 1743292800000
+            assert passed.source == "claude"
+            assert passed.branch == "postgres"
+            assert kwargs["mode"] == "hybrid"
+            assert kwargs["limit"] == 10
+        finally:
+            sentinel_conn.close()
 
     @pytest.mark.asyncio
     async def test_filters_object_passed_through_unchanged(self):
         """Explicit Filters object is used verbatim (not rebuilt)."""
         client = _healthy_client(chat_return="ok")
-        sentinel_conn = MagicMock(name="sqlite_conn")
+        sentinel_conn = sqlite3.connect(":memory:")
         my_filters = Filters(project="/x", since_ms=100, source="shell")
+        try:
+            with patch("hippo_brain.rag.retrieval_search") as retrieval_mock:
+                retrieval_mock.return_value = [_fake_search_result()]
+                await ask(
+                    "q",
+                    client,
+                    None,
+                    "m",
+                    "e",
+                    filters=my_filters,
+                    conn=sentinel_conn,
+                    mode="semantic",
+                )
 
-        with patch("hippo_brain.rag.retrieval_search") as retrieval_mock:
-            retrieval_mock.return_value = [_fake_search_result()]
-            await ask(
-                "q",
-                client,
-                None,
-                "m",
-                "e",
-                filters=my_filters,
-                conn=sentinel_conn,
-                mode="semantic",
-            )
-
-        assert retrieval_mock.call_args.kwargs["filters"] is my_filters
-        assert retrieval_mock.call_args.kwargs["mode"] == "semantic"
+            assert retrieval_mock.call_args.kwargs["filters"] is my_filters
+            assert retrieval_mock.call_args.kwargs["mode"] == "semantic"
+        finally:
+            sentinel_conn.close()
 
     @pytest.mark.asyncio
     async def test_no_filters_with_non_sqlite_handle_uses_legacy(self):
@@ -520,50 +525,52 @@ class TestFilteredRetrievalRouting:
         even when no filters are supplied. Prior behavior was pure-semantic KNN,
         which biased toward a single cluster for broad questions.
         """
-        import sqlite3
-
         client = _healthy_client(chat_return="hybrid")
         conn = sqlite3.connect(":memory:")
+        try:
+            with (
+                patch("hippo_brain.rag.retrieval_search") as rs_mock,
+                patch("hippo_brain.rag.search_similar") as legacy_mock,
+            ):
+                rs_mock.return_value = [_fake_search_result()]
+                result = await ask("q", client, conn, "m", "e")
 
-        with (
-            patch("hippo_brain.rag.retrieval_search") as rs_mock,
-            patch("hippo_brain.rag.search_similar") as legacy_mock,
-        ):
-            rs_mock.return_value = [_fake_search_result()]
-            result = await ask("q", client, conn, "m", "e")
-
-        assert result["answer"] == "hybrid"
-        legacy_mock.assert_not_called()
-        rs_mock.assert_called_once()
-        assert rs_mock.call_args.kwargs["filters"] is None
-        assert rs_mock.call_args.kwargs["mode"] == "hybrid"
+            assert result["answer"] == "hybrid"
+            legacy_mock.assert_not_called()
+            rs_mock.assert_called_once()
+            assert rs_mock.call_args.kwargs["filters"] is None
+            assert rs_mock.call_args.kwargs["mode"] == "hybrid"
+        finally:
+            conn.close()
 
     @pytest.mark.asyncio
     async def test_filters_path_surfaces_uuid_and_linked_events_in_sources(self):
         """SearchResult fields (uuid, linked_event_ids) must flow into sources."""
         client = _healthy_client(chat_return="ok")
-        sentinel_conn = MagicMock()
+        sentinel_conn = sqlite3.connect(":memory:")
+        try:
+            with patch("hippo_brain.rag.retrieval_search") as retrieval_mock:
+                retrieval_mock.return_value = [
+                    _fake_search_result(uuid="u-1", linked_event_ids=[1, 2, 3]),
+                    _fake_search_result(uuid="u-2", score=0.5, linked_event_ids=[]),
+                ]
+                result = await ask(
+                    "q",
+                    client,
+                    None,
+                    "m",
+                    "e",
+                    project="/home/user",
+                    conn=sentinel_conn,
+                )
 
-        with patch("hippo_brain.rag.retrieval_search") as retrieval_mock:
-            retrieval_mock.return_value = [
-                _fake_search_result(uuid="u-1", linked_event_ids=[1, 2, 3]),
-                _fake_search_result(uuid="u-2", score=0.5, linked_event_ids=[]),
-            ]
-            result = await ask(
-                "q",
-                client,
-                None,
-                "m",
-                "e",
-                project="/home/user",
-                conn=sentinel_conn,
-            )
-
-        assert [s["uuid"] for s in result["sources"]] == ["u-1", "u-2"]
-        assert result["sources"][0]["linked_event_ids"] == [1, 2, 3]
-        assert result["sources"][1]["linked_event_ids"] == []
-        # Score round-trips from SearchResult.score through the _distance adapter.
-        assert result["sources"][0]["score"] == pytest.approx(0.91, abs=0.001)
+            assert [s["uuid"] for s in result["sources"]] == ["u-1", "u-2"]
+            assert result["sources"][0]["linked_event_ids"] == [1, 2, 3]
+            assert result["sources"][1]["linked_event_ids"] == []
+            # Score round-trips from SearchResult.score through the _distance adapter.
+            assert result["sources"][0]["score"] == pytest.approx(0.91, abs=0.001)
+        finally:
+            sentinel_conn.close()
 
     @pytest.mark.asyncio
     async def test_filters_without_connection_degrades(self):
@@ -581,20 +588,24 @@ class TestFilteredRetrievalRouting:
     @pytest.mark.asyncio
     async def test_filters_path_degrades_when_retrieval_raises(self):
         client = _healthy_client()
-        sentinel_conn = MagicMock()
+        sentinel_conn = sqlite3.connect(":memory:")
+        try:
+            with patch(
+                "hippo_brain.rag.retrieval_search", side_effect=RuntimeError("vec0 missing")
+            ):
+                result = await ask(
+                    "q",
+                    client,
+                    None,
+                    "m",
+                    "e",
+                    filters=Filters(project="/x"),
+                    conn=sentinel_conn,
+                )
 
-        with patch("hippo_brain.rag.retrieval_search", side_effect=RuntimeError("vec0 missing")):
-            result = await ask(
-                "q",
-                client,
-                None,
-                "m",
-                "e",
-                filters=Filters(project="/x"),
-                conn=sentinel_conn,
-            )
-
-        assert result["degraded"] is True
-        assert result["stage"] == "retrieve"
-        assert "vec0 missing" in result["error"]
-        client.chat.assert_not_called()
+            assert result["degraded"] is True
+            assert result["stage"] == "retrieve"
+            assert "vec0 missing" in result["error"]
+            client.chat.assert_not_called()
+        finally:
+            sentinel_conn.close()

--- a/brain/tests/test_rag.py
+++ b/brain/tests/test_rag.py
@@ -414,6 +414,17 @@ class TestAsk:
         user_content = messages[1]["content"]
         assert len(user_content) < 4500
 
+    @pytest.mark.asyncio
+    async def test_limit_caps_sources_returned(self):
+        """ask(limit=N) must forward N to source shaping so sources <= N."""
+        client = _healthy_client(chat_return="ok")
+        many_hits = [dict(SAMPLE_HITS[0], uuid=f"u-{i}") for i in range(8)]
+
+        with patch("hippo_brain.rag.search_similar", return_value=many_hits):
+            result = await ask("q", client, MagicMock(), "m", "e", limit=3)
+
+        assert len(result["sources"]) == 3
+
 
 # -- Retrieval-router plumbing ----------------------------------------------
 


### PR DESCRIPTION
## Summary

- The issue&#39;s hypothesis (enrichment queue stalled / Claude hook misfiring) was wrong. Verified: 989 Claude sessions enriched through 2026-04-19 00:18, 2317 knowledge nodes all with vectors, brain queue 0 pending / 0 failed.
- Real cause: vanilla `ask` (MCP + `/ask`) always took the legacy pure-semantic KNN path. That retrieval biased toward release-ceremony language, concentrating the top-K in v0.7/v0.8 nodes and crowding out recent activity.
- Fix: when a real `sqlite3.Connection` is available, route through the existing `retrieval.search` hybrid (RRF + FTS5 + MMR) path regardless of whether filters are set. Non-sqlite handles still fall back to `search_similar` for test doubles.
- Also raised the source cap from 5 → 10 (configurable).

## Before / after (issue&#39;s exact query)

Question: *&#34;What is the timeline for features added to hippo so far?&#34;*

Before: top 10 hits concentrated around 2026-04-04 / 04-09 release ceremonies; answer stopped at v0.8.1 / April 9.

After: top 10 hits span 2026-04-01 → 2026-04-19 with MMR diversification; answer now covers April 16 GH Actions work (Phase 6) and April 19 hippo-gui activity.

## Test plan

- [x] `uv run --project brain pytest brain/tests` — 580 passed, 1 xfailed
- [x] `uv run --project brain ruff check brain/` — clean
- [x] `uv run --project brain ruff format --check brain/` — clean
- [x] semgrep scan on modified files — no findings
- [x] End-to-end: restarted brain via launchctl, re-ran the issue&#39;s question through `/ask`, verified diverse 10-source top-K spanning April 1 → April 19

## Follow-ups (not in this PR)

- `retrieval.search(mode=&#34;recent&#34;, query=&#34;...&#34;)` returns zero results when the FTS5 match is empty instead of falling back to date-ordered results — worth a separate issue.
- Coverage gap: v0.9 / v0.11 / v0.12 bumps produced no &#34;release&#34;-shaped knowledge nodes (they were version bumps without changelog / tag ceremony). Not a retrieval bug, but the LLM can only synthesize what&#39;s in the knowledge base.