### PR TITLE
ci: bump upload-artifact to v5, target macos-26 with Xcode 26 for GUI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           echo "Checksum: ${CHECKSUM}"
 
       - name: Upload daemon artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: daemon-binary
           path: ${{ steps.artifact.outputs.name }}
@@ -141,7 +141,7 @@ jobs:
           echo "Checksum: ${CHECKSUM}"
 
       - name: Upload brain artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: brain-package
           path: ${{ steps.artifact.outputs.name }}
@@ -150,7 +150,7 @@ jobs:
 
   build-gui:
     name: Build GUI Application
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 30
     outputs:
       artifact_name: ${{ steps.artifact.outputs.name }}
@@ -161,7 +161,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '26'
 
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/release.yml` to use newer versions of key dependencies and environments for building and uploading artifacts. The main focus is on keeping the CI pipeline up to date and compatible with the latest tools.

**CI/CD workflow updates:**

* Updated `actions/upload-artifact` from version 4 to version 5 for both the daemon and brain artifact upload steps, ensuring compatibility with the latest features and bug fixes. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L74-R74) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L144-R144)

**Build environment upgrades:**

* Changed the build environment for the GUI application from `macos-latest` to `macos-26` to target a specific, newer macOS runner.
* Updated the Xcode setup step to use Xcode version `26` instead of `latest-stable`, ensuring builds use a consistent and up-to-date toolchain.