### PR TITLE
chore: bump brain to v0.13.2 and fix GUI workflow

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -39,18 +39,18 @@ jobs:
         id: version
         run: |
           VERSION="$(python3 - <<'PY'
-import pathlib
-import re
-
-match = re.search(
-    r'^\s*version\s*=\s*"([^"]+)"\s*$',
-    pathlib.Path("Cargo.toml").read_text(),
-    re.MULTILINE,
-)
-if not match:
-    raise SystemExit("workspace version not found in Cargo.toml")
-print(match.group(1))
-PY
+          import pathlib
+          import re
+          
+          match = re.search(
+              r'^\s*version\s*=\s*"([^"]+)"\s*$',
+              pathlib.Path("Cargo.toml").read_text(),
+              re.MULTILINE,
+          )
+          if not match:
+              raise SystemExit("workspace version not found in Cargo.toml")
+          print(match.group(1))
+          PY
           )"
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Workspace version: ${VERSION}"

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/hippo-gui/Sources/HippoGUI/Models/QueryResponse.swift
+++ b/hippo-gui/Sources/HippoGUI/Models/QueryResponse.swift
@@ -131,8 +131,7 @@ struct SemanticQueryResult: Codable, Identifiable, Hashable, Sendable {
 
         if let jsonString = try? container.decode(String.self, forKey: key),
             let data = jsonString.data(using: .utf8),
-            let decoded = try? JSONDecoder().decode([String].self, from: data)
-        {
+            let decoded = try? JSONDecoder().decode([String].self, from: data) {
             return decoded
         }
 

--- a/hippo-gui/Sources/HippoGUI/Views/AboutSettingsView.swift
+++ b/hippo-gui/Sources/HippoGUI/Views/AboutSettingsView.swift
@@ -61,7 +61,7 @@ struct AboutSettingsView: View {
                 "CFBundleDisplayName": "HippoGUI",
                 "CFBundleIdentifier": "com.hippo.HippoGUI",
                 "CFBundleShortVersionString": "0.11.0",
-                "CFBundleVersion": "189"
+                "CFBundleVersion": "189",
             ]
         )
     )


### PR DESCRIPTION
## Summary
- bump the brain lockfile to v0.13.2
- apply the Swift formatting cleanup on the GUI changes
- repair the GUI Actions workflow so version extraction parses correctly

## Testing
- mise run test