### PR TITLE
fix(install): configure Claude session hook on daemon install, fix tmux index error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.13.3"
+version = "0.13.4"
 requires-python = ">=3.14"
 dependencies = [
     "httpx>=0.28",

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.13.3"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -725,10 +725,12 @@ fn check_claude_session_hook_at(config: &HippoConfig, settings_path: &std::path:
             println!("[!!] Claude session hook path mismatch");
             println!("     configured: {}", cmd);
             println!("     expected:   {}", expected.display());
+            println!("     Fix: hippo daemon install --force");
         }
         None => {
             println!("[--] Claude session hook not configured");
             println!("     expected: {}", expected.display());
+            println!("     Fix: hippo daemon install --force");
         }
     }
 }

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -697,8 +697,10 @@ fn check_claude_session_hook_at(config: &HippoConfig, settings_path: &std::path:
         }
     };
 
-    // Navigate: hooks -> SessionStart -> [].hooks -> [].command
-    let configured_cmd = json
+    // Collect all commands across all SessionStart matchers so a user with multiple
+    // hooks configured doesn't get a false mismatch when the hippo hook is present
+    // but not the first entry.
+    let all_commands: Vec<String> = json
         .get("hooks")
         .and_then(|h| h.get("SessionStart"))
         .and_then(|ss| ss.as_array())
@@ -708,10 +710,16 @@ fn check_claude_session_hook_at(config: &HippoConfig, settings_path: &std::path:
         .filter_map(|hooks| hooks.as_array())
         .flatten()
         .filter_map(|hook| hook.get("command"))
-        .find_map(|cmd| cmd.as_str().map(String::from));
+        .filter_map(|cmd| cmd.as_str().map(String::from))
+        .collect();
 
-    match configured_cmd {
-        Some(ref cmd) if std::path::Path::new(cmd) == expected => {
+    // Look specifically for the hippo hook among all configured commands
+    let hippo_cmd = all_commands
+        .iter()
+        .find(|cmd| cmd.contains("claude-session-hook.sh"));
+
+    match hippo_cmd {
+        Some(cmd) if std::path::Path::new(cmd.as_str()) == expected => {
             if expected.exists() {
                 println!("[OK] Claude session hook configured");
             } else {

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -685,6 +685,8 @@ fn check_claude_session_hook_at(config: &HippoConfig, settings_path: &std::path:
         Ok(c) => c,
         Err(_) => {
             println!("[--] Claude settings not found (session hook not configured)");
+            println!("     expected: {}", expected.display());
+            println!("     Fix: hippo daemon install --force");
             return;
         }
     };
@@ -693,9 +695,33 @@ fn check_claude_session_hook_at(config: &HippoConfig, settings_path: &std::path:
         Ok(v) => v,
         Err(_) => {
             println!("[!!] Claude settings.json is malformed");
+            println!("     fix the JSON manually, then rerun: hippo daemon install --force");
             return;
         }
     };
+
+    // Reject structural surprises with a dedicated message. `daemon install` would
+    // bail on these too, so suggesting `--force` would be misleading — the user
+    // must repair the file by hand.
+    if !json.is_object() {
+        println!("[!!] Claude settings.json root is not a JSON object");
+        println!("     repair the file manually before running hippo daemon install");
+        return;
+    }
+    if let Some(hooks) = json.get("hooks")
+        && !hooks.is_object()
+    {
+        println!("[!!] Claude settings.json `hooks` is not an object");
+        println!("     repair the file manually before running hippo daemon install");
+        return;
+    }
+    if let Some(ss) = json.get("hooks").and_then(|h| h.get("SessionStart"))
+        && !ss.is_array()
+    {
+        println!("[!!] Claude settings.json `hooks.SessionStart` is not an array");
+        println!("     repair the file manually before running hippo daemon install");
+        return;
+    }
 
     // Collect all commands across all SessionStart matchers so a user with multiple
     // hooks configured doesn't get a false mismatch when the hippo hook is present
@@ -713,33 +739,41 @@ fn check_claude_session_hook_at(config: &HippoConfig, settings_path: &std::path:
         .filter_map(|cmd| cmd.as_str().map(String::from))
         .collect();
 
-    // Look specifically for the hippo hook among all configured commands
-    let hippo_cmd = all_commands
+    // Narrow to hippo hook commands — a user may have multiple (stale + current).
+    // If *any* exactly matches expected, the install is correct; only report a
+    // mismatch when none match.
+    let hippo_cmds: Vec<&String> = all_commands
         .iter()
-        .find(|cmd| cmd.contains("claude-session-hook.sh"));
+        .filter(|cmd| cmd.contains("claude-session-hook.sh"))
+        .collect();
+    let exact_match = hippo_cmds
+        .iter()
+        .any(|cmd| std::path::Path::new(cmd.as_str()) == expected);
 
-    match hippo_cmd {
-        Some(cmd) if std::path::Path::new(cmd.as_str()) == expected => {
-            if expected.exists() {
-                println!("[OK] Claude session hook configured");
-            } else {
+    if exact_match {
+        if expected.exists() {
+            println!("[OK] Claude session hook configured");
+            if hippo_cmds.len() > 1 {
                 println!(
-                    "[!!] Claude session hook configured but script missing: {}",
-                    expected.display()
+                    "     note: {} stale hippo hook entries also present — clean up manually",
+                    hippo_cmds.len() - 1
                 );
             }
+        } else {
+            println!(
+                "[!!] Claude session hook configured but script missing: {}",
+                expected.display()
+            );
         }
-        Some(cmd) => {
-            println!("[!!] Claude session hook path mismatch");
-            println!("     configured: {}", cmd);
-            println!("     expected:   {}", expected.display());
-            println!("     Fix: hippo daemon install --force");
-        }
-        None => {
-            println!("[--] Claude session hook not configured");
-            println!("     expected: {}", expected.display());
-            println!("     Fix: hippo daemon install --force");
-        }
+    } else if let Some(first) = hippo_cmds.first() {
+        println!("[!!] Claude session hook path mismatch");
+        println!("     configured: {}", first);
+        println!("     expected:   {}", expected.display());
+        println!("     Fix: hippo daemon install --force");
+    } else {
+        println!("[--] Claude session hook not configured");
+        println!("     expected: {}", expected.display());
+        println!("     Fix: hippo daemon install --force");
     }
 }
 
@@ -1089,6 +1123,46 @@ replacement = "***"
         let mut config = HippoConfig::default();
         config.storage.data_dir = temp.path().join("hippo");
         // Should not panic; prints [!!] path mismatch
+        check_claude_session_hook_at(&config, &settings);
+    }
+
+    #[test]
+    fn test_hook_check_multiple_entries_one_exact_match() {
+        // User has both a stale hippo hook and a correct one — doctor should
+        // treat the install as OK rather than false-report a mismatch.
+        let temp = tempdir().unwrap();
+        let expected_path = temp.path().join("hippo-brain/shell/claude-session-hook.sh");
+        std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();
+        std::fs::write(&expected_path, "#!/bin/bash\n").unwrap();
+
+        let settings = temp.path().join("settings.json");
+        let stale = "/old/stale/claude-session-hook.sh";
+        std::fs::write(
+            &settings,
+            format!(
+                r#"{{"hooks":{{"SessionStart":[
+                    {{"hooks":[{{"command":"{stale}"}}]}},
+                    {{"hooks":[{{"command":"{}"}}]}}
+                ]}}}}"#,
+                expected_path.display()
+            ),
+        )
+        .unwrap();
+
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = temp.path().join("hippo");
+        check_claude_session_hook_at(&config, &settings);
+    }
+
+    #[test]
+    fn test_hook_check_structural_type_mismatch() {
+        // Root is not an object → dedicated manual-repair message, no Fix hint.
+        let temp = tempdir().unwrap();
+        let settings = temp.path().join("settings.json");
+        std::fs::write(&settings, r#"[]"#).unwrap();
+
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = temp.path().join("hippo");
         check_claude_session_hook_at(&config, &settings);
     }
 

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -313,21 +313,28 @@ fn drain_poll(
 /// Configure the Claude Code session hook in ~/.claude/settings.json.
 ///
 /// Skips if the hook is already pointing at the expected path. Updates only the
-/// hippo hook entry if the path has drifted (e.g. after a curl reinstall). Appends
-/// a new matcher if no hippo hook exists at all. All other settings.json content is
-/// preserved.
+/// `command` field of the matching hook entry if the path has drifted (other fields
+/// on the matcher and hook objects are preserved). Appends a new matcher if no hippo
+/// hook exists at all. All other settings.json content is preserved.
+///
+/// Returns an error if the file exists but contains malformed JSON — never silently
+/// overwrites user settings with an empty object.
 pub fn configure_claude_session_hook(brain_dir: &Path) -> Result<()> {
     let settings_path = dirs::home_dir()
         .context("cannot determine home directory")?
         .join(".claude/settings.json");
+    configure_claude_session_hook_at(&settings_path, brain_dir)
+}
 
+fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> Result<()> {
     let hook_path = brain_dir.join("shell/claude-session-hook.sh");
     let hook_path_str = hook_path.to_string_lossy().to_string();
 
     let mut root: serde_json::Value = if settings_path.exists() {
         let content = std::fs::read_to_string(&settings_path)
             .context("failed to read ~/.claude/settings.json")?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(&content)
+            .with_context(|| "~/.claude/settings.json is malformed JSON — fix it manually before running install")?
     } else {
         serde_json::json!({})
     };
@@ -348,50 +355,67 @@ pub fn configure_claude_session_hook(brain_dir: &Path) -> Result<()> {
         .as_array_mut()
         .context("SessionStart is not an array")?;
 
-    // Find any existing hippo hook entry
-    let hippo_idx = matchers.iter().position(|m| {
+    // Find the (matcher_idx, hook_idx) of the specific hippo hook command
+    let hippo_location = matchers.iter().enumerate().find_map(|(mi, m)| {
         m.get("hooks")
             .and_then(|h| h.as_array())
-            .into_iter()
-            .flatten()
-            .filter_map(|h| h.get("command"))
-            .filter_map(|c| c.as_str())
-            .any(|cmd| cmd.contains("claude-session-hook.sh"))
+            .and_then(|hooks| {
+                hooks.iter().enumerate().find_map(|(hi, h)| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .filter(|cmd| cmd.contains("claude-session-hook.sh"))
+                        .map(|_| (mi, hi))
+                })
+            })
     });
 
-    let new_matcher = serde_json::json!({
-        "hooks": [{ "type": "command", "command": hook_path_str }]
-    });
-
-    match hippo_idx {
-        Some(i) => {
-            let current = matchers[i]
+    match hippo_location {
+        Some((mi, hi)) => {
+            let current = matchers[mi]
                 .get("hooks")
                 .and_then(|h| h.as_array())
-                .into_iter()
-                .flatten()
-                .find_map(|h| h.get("command").and_then(|c| c.as_str()).map(String::from));
-            if current.as_deref() == Some(&hook_path_str) {
+                .and_then(|hooks| hooks.get(hi))
+                .and_then(|h| h.get("command"))
+                .and_then(|c| c.as_str());
+            if current == Some(hook_path_str.as_str()) {
                 println!("  Claude session hook already correct, skipping");
                 return Ok(());
             }
-            matchers[i] = new_matcher;
+            // Mutate only the command field — preserve all other hook/matcher fields
+            let hooks = matchers[mi]
+                .get_mut("hooks")
+                .and_then(|h| h.as_array_mut())
+                .context("existing matcher hooks is not an array")?;
+            let hook_obj = hooks
+                .get_mut(hi)
+                .and_then(|h| h.as_object_mut())
+                .context("existing hook entry is not an object")?;
+            hook_obj.insert(
+                "command".to_string(),
+                serde_json::Value::String(hook_path_str),
+            );
             println!("  Updated Claude session hook: {}", hook_path.display());
         }
         None => {
-            matchers.push(new_matcher);
+            matchers.push(serde_json::json!({
+                "hooks": [{ "type": "command", "command": hook_path_str }]
+            }));
             println!("  Configured Claude session hook: {}", hook_path.display());
         }
     }
 
-    if let Some(parent) = settings_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(
-        &settings_path,
-        serde_json::to_string_pretty(&root).context("failed to serialize settings.json")?,
-    )
-    .context("failed to write ~/.claude/settings.json")?;
+    // Atomic write: write to a sibling tmp file then rename into place so a crash
+    // mid-write cannot leave a truncated settings.json.
+    let parent = settings_path
+        .parent()
+        .context("~/.claude/settings.json has no parent directory")?;
+    std::fs::create_dir_all(parent)?;
+    let pretty =
+        serde_json::to_string_pretty(&root).context("failed to serialize settings.json")?;
+    let tmp_path = settings_path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, &pretty).context("failed to write temporary settings file")?;
+    std::fs::rename(&tmp_path, &settings_path)
+        .context("failed to atomically update ~/.claude/settings.json")?;
 
     Ok(())
 }
@@ -614,5 +638,133 @@ mod tests {
     fn parse_launchctl_pid_ignores_malformed_values() {
         let sample = "\t\"PID\" = not-a-number;";
         assert_eq!(parse_launchctl_pid(sample), None);
+    }
+
+    // ── configure_claude_session_hook ──────────────────────────────────────────
+
+    #[test]
+    fn configure_hook_adds_entry_when_none_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = tmp.path().join(".claude/settings.json");
+        std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        std::fs::write(&settings, r#"{"theme":"dark"}"#).unwrap();
+
+        let brain_dir = tmp.path().join("hippo-brain");
+        configure_claude_session_hook_at(&settings, &brain_dir).unwrap();
+
+        let content = std::fs::read_to_string(&settings).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let cmd = v["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(cmd.ends_with("claude-session-hook.sh"));
+        // Unrelated field preserved
+        assert_eq!(v["theme"].as_str(), Some("dark"));
+    }
+
+    #[test]
+    fn configure_hook_skips_when_already_correct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = tmp.path().join(".claude/settings.json");
+        std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+
+        let brain_dir = tmp.path().join("hippo-brain");
+        let hook_path = brain_dir.join("shell/claude-session-hook.sh");
+        let initial = serde_json::json!({
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{"type": "command", "command": hook_path.to_string_lossy()}]
+                }]
+            }
+        });
+        std::fs::write(&settings, serde_json::to_string(&initial).unwrap()).unwrap();
+        let mtime_before = std::fs::metadata(&settings).unwrap().modified().unwrap();
+
+        configure_claude_session_hook_at(&settings, &brain_dir).unwrap();
+
+        let mtime_after = std::fs::metadata(&settings).unwrap().modified().unwrap();
+        // File must not have been rewritten
+        assert_eq!(mtime_before, mtime_after);
+    }
+
+    #[test]
+    fn configure_hook_updates_drifted_path_in_place() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = tmp.path().join(".claude/settings.json");
+        std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+
+        let brain_dir = tmp.path().join("hippo-brain");
+        let initial = serde_json::json!({
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": "some-filter",
+                    "hooks": [
+                        {"type": "command", "command": "/old/path/claude-session-hook.sh"}
+                    ]
+                }]
+            }
+        });
+        std::fs::write(&settings, serde_json::to_string(&initial).unwrap()).unwrap();
+
+        configure_claude_session_hook_at(&settings, &brain_dir).unwrap();
+
+        let content = std::fs::read_to_string(&settings).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let matcher = &v["hooks"]["SessionStart"][0];
+        // matcher-level field preserved
+        assert_eq!(matcher["matcher"].as_str(), Some("some-filter"));
+        let cmd = matcher["hooks"][0]["command"].as_str().unwrap();
+        assert!(cmd.ends_with("claude-session-hook.sh"));
+        assert!(!cmd.starts_with("/old/path"));
+    }
+
+    #[test]
+    fn configure_hook_preserves_unrelated_session_start_matchers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = tmp.path().join(".claude/settings.json");
+        std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+
+        let brain_dir = tmp.path().join("hippo-brain");
+        let initial = serde_json::json!({
+            "hooks": {
+                "SessionStart": [
+                    {"hooks": [{"type": "command", "command": "/other/tool/hook.sh"}]}
+                ]
+            }
+        });
+        std::fs::write(&settings, serde_json::to_string(&initial).unwrap()).unwrap();
+
+        configure_claude_session_hook_at(&settings, &brain_dir).unwrap();
+
+        let content = std::fs::read_to_string(&settings).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let matchers = v["hooks"]["SessionStart"].as_array().unwrap();
+        // Original matcher preserved, hippo matcher appended
+        assert_eq!(matchers.len(), 2);
+        assert_eq!(
+            matchers[0]["hooks"][0]["command"].as_str(),
+            Some("/other/tool/hook.sh")
+        );
+        assert!(matchers[1]["hooks"][0]["command"]
+            .as_str()
+            .unwrap()
+            .ends_with("claude-session-hook.sh"));
+    }
+
+    #[test]
+    fn configure_hook_returns_error_on_malformed_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = tmp.path().join(".claude/settings.json");
+        std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        std::fs::write(&settings, "{ this is not json }").unwrap();
+
+        let brain_dir = tmp.path().join("hippo-brain");
+        let result = configure_claude_session_hook_at(&settings, &brain_dir);
+        assert!(result.is_err());
+        // File must not have been touched
+        assert_eq!(
+            std::fs::read_to_string(&settings).unwrap(),
+            "{ this is not json }"
+        );
     }
 }

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -310,6 +310,92 @@ fn drain_poll(
     }
 }
 
+/// Configure the Claude Code session hook in ~/.claude/settings.json.
+///
+/// Skips if the hook is already pointing at the expected path. Updates only the
+/// hippo hook entry if the path has drifted (e.g. after a curl reinstall). Appends
+/// a new matcher if no hippo hook exists at all. All other settings.json content is
+/// preserved.
+pub fn configure_claude_session_hook(brain_dir: &Path) -> Result<()> {
+    let settings_path = dirs::home_dir()
+        .context("cannot determine home directory")?
+        .join(".claude/settings.json");
+
+    let hook_path = brain_dir.join("shell/claude-session-hook.sh");
+    let hook_path_str = hook_path.to_string_lossy().to_string();
+
+    let mut root: serde_json::Value = if settings_path.exists() {
+        let content = std::fs::read_to_string(&settings_path)
+            .context("failed to read ~/.claude/settings.json")?;
+        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+
+    if !root.is_object() {
+        anyhow::bail!("~/.claude/settings.json root is not a JSON object");
+    }
+
+    let matchers = root
+        .as_object_mut()
+        .unwrap()
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("hooks is not an object")?
+        .entry("SessionStart")
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .context("SessionStart is not an array")?;
+
+    // Find any existing hippo hook entry
+    let hippo_idx = matchers.iter().position(|m| {
+        m.get("hooks")
+            .and_then(|h| h.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|h| h.get("command"))
+            .filter_map(|c| c.as_str())
+            .any(|cmd| cmd.contains("claude-session-hook.sh"))
+    });
+
+    let new_matcher = serde_json::json!({
+        "hooks": [{ "type": "command", "command": hook_path_str }]
+    });
+
+    match hippo_idx {
+        Some(i) => {
+            let current = matchers[i]
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .into_iter()
+                .flatten()
+                .find_map(|h| h.get("command").and_then(|c| c.as_str()).map(String::from));
+            if current.as_deref() == Some(&hook_path_str) {
+                println!("  Claude session hook already correct, skipping");
+                return Ok(());
+            }
+            matchers[i] = new_matcher;
+            println!("  Updated Claude session hook: {}", hook_path.display());
+        }
+        None => {
+            matchers.push(new_matcher);
+            println!("  Configured Claude session hook: {}", hook_path.display());
+        }
+    }
+
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&root).context("failed to serialize settings.json")?,
+    )
+    .context("failed to write ~/.claude/settings.json")?;
+
+    Ok(())
+}
+
 /// Install the Firefox Native Messaging host manifest and wrapper script.
 ///
 /// Creates `hippo_daemon.json` (the manifest) and `hippo-native-messaging` (a wrapper

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -422,8 +422,11 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
     let tmp_path =
         settings_path.with_file_name(format!("settings.json.tmp.{}", std::process::id()));
     std::fs::write(&tmp_path, &pretty).context("failed to write temporary settings file")?;
-    std::fs::rename(&tmp_path, settings_path)
-        .context("failed to atomically update ~/.claude/settings.json")?;
+    if let Err(e) = std::fs::rename(&tmp_path, settings_path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(anyhow::Error::new(e)
+            .context("failed to atomically update ~/.claude/settings.json"));
+    }
 
     Ok(())
 }

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -319,6 +319,10 @@ fn drain_poll(
 ///
 /// Returns an error if the file exists but contains malformed JSON — never silently
 /// overwrites user settings with an empty object.
+///
+/// This step does not respect `--force` because it is fully idempotent: it only
+/// writes when the path has actually drifted, never destroys existing data, and the
+/// "already correct" check makes repeat runs a no-op.
 pub fn configure_claude_session_hook(brain_dir: &Path) -> Result<()> {
     let settings_path = dirs::home_dir()
         .context("cannot determine home directory")?
@@ -328,7 +332,10 @@ pub fn configure_claude_session_hook(brain_dir: &Path) -> Result<()> {
 
 fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> Result<()> {
     let hook_path = brain_dir.join("shell/claude-session-hook.sh");
-    let hook_path_str = hook_path.to_string_lossy().to_string();
+    let hook_path_str = hook_path
+        .to_str()
+        .context("hook path is not valid UTF-8")?
+        .to_string();
 
     let mut root: serde_json::Value = if settings_path.exists() {
         let content = std::fs::read_to_string(settings_path)
@@ -377,7 +384,7 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
                 .and_then(|h| h.get("command"))
                 .and_then(|c| c.as_str());
             if current == Some(hook_path_str.as_str()) {
-                println!("  Claude session hook already correct, skipping");
+                println!("  Claude session hook already correct, skipped");
                 return Ok(());
             }
             // Mutate only the command field — preserve all other hook/matcher fields
@@ -403,15 +410,17 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
         }
     }
 
-    // Atomic write: write to a sibling tmp file then rename into place so a crash
-    // mid-write cannot leave a truncated settings.json.
+    // Atomic write: PID-suffixed tmp sibling + rename so a crash mid-write cannot
+    // leave a truncated settings.json. The PID suffix avoids conflicts if two
+    // `daemon install` processes somehow run concurrently.
     let parent = settings_path
         .parent()
         .context("~/.claude/settings.json has no parent directory")?;
     std::fs::create_dir_all(parent)?;
     let pretty =
         serde_json::to_string_pretty(&root).context("failed to serialize settings.json")?;
-    let tmp_path = settings_path.with_extension("json.tmp");
+    let tmp_path =
+        settings_path.with_file_name(format!("settings.json.tmp.{}", std::process::id()));
     std::fs::write(&tmp_path, &pretty).context("failed to write temporary settings file")?;
     std::fs::rename(&tmp_path, settings_path)
         .context("failed to atomically update ~/.claude/settings.json")?;
@@ -682,7 +691,8 @@ mod tests {
         configure_claude_session_hook_at(&settings, &brain_dir).unwrap();
 
         let mtime_after = std::fs::metadata(&settings).unwrap().modified().unwrap();
-        // File must not have been rewritten
+        // File must not have been rewritten. APFS nanosecond mtime precision
+        // makes this reliable; HFS+ second granularity would need a sleep.
         assert_eq!(mtime_before, mtime_after);
     }
 

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -422,6 +422,23 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
     let tmp_path =
         settings_path.with_file_name(format!("settings.json.tmp.{}", std::process::id()));
     std::fs::write(&tmp_path, &pretty).context("failed to write temporary settings file")?;
+
+    // Preserve the existing file's permissions across the rename so a user who
+    // locked down ~/.claude/settings.json (e.g. chmod 0600) keeps that mode.
+    // When the destination does not yet exist, default to 0600 — Claude settings
+    // may contain API keys and should not inherit an arbitrary umask.
+    let mode = std::fs::metadata(settings_path)
+        .map(|m| m.permissions().mode())
+        .unwrap_or(0o600);
+    if let Err(e) =
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(mode & 0o7777))
+    {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(
+            anyhow::Error::new(e).context("failed to set permissions on temporary settings file")
+        );
+    }
+
     if let Err(e) = std::fs::rename(&tmp_path, settings_path) {
         let _ = std::fs::remove_file(&tmp_path);
         return Err(
@@ -764,6 +781,34 @@ mod tests {
                 .unwrap()
                 .ends_with("claude-session-hook.sh")
         );
+    }
+
+    #[test]
+    fn configure_hook_preserves_file_permissions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = tmp.path().join(".claude/settings.json");
+        std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        std::fs::write(&settings, r#"{"theme":"dark"}"#).unwrap();
+        std::fs::set_permissions(&settings, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let brain_dir = tmp.path().join("hippo-brain");
+        configure_claude_session_hook_at(&settings, &brain_dir).unwrap();
+
+        let mode = std::fs::metadata(&settings).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {:o}", mode);
+    }
+
+    #[test]
+    fn configure_hook_creates_new_settings_with_0600() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = tmp.path().join(".claude/settings.json");
+        // Parent exists, file does not — hook must default to 0600.
+
+        let brain_dir = tmp.path().join("hippo-brain");
+        configure_claude_session_hook_at(&settings, &brain_dir).unwrap();
+
+        let mode = std::fs::metadata(&settings).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected default 0600, got {:o}", mode);
     }
 
     #[test]

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -333,8 +333,9 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
     let mut root: serde_json::Value = if settings_path.exists() {
         let content = std::fs::read_to_string(settings_path)
             .context("failed to read ~/.claude/settings.json")?;
-        serde_json::from_str(&content)
-            .with_context(|| "~/.claude/settings.json is malformed JSON — fix it manually before running install")?
+        serde_json::from_str(&content).with_context(
+            || "~/.claude/settings.json is malformed JSON — fix it manually before running install",
+        )?
     } else {
         serde_json::json!({})
     };
@@ -357,16 +358,14 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
 
     // Find the (matcher_idx, hook_idx) of the specific hippo hook command
     let hippo_location = matchers.iter().enumerate().find_map(|(mi, m)| {
-        m.get("hooks")
-            .and_then(|h| h.as_array())
-            .and_then(|hooks| {
-                hooks.iter().enumerate().find_map(|(hi, h)| {
-                    h.get("command")
-                        .and_then(|c| c.as_str())
-                        .filter(|cmd| cmd.contains("claude-session-hook.sh"))
-                        .map(|_| (mi, hi))
-                })
+        m.get("hooks").and_then(|h| h.as_array()).and_then(|hooks| {
+            hooks.iter().enumerate().find_map(|(hi, h)| {
+                h.get("command")
+                    .and_then(|c| c.as_str())
+                    .filter(|cmd| cmd.contains("claude-session-hook.sh"))
+                    .map(|_| (mi, hi))
             })
+        })
     });
 
     match hippo_location {
@@ -745,10 +744,12 @@ mod tests {
             matchers[0]["hooks"][0]["command"].as_str(),
             Some("/other/tool/hook.sh")
         );
-        assert!(matchers[1]["hooks"][0]["command"]
-            .as_str()
-            .unwrap()
-            .ends_with("claude-session-hook.sh"));
+        assert!(
+            matchers[1]["hooks"][0]["command"]
+                .as_str()
+                .unwrap()
+                .ends_with("claude-session-hook.sh")
+        );
     }
 
     #[test]

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -424,8 +424,9 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
     std::fs::write(&tmp_path, &pretty).context("failed to write temporary settings file")?;
     if let Err(e) = std::fs::rename(&tmp_path, settings_path) {
         let _ = std::fs::remove_file(&tmp_path);
-        return Err(anyhow::Error::new(e)
-            .context("failed to atomically update ~/.claude/settings.json"));
+        return Err(
+            anyhow::Error::new(e).context("failed to atomically update ~/.claude/settings.json")
+        );
     }
 
     Ok(())

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -331,7 +331,7 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
     let hook_path_str = hook_path.to_string_lossy().to_string();
 
     let mut root: serde_json::Value = if settings_path.exists() {
-        let content = std::fs::read_to_string(&settings_path)
+        let content = std::fs::read_to_string(settings_path)
             .context("failed to read ~/.claude/settings.json")?;
         serde_json::from_str(&content)
             .with_context(|| "~/.claude/settings.json is malformed JSON — fix it manually before running install")?
@@ -414,7 +414,7 @@ fn configure_claude_session_hook_at(settings_path: &Path, brain_dir: &Path) -> R
         serde_json::to_string_pretty(&root).context("failed to serialize settings.json")?;
     let tmp_path = settings_path.with_extension("json.tmp");
     std::fs::write(&tmp_path, &pretty).context("failed to write temporary settings file")?;
-    std::fs::rename(&tmp_path, &settings_path)
+    std::fs::rename(&tmp_path, settings_path)
         .context("failed to atomically update ~/.claude/settings.json")?;
 
     Ok(())

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -304,7 +304,7 @@ async fn main() -> Result<()> {
                     .data_dir
                     .parent()
                     .map(|p| p.join("hippo-brain"))
-                    .unwrap_or_else(|| brain_dir.clone());
+                    .context("data_dir has no parent — cannot derive brain dir for hook")?;
                 match install::configure_claude_session_hook(&hook_brain_dir) {
                     Ok(()) => {}
                     Err(e) => println!(

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -297,11 +297,19 @@ async fn main() -> Result<()> {
 
                 println!();
                 println!("Configuring Claude session hook...");
-                match install::configure_claude_session_hook(&brain_dir) {
+                // Derive the hook's brain dir the same way `hippo doctor` does
+                // (sibling of data_dir) so install and doctor always agree on the
+                // expected path, regardless of what --brain-dir was passed.
+                let hook_brain_dir = vars
+                    .data_dir
+                    .parent()
+                    .map(|p| p.join("hippo-brain"))
+                    .unwrap_or_else(|| brain_dir.clone());
+                match install::configure_claude_session_hook(&hook_brain_dir) {
                     Ok(()) => {}
                     Err(e) => println!(
                         "  Warning: {e} — configure manually: {}/shell/claude-session-hook.sh",
-                        brain_dir.display()
+                        hook_brain_dir.display()
                     ),
                 }
 

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -299,7 +299,10 @@ async fn main() -> Result<()> {
                 println!("Configuring Claude session hook...");
                 match install::configure_claude_session_hook(&brain_dir) {
                     Ok(()) => {}
-                    Err(e) => println!("  Warning: {e} — configure manually: {}/shell/claude-session-hook.sh", brain_dir.display()),
+                    Err(e) => println!(
+                        "  Warning: {e} — configure manually: {}/shell/claude-session-hook.sh",
+                        brain_dir.display()
+                    ),
                 }
 
                 // Reload services that were running before the upgrade.

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -295,6 +295,13 @@ async fn main() -> Result<()> {
                 println!("Installing Native Messaging manifest for Firefox...");
                 install::install_native_messaging_manifest(&vars.hippo_bin, force)?;
 
+                println!();
+                println!("Configuring Claude session hook...");
+                match install::configure_claude_session_hook(&brain_dir) {
+                    Ok(()) => {}
+                    Err(e) => println!("  Warning: {e} — configure manually: {}/shell/claude-session-hook.sh", brain_dir.display()),
+                }
+
                 // Reload services that were running before the upgrade.
                 if daemon_was_loaded || brain_was_loaded {
                     println!();

--- a/shell/claude-session-hook.sh
+++ b/shell/claude-session-hook.sh
@@ -88,7 +88,10 @@ TMUX_CMD="HIPPO_WATCH_PID=${CLAUDE_PID} $(printf '%q' "$HIPPO_BIN") ingest claud
 # tmux new-window -d returns immediately — the tail loop runs inside the new window,
 # so this hook never blocks Claude Code from launching.
 if [ -n "$TMUX_TARGET_SESSION" ]; then
-    tmux new-window -d -t "$TMUX_TARGET_SESSION" -n "$WINDOW_NAME" "$TMUX_CMD"
+    # We are inside tmux: create a new window in the current session. Omitting -t
+    # lets tmux pick the next free index rather than inserting relative to a specific
+    # window, which avoids "index N in use" errors with non-default base-index configs.
+    tmux new-window -d -n "$WINDOW_NAME" "$TMUX_CMD"
     log "spawned tmux window in session=$TMUX_TARGET_SESSION"
 elif tmux list-sessions &>/dev/null; then
     # Not inside tmux but a tmux server is running — reuse the hippo session


### PR DESCRIPTION
This pull request introduces significant improvements and robustness to the configuration and verification of the Claude session hook integration in `hippo-daemon`. The changes ensure that the hook is managed in an idempotent and user-safe way, with careful handling of user modifications and error cases. Additionally, the release version is bumped for both the Rust and Python packages.

**Key changes include:**

### Claude Session Hook Configuration and Verification

* Added a robust, idempotent `configure_claude_session_hook` function in `install.rs` that updates or appends the Claude session hook in `~/.claude/settings.json` without overwriting unrelated user settings, preserving file permissions, and handling malformed JSON gracefully. This function is now invoked during `hippo daemon install`. [[1]](diffhunk://#diff-be21bd8c073fcae3d7c1dcf7782049f7690dafb70f1537c233ba57267a589bd7R313-R451) [[2]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dR298-R315)
* Enhanced the `check_claude_session_hook_at` function in `commands.rs` to:
  - Detect and report structural issues in `settings.json` with clear instructions for manual repair.
  - Correctly handle multiple hook entries, only reporting a mismatch if none match the expected command.
  - Provide improved user guidance for fixing configuration issues. [[1]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aR688-R689) [[2]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aR698-R729) [[3]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aL711-R776)

### Testing and Reliability

* Added comprehensive tests for both the new hook configuration logic and improved verification, covering scenarios like adding, updating, skipping, and error handling, as well as file permission preservation. [[1]](diffhunk://#diff-be21bd8c073fcae3d7c1dcf7782049f7690dafb70f1537c233ba57267a589bd7R671-R829) [[2]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aR1129-R1168)

### Shell Script Reliability

* Updated `claude-session-hook.sh` to avoid tmux window index conflicts by omitting the `-t` parameter, letting tmux choose the next available window index.

### Version Bumps

* Bumped the version numbers in both `Cargo.toml` (`hippo-core`/`hippo-daemon`) and `brain/pyproject.toml` (`hippo-brain`) from `0.13.3` to `0.13.4`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L6-R6) [[2]](diffhunk://#diff-933170718cb256eb36da291869226bd409542f5935074e52d6095b79d2764da3L3-R3)