### PR TITLE
fix(doctor): derive session hook path at runtime, drop misleading install step

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.13.1"
+version = "0.13.2"
 requires-python = ">=3.14"
 dependencies = [
     "httpx>=0.28",

--- a/crates/hippo-daemon/build.rs
+++ b/crates/hippo-daemon/build.rs
@@ -7,19 +7,6 @@ fn main() {
     let version = git_describe_version(&base);
     println!("cargo:rustc-env=HIPPO_VERSION_FULL={version}");
 
-    // Embed the expected session hook path so `hippo doctor` can verify it
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let repo_root = std::path::Path::new(&manifest_dir)
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap();
-    let hook_path = repo_root.join("shell/claude-session-hook.sh");
-    println!(
-        "cargo:rustc-env=HIPPO_SESSION_HOOK_PATH={}",
-        hook_path.display()
-    );
-
     // Rebuild when git state changes
     println!("cargo:rerun-if-changed=../../.git/HEAD");
     println!("cargo:rerun-if-changed=../../.git/refs/");

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -604,7 +604,7 @@ pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
     }
 
     // Check Claude session hook
-    check_claude_session_hook();
+    check_claude_session_hook(config);
 
     // Check OpenTelemetry configuration
     check_otel_status(config, &client).await;
@@ -661,8 +661,16 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) {
     }
 }
 
-fn check_claude_session_hook() {
-    let expected = env!("HIPPO_SESSION_HOOK_PATH");
+fn check_claude_session_hook(config: &HippoConfig) {
+    // The brain is installed one level above the hippo data dir, e.g.
+    // data_dir = ~/.local/share/hippo  →  brain = ~/.local/share/hippo-brain
+    let expected = config
+        .storage
+        .data_dir
+        .parent()
+        .map(|p| p.join("hippo-brain/shell/claude-session-hook.sh"))
+        .unwrap_or_default();
+
     let settings_path = dirs::home_dir()
         .map(|h| h.join(".claude/settings.json"))
         .unwrap_or_default();
@@ -697,24 +705,24 @@ fn check_claude_session_hook() {
         .find_map(|cmd| cmd.as_str().map(String::from));
 
     match configured_cmd {
-        Some(cmd) if cmd == expected => {
-            if std::path::Path::new(expected).exists() {
+        Some(ref cmd) if std::path::Path::new(cmd) == expected => {
+            if expected.exists() {
                 println!("[OK] Claude session hook configured");
             } else {
                 println!(
                     "[!!] Claude session hook configured but script missing: {}",
-                    expected
+                    expected.display()
                 );
             }
         }
         Some(cmd) => {
             println!("[!!] Claude session hook path mismatch");
             println!("     configured: {}", cmd);
-            println!("     expected:   {}", expected);
+            println!("     expected:   {}", expected.display());
         }
         None => {
             println!("[--] Claude session hook not configured");
-            println!("     expected: {}", expected);
+            println!("     expected: {}", expected.display());
         }
     }
 }

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -662,20 +662,27 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) {
 }
 
 fn check_claude_session_hook(config: &HippoConfig) {
-    // The brain is installed one level above the hippo data dir, e.g.
-    // data_dir = ~/.local/share/hippo  →  brain = ~/.local/share/hippo-brain
-    let expected = config
-        .storage
-        .data_dir
-        .parent()
-        .map(|p| p.join("hippo-brain/shell/claude-session-hook.sh"))
-        .unwrap_or_default();
-
     let settings_path = dirs::home_dir()
         .map(|h| h.join(".claude/settings.json"))
         .unwrap_or_default();
+    check_claude_session_hook_at(config, &settings_path);
+}
 
-    let content = match std::fs::read_to_string(&settings_path) {
+fn check_claude_session_hook_at(config: &HippoConfig, settings_path: &std::path::Path) {
+    // The brain is installed one level above the hippo data dir, e.g.
+    // data_dir = ~/.local/share/hippo  →  brain = ~/.local/share/hippo-brain
+    let expected = match config.storage.data_dir.parent() {
+        Some(parent) => parent.join("hippo-brain/shell/claude-session-hook.sh"),
+        None => {
+            println!(
+                "[!!] Cannot derive expected Claude session hook path from data_dir: {}",
+                config.storage.data_dir.display()
+            );
+            return;
+        }
+    };
+
+    let content = match std::fs::read_to_string(settings_path) {
         Ok(c) => c,
         Err(_) => {
             println!("[--] Claude settings not found (session hook not configured)");
@@ -995,5 +1002,77 @@ replacement = "***"
         print_brain_health_details(&config, &client).await;
 
         server.await.unwrap();
+    }
+
+    #[test]
+    fn test_hook_expected_path_derived_from_data_dir() {
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = std::path::PathBuf::from("/home/user/.local/share/hippo");
+        // parent = /home/user/.local/share → brain dir = .../hippo-brain
+        let expected = config
+            .storage
+            .data_dir
+            .parent()
+            .map(|p| p.join("hippo-brain/shell/claude-session-hook.sh"))
+            .unwrap();
+        assert_eq!(
+            expected,
+            std::path::Path::new("/home/user/.local/share/hippo-brain/shell/claude-session-hook.sh")
+        );
+    }
+
+    #[test]
+    fn test_hook_check_not_configured() {
+        let temp = tempdir().unwrap();
+        let settings = temp.path().join("settings.json");
+        std::fs::write(&settings, r#"{"theme":"dark"}"#).unwrap();
+
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = temp.path().join("hippo");
+        // Should not panic; prints [--] not configured
+        check_claude_session_hook_at(&config, &settings);
+    }
+
+    #[test]
+    fn test_hook_check_mismatch() {
+        let temp = tempdir().unwrap();
+        let settings = temp.path().join("settings.json");
+        let wrong_path = "/wrong/path/claude-session-hook.sh";
+        std::fs::write(
+            &settings,
+            format!(
+                r#"{{"hooks":{{"SessionStart":[{{"hooks":[{{"command":"{wrong_path}"}}]}}]}}}}"#
+            ),
+        )
+        .unwrap();
+
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = temp.path().join("hippo");
+        // Should not panic; prints [!!] path mismatch
+        check_claude_session_hook_at(&config, &settings);
+    }
+
+    #[test]
+    fn test_hook_check_match_missing_script() {
+        let temp = tempdir().unwrap();
+        // Expected path: temp/hippo-brain/shell/claude-session-hook.sh
+        // data_dir parent = temp, so expected = temp/hippo-brain/shell/claude-session-hook.sh
+        let expected_path = temp
+            .path()
+            .join("hippo-brain/shell/claude-session-hook.sh");
+        let settings = temp.path().join("settings.json");
+        std::fs::write(
+            &settings,
+            format!(
+                r#"{{"hooks":{{"SessionStart":[{{"hooks":[{{"command":"{}"}}]}}]}}}}"#,
+                expected_path.display()
+            ),
+        )
+        .unwrap();
+
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = temp.path().join("hippo");
+        // Script doesn't exist on disk → prints [!!] configured but script missing
+        check_claude_session_hook_at(&config, &settings);
     }
 }

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -95,6 +95,9 @@ async fn main() -> Result<()> {
                         );
                         continue;
                     }
+                    if install::service_is_loaded(label) {
+                        continue;
+                    }
                     let status = std::process::Command::new("launchctl")
                         .args([
                             "bootstrap",
@@ -106,7 +109,7 @@ async fn main() -> Result<()> {
                     if status.success() {
                         println!("Started {label}");
                     } else {
-                        println!("{label} already loaded or failed to start");
+                        eprintln!("{label} failed to start");
                     }
                 }
             }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -412,6 +412,10 @@ install_services() {
             log_warning "Failed to install LaunchAgents automatically"
             log_info "You can install them manually later with: hippo daemon install --brain-dir '${BRAIN_DIR}'"
         }
+        # daemon install only restarts services that were already running (upgrade path).
+        # For fresh installs the plists are written but services aren't bootstrapped yet.
+        # daemon start is idempotent: skips services that are already loaded.
+        "${BIN_DIR}/hippo" daemon start || true
     fi
 
     log_success "Services installed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -491,8 +491,7 @@ main() {
     log_info "       echo 'source ${BRAIN_DIR}/shell/hippo.zsh' >> ~/.zshrc"
     log_info "       exec zsh  # reload shell"
     log_info "  2. Configure your LM Studio model: hippo config edit"
-    log_info "  3. Start services: hippo daemon start"
-    log_info "  4. Verify installation: hippo doctor"
+    log_info "  3. Verify installation: hippo doctor"
     echo ""
     log_info "For full documentation, visit: https://github.com/${REPO}"
 }


### PR DESCRIPTION
## Summary

- `build.rs`: remove compile-time `HIPPO_SESSION_HOOK_PATH` env — released binaries were embedding the CI runner path (`/Users/runner/work/...`), causing every end-user install to show a false hook mismatch
- `commands.rs`: `check_claude_session_hook` now computes the expected path at runtime as `config.storage.data_dir.parent() + hippo-brain/shell/claude-session-hook.sh` (resolves to `~/.local/share/hippo-brain/shell/claude-session-hook.sh` on a standard install)
- `install.sh`: drop "Start services: hippo daemon start" from next steps — the installer already starts both services, so the step produced confusing "already loaded" errors

## Test Plan

- [ ] `hippo doctor` on a fresh install no longer reports hook path mismatch
- [ ] `hippo doctor` on a dev checkout (hook configured to repo path) still reports mismatch with the correct expected path
- [ ] All 215 Rust tests pass (`cargo test -p hippo-daemon -p hippo-core`)
- [ ] Fresh install next steps no longer include the redundant "start services" step