### PR TITLE
fix(extension): ensure dist/ is built on install (regression from 3898910)

### DIFF
--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -606,6 +606,9 @@ pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
     // Check Claude session hook
     check_claude_session_hook(config);
 
+    // Check Firefox extension build + Native Messaging manifest
+    check_firefox_extension();
+
     // Check OpenTelemetry configuration
     check_otel_status(config, &client).await;
 
@@ -786,6 +789,90 @@ fn expected_claude_session_hook_path(data_dir: &std::path::Path) -> Option<PathB
         .map(|brain_dir| brain_dir.join("shell/claude-session-hook.sh"))
 }
 
+/// Check that the Firefox extension's compiled dist/ bundle exists and the
+/// Native Messaging manifest is installed.
+///
+/// The extension's `manifest.json` references `dist/background.js` and
+/// `dist/content.js`, but `dist/` is gitignored — it must be produced by
+/// `mise run build:ext:dist`. If dist/ is missing the extension loads cleanly
+/// as a temporary add-on in Firefox but captures nothing (silent no-op).
+fn check_firefox_extension() {
+    // Native Messaging manifest — the bridge between Firefox and hippo-daemon.
+    let nm_manifest = dirs::home_dir().map(|h| {
+        h.join("Library/Application Support/Mozilla/NativeMessagingHosts/hippo_daemon.json")
+    });
+    match nm_manifest {
+        Some(path) if path.exists() => println!("[OK] Firefox Native Messaging manifest installed"),
+        Some(path) => {
+            println!(
+                "[!!] Firefox Native Messaging manifest missing: {}",
+                path.display()
+            );
+            println!("     Fix: hippo daemon install --force");
+        }
+        None => println!("[--] Firefox Native Messaging check skipped (no home dir)"),
+    }
+
+    // Extension dist/ files. We locate the repo via the canonical path of the
+    // currently running binary — typically `<repo>/target/release/hippo`, with
+    // `~/.local/bin/hippo` being a symlink into it. If we can't find the repo
+    // layout, skip rather than false-alarm.
+    let Some(repo_root) = repo_root_from_current_exe() else {
+        println!("[--] Firefox extension dist/ check skipped (could not locate repo root)");
+        return;
+    };
+    check_firefox_extension_dist_at(&repo_root.join("extension/firefox"));
+}
+
+fn check_firefox_extension_dist_at(ext_dir: &std::path::Path) {
+    if !ext_dir.exists() {
+        // Not fatal: release installs won't have the repo extension dir.
+        println!(
+            "[--] Firefox extension dir not found at {}",
+            ext_dir.display()
+        );
+        return;
+    }
+    let required = ["dist/background.js", "dist/content.js"];
+    let missing: Vec<&str> = required
+        .iter()
+        .filter(|rel| !ext_dir.join(rel).exists())
+        .copied()
+        .collect();
+    if missing.is_empty() {
+        println!("[OK] Firefox extension dist/ built ({})", ext_dir.display());
+    } else {
+        println!(
+            "[!!] Firefox extension dist/ missing: {}",
+            missing.join(", ")
+        );
+        println!("     The extension loads but captures nothing when dist/ is absent.");
+        println!("     Fix: mise run build:ext:dist");
+    }
+}
+
+/// Walk up from the running binary's canonical path looking for a hippo repo
+/// checkout (identified by a top-level `Cargo.toml` and `extension/firefox/`
+/// sibling). Returns `None` for release installs where the binary lives
+/// outside the source tree.
+fn repo_root_from_current_exe() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    // Follow symlinks — ~/.local/bin/hippo typically points into target/release.
+    let real = std::fs::canonicalize(&exe).unwrap_or(exe);
+    // Climb parents looking for Cargo.toml + extension/firefox/manifest.json.
+    let mut cur = real.as_path();
+    for _ in 0..6 {
+        let parent = cur.parent()?;
+        if parent.join("Cargo.toml").exists()
+            && parent.join("extension/firefox/manifest.json").exists()
+        {
+            return Some(parent.to_path_buf());
+        }
+        cur = parent;
+    }
+    None
+}
+
 pub fn parse_duration_to_since_ms(s: &str) -> Option<i64> {
     let s = s.trim();
     if s.len() < 2 {
@@ -830,6 +917,51 @@ mod tests {
     fn test_expected_claude_session_hook_path_without_data_dir_component_returns_none() {
         let data_dir = std::path::Path::new("/");
         assert_eq!(expected_claude_session_hook_path(data_dir), None);
+    }
+
+    #[test]
+    fn test_check_firefox_extension_dist_at_reports_missing_files() {
+        // Arrange: a fake extension dir with manifest.json but no dist/.
+        let tmp = tempdir().unwrap();
+        let ext = tmp.path().join("firefox");
+        std::fs::create_dir_all(&ext).unwrap();
+        std::fs::write(ext.join("manifest.json"), "{}").unwrap();
+
+        // The function prints to stdout; we just assert it doesn't panic and
+        // that the logic correctly identifies missing files.
+        let missing: Vec<&str> = ["dist/background.js", "dist/content.js"]
+            .iter()
+            .filter(|rel| !ext.join(rel).exists())
+            .copied()
+            .collect();
+        assert_eq!(missing, vec!["dist/background.js", "dist/content.js"]);
+
+        check_firefox_extension_dist_at(&ext);
+    }
+
+    #[test]
+    fn test_check_firefox_extension_dist_at_accepts_present_files() {
+        let tmp = tempdir().unwrap();
+        let ext = tmp.path().join("firefox");
+        std::fs::create_dir_all(ext.join("dist")).unwrap();
+        std::fs::write(ext.join("dist/background.js"), "// built").unwrap();
+        std::fs::write(ext.join("dist/content.js"), "// built").unwrap();
+
+        let missing: Vec<&str> = ["dist/background.js", "dist/content.js"]
+            .iter()
+            .filter(|rel| !ext.join(rel).exists())
+            .copied()
+            .collect();
+        assert!(missing.is_empty());
+
+        check_firefox_extension_dist_at(&ext);
+    }
+
+    #[test]
+    fn test_check_firefox_extension_dist_at_handles_missing_ext_dir() {
+        // Nonexistent path must not panic — release installs won't have it.
+        let tmp = tempdir().unwrap();
+        check_firefox_extension_dist_at(&tmp.path().join("does-not-exist"));
     }
 
     #[tokio::test]

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -840,7 +840,10 @@ fn check_firefox_extension_dist_at(ext_dir: &std::path::Path) {
         .copied()
         .collect();
     if missing.is_empty() {
-        println!("[OK] Firefox extension dist/ built ({})", ext_dir.display());
+        println!(
+            "[OK] Firefox extension dist/ built ({})",
+            ext_dir.join("dist").display()
+        );
     } else {
         println!(
             "[!!] Firefox extension dist/ missing: {}",

--- a/mise.toml
+++ b/mise.toml
@@ -25,8 +25,8 @@ run = "uv sync --project brain"
 description = "Build everything"
 depends = ["build", "build:brain"]
 
-[tasks."build:ext"]
-description = "Build and package the Firefox extension as an .xpi"
+[tasks."build:ext:dist"]
+description = "Build the Firefox extension dist/ bundle (TypeScript -> dist/*.js)"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
@@ -34,8 +34,11 @@ set -euo pipefail
 cd extension/firefox
 
 if ! command -v npm >/dev/null 2>&1; then
-    echo "npm not found; skipping extension build"
-    exit 0
+    echo "WARN: npm not found; cannot build extension dist/"
+    echo "      manifest.json references dist/background.js and dist/content.js."
+    echo "      Install Node.js (e.g., 'brew install node') then rerun 'mise run build:ext:dist'."
+    echo "      Without dist/, the Firefox extension is a no-op when loaded via about:debugging."
+    exit 1
 fi
 
 if [ ! -d node_modules ]; then
@@ -47,7 +50,37 @@ if [ ! -d node_modules ]; then
     fi
 fi
 
-echo "==> Building extension..."
+echo "==> Building extension dist/..."
+npm run build --silent
+
+# Sanity check: manifest.json references these files directly. If they're
+# missing, the extension is silently a no-op when loaded as a temporary add-on.
+for f in dist/background.js dist/content.js; do
+    if [ ! -f "$f" ]; then
+        echo "ERROR: expected $f was not produced by the build"
+        exit 1
+    fi
+done
+echo "  Built: extension/firefox/dist/"
+"""
+
+[tasks."build:ext"]
+description = "Build and package the Firefox extension as an .xpi"
+depends = ["build:ext:dist"]
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd extension/firefox
+
+# dist/ is built by the build:ext:dist dep; this task produces the .xpi
+# for Firefox Developer Edition side-loading.
+if ! command -v npm >/dev/null 2>&1; then
+    echo "npm not found; skipping .xpi packaging"
+    exit 0
+fi
+
+echo "==> Packaging extension..."
 npm run package --silent
 
 # web-ext emits a .zip; Firefox loads it just fine as an .xpi.
@@ -539,11 +572,20 @@ echo "==> Starting services..."
 launchctl bootstrap "$DOMAIN" "$DAEMON_PLIST" && echo "  Loaded daemon" || echo "  Failed to load daemon"
 launchctl bootstrap "$DOMAIN" "$BRAIN_PLIST" && echo "  Loaded brain" || echo "  Failed to load brain"
 
-# ── 8b. Install Firefox extension (side-load into Developer Edition) ────
+# ── 8b. Build Firefox extension dist/ ───────────────────────────────────
+# manifest.json references dist/background.js and dist/content.js. These
+# MUST exist for the extension to work when loaded via about:debugging (the
+# documented setup). install:ext below builds dist/ too as part of .xpi
+# packaging, but it short-circuits if Firefox Developer Edition isn't
+# installed — leaving dist/ missing. Run the dist build unconditionally.
+echo "==> Building Firefox extension dist/..."
+mise run build:ext:dist || echo "  WARN: extension dist/ build failed — Firefox extension will be a no-op"
+
+# ── 8c. Install Firefox extension (side-load into Developer Edition) ────
 echo "==> Installing Firefox extension..."
 mise run install:ext || echo "  WARN: extension install failed (non-fatal)"
 
-# ── 8c. Install Claude Code skill ───────────────────────────────────────
+# ── 8d. Install Claude Code skill ───────────────────────────────────────
 echo "==> Installing Claude Code skill..."
 mise run install:skill || echo "  WARN: skill install failed (non-fatal)"
 

--- a/mise.toml
+++ b/mise.toml
@@ -34,10 +34,10 @@ set -euo pipefail
 cd extension/firefox
 
 if ! command -v npm >/dev/null 2>&1; then
-    echo "WARN: npm not found; cannot build extension dist/"
-    echo "      manifest.json references dist/background.js and dist/content.js."
-    echo "      Install Node.js (e.g., 'brew install node') then rerun 'mise run build:ext:dist'."
-    echo "      Without dist/, the Firefox extension is a no-op when loaded via about:debugging."
+    echo "ERROR: npm not found; cannot build extension dist/" >&2
+    echo "       manifest.json references dist/background.js and dist/content.js." >&2
+    echo "       Install Node.js (e.g., 'brew install node') then rerun 'mise run build:ext:dist'." >&2
+    echo "       Without dist/, the Firefox extension is a no-op when loaded via about:debugging." >&2
     exit 1
 fi
 
@@ -66,19 +66,21 @@ echo "  Built: extension/firefox/dist/"
 
 [tasks."build:ext"]
 description = "Build and package the Firefox extension as an .xpi"
-depends = ["build:ext:dist"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd extension/firefox
-
-# dist/ is built by the build:ext:dist dep; this task produces the .xpi
-# for Firefox Developer Edition side-loading.
+# Preserve the historical no-op behavior when Node/npm is unavailable.
+# Only build dist/ and package the .xpi when npm exists.
 if ! command -v npm >/dev/null 2>&1; then
     echo "npm not found; skipping .xpi packaging"
     exit 0
 fi
+
+echo "==> Building extension dist/..."
+mise run build:ext:dist
+
+cd extension/firefox
 
 echo "==> Packaging extension..."
 npm run package --silent
@@ -574,10 +576,12 @@ launchctl bootstrap "$DOMAIN" "$BRAIN_PLIST" && echo "  Loaded brain" || echo " 
 
 # ── 8b. Build Firefox extension dist/ ───────────────────────────────────
 # manifest.json references dist/background.js and dist/content.js. These
-# MUST exist for the extension to work when loaded via about:debugging (the
-# documented setup). install:ext below builds dist/ too as part of .xpi
-# packaging, but it short-circuits if Firefox Developer Edition isn't
-# installed — leaving dist/ missing. Run the dist build unconditionally.
+# are required for the extension to work when loaded via about:debugging
+# (the documented setup). install:ext below also builds dist/ as part of
+# .xpi packaging, but it may short-circuit if Firefox Developer Edition
+# isn't installed. Run the dist build unconditionally as a best-effort
+# step; if it fails, install can continue but the Firefox extension may
+# remain non-functional.
 echo "==> Building Firefox extension dist/..."
 mise run build:ext:dist || echo "  WARN: extension dist/ build failed — Firefox extension will be a no-op"
 


### PR DESCRIPTION
## Summary

Fixes a **21-day silent outage** of the Firefox browser source. Since commit `3898910` (2026-04-01, "feat(extension): complete TypeScript rewrite"), the extension's `manifest.json` has pointed at `dist/background.js` and `dist/content.js`, but `extension/firefox/dist/` is gitignored and there was no install-pipeline step that reliably produced it. Result: the extension loaded cleanly via `about:debugging` but captured nothing. Zero browser events since 2026-04-01 23:25.

### Root cause

- `manifest.json` references `dist/background.js` + `dist/content.js` (added in 3898910).
- `extension/firefox/.gitignore` excludes `dist/`.
- The only task that built `dist/` was `build:ext`, chained under `install:ext`.
- `install:ext` short-circuits when Firefox Developer Edition isn't found, and `build:ext` silently exits 0 when `npm` is missing — so `dist/` could end up absent without any warning.
- Documented setup (CLAUDE.md) instructs users to load `extension/firefox/manifest.json` as a temporary add-on, not the side-loaded `.xpi` — and that path requires `dist/` on disk.

### Changes

- **`mise.toml`**: New `build:ext:dist` task dedicated to producing `dist/*.js`. Fails loudly (exit 1 with actionable message) when `npm` is missing, instead of silently exiting 0. `build:ext` now depends on `build:ext:dist`, and `mise run install` calls `build:ext:dist` directly as step 8b — so the dist bundle is produced whether or not Firefox side-loading succeeds.
- **`crates/hippo-daemon/src/commands.rs`**: `hippo doctor` now reports the Firefox Native Messaging manifest status and whether `extension/firefox/dist/background.js` + `dist/content.js` exist. The repo location is derived from the running binary's canonical path, so release installs (where the binary lives outside the source tree) correctly skip the dist check rather than false-alarm.

Approach **A** (build step) chosen over committing artifacts because the Node toolchain is already required for the existing `build:ext` / `install:ext` / `package:ext` flows.

## Test plan

- [x] `cargo build` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — passes
- [x] `cargo fmt --check` — passes
- [x] `cargo test -p hippo-daemon --lib` — 82 tests pass (includes 3 new tests for `check_firefox_extension_dist_at`)
- [x] `mise tasks` — new `build:ext:dist` listed; syntax valid
- [x] `mise run build:ext:dist` — produces `extension/firefox/dist/background.js`, `dist/content.js`, `dist/popup.js`
- [x] `cargo run --bin hippo -- doctor` — prints `[OK] Firefox Native Messaging manifest installed` and `[OK] Firefox extension dist/ built`
- [x] Negative case: with `dist/` removed, doctor prints `[!!] Firefox extension dist/ missing: dist/background.js, dist/content.js` + `Fix: mise run build:ext:dist`

## Follow-ups

- The already-deployed `.xpi` in the user's Firefox profile is now stale (built from pre-rewrite JS). After merging, running `mise run install` will rebuild and redeploy, but users should confirm the extension is actively loaded — if they previously loaded the repo `manifest.json` as a temporary add-on, it will start working as soon as `dist/` is rebuilt (no Firefox reload required? yes reload; `about:debugging` → Reload).
- `build:ext` still exits 0 when npm is missing (preserving the "skip .xpi packaging" behavior). Only the new `build:ext:dist` fails hard. If we decide the .xpi flow is dead in favor of `about:debugging`, we can simplify further.
- Consider making `install:ext` optional (gated by a config flag) since `about:debugging` is the documented path.

Root-cause commit: `3898910`