### PR TITLE
fix(session-hook): restore tmux -t target (regression from #48)

### DIFF
--- a/shell/claude-session-hook.sh
+++ b/shell/claude-session-hook.sh
@@ -88,16 +88,21 @@ TMUX_CMD="HIPPO_WATCH_PID=${CLAUDE_PID} $(printf '%q' "$HIPPO_BIN") ingest claud
 # tmux new-window -d returns immediately — the tail loop runs inside the new window,
 # so this hook never blocks Claude Code from launching.
 if [ -n "$TMUX_TARGET_SESSION" ]; then
-    # We are inside tmux: create a new window in the current session. Omitting -t
-    # lets tmux pick the next free index rather than inserting relative to a specific
-    # window, which avoids "index N in use" errors with non-default base-index configs.
-    tmux new-window -d -n "$WINDOW_NAME" "$TMUX_CMD"
+    # Target Claude's tmux session. Trailing colon (`session:`) is the key: per
+    # tmux(1), "An empty window name specifies the next unused index if
+    # appropriate (for example the new-window ... commands)". A bare
+    # `-t session_name` would be parsed as a target-window and collide with
+    # the base-index (e.g. `index 1 in use` when base-index=1 and window 1
+    # exists), which is the regression fixed here. Omitting `-t` entirely is
+    # also wrong: this hook is a child of Claude Code, not of tmux, so $TMUX
+    # may not be set and tmux would have no current session to target.
+    tmux new-window -d -t "${TMUX_TARGET_SESSION}:" -n "$WINDOW_NAME" "$TMUX_CMD"
     log "spawned tmux window in session=$TMUX_TARGET_SESSION"
 elif tmux list-sessions &>/dev/null; then
     # Not inside tmux but a tmux server is running — reuse the hippo session
     # if it already exists (from a prior fallback spawn), otherwise create it.
     if tmux has-session -t hippo 2>/dev/null; then
-        tmux new-window -d -t hippo -n "$WINDOW_NAME" "$TMUX_CMD"
+        tmux new-window -d -t "hippo:" -n "$WINDOW_NAME" "$TMUX_CMD"
         log "spawned fallback tmux window in existing session=hippo"
     else
         tmux new-session -d -s hippo -n "$WINDOW_NAME" "$TMUX_CMD"

--- a/tests/shell/test-claude-session-hook.sh
+++ b/tests/shell/test-claude-session-hook.sh
@@ -30,7 +30,7 @@ fi
 # server and so parallel CI runs cannot clobber each other.
 TMP_DIR="$(mktemp -d -t hippo-hook-test.XXXXXX)"
 TMUX_SOCKET="$TMP_DIR/tmux.sock"
-TMUX="tmux -S $TMUX_SOCKET"
+TMUX="tmux -f /dev/null -S $TMUX_SOCKET"
 
 cleanup() {
     $TMUX kill-server 2>/dev/null || true
@@ -63,8 +63,10 @@ assert() {
 # ---------------------------------------------------------------------------
 echo "Test 1: tmux -t 'session:' picks next free index (no 'index N in use')"
 
-$TMUX new-session -d -s "1" -n "existing-1" "sleep 30"
+$TMUX new-session -d -s "1" -n "bootstrap" "sleep 30"
 $TMUX set-option -t "1" base-index 1 >/dev/null
+$TMUX move-window -s "1:0" -t "1:1"
+$TMUX rename-window -t "1:1" "existing-1"
 
 # Representative env as set by the hook before the tmux branch.
 TMUX_TARGET_SESSION="1"
@@ -73,8 +75,11 @@ TMUX_CMD="sleep 30"
 
 # Exercise the exact invocation shape from the hook. Capture stderr to catch
 # the "index N in use" regression explicitly.
+hook_stderr_file="$TMP_DIR/test1-tmux-stderr.log"
+$TMUX new-window -d -t "${TMUX_TARGET_SESSION}:" -n "$WINDOW_NAME" "$TMUX_CMD" \
+    >/dev/null 2>"$hook_stderr_file" || true
 # shellcheck disable=SC2034  # hook_stderr is referenced inside `assert` eval strings
-hook_stderr="$($TMUX new-window -d -t "${TMUX_TARGET_SESSION}:" -n "$WINDOW_NAME" "$TMUX_CMD" 2>&1 1>/dev/null || true)"
+hook_stderr="$(cat "$hook_stderr_file")"
 
 assert "no 'index N in use' error from tmux" \
     "[ -z \"\$hook_stderr\" ]"
@@ -102,8 +107,10 @@ $TMUX kill-session -t "1"
 echo
 echo "Test 2: end-to-end hook invocation creates window in target session"
 
-$TMUX new-session -d -s "worksess" -n "filler" "sleep 30"
+$TMUX new-session -d -s "worksess" -n "bootstrap" "sleep 30"
 $TMUX set-option -t "worksess" base-index 1 >/dev/null
+$TMUX move-window -s "worksess:0" -t "worksess:1"
+$TMUX rename-window -t "worksess:1" "filler"
 
 # The hook wants a hippo binary to quote into the tmux command; a stub on
 # PATH satisfies the probe without requiring a real build.
@@ -152,7 +159,7 @@ fi
 
 cat >"$STUB_BIN/tmux" <<STUB
 #!/usr/bin/env bash
-exec "$REAL_TMUX" -S "$TMUX_SOCKET" "\$@"
+exec "$REAL_TMUX" -f /dev/null -S "$TMUX_SOCKET" "\$@"
 STUB
 chmod +x "$STUB_BIN/tmux"
 

--- a/tests/shell/test-claude-session-hook.sh
+++ b/tests/shell/test-claude-session-hook.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Smoke test for shell/claude-session-hook.sh tmux targeting.
+#
+# Regression guard for two bugs:
+#
+#   1. Pre-#48: `tmux new-window -d -t "$TMUX_TARGET_SESSION"` parsed the bare
+#      session name as a target-window, hitting "index N in use" when
+#      base-index=1 and window 1 already existed.
+#
+#   2. Post-#48 (H1 sev1): `tmux new-window -d` with no `-t` dropped every
+#      session because the hook runs as a child of Claude Code — $TMUX is not
+#      inherited, so tmux had no session to target.
+#
+# The fix is `-t "${TMUX_TARGET_SESSION}:"` (trailing colon = "next unused
+# index in this specific session"). This test exercises that exact shape.
+#
+# Run: bash tests/shell/test-claude-session-hook.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK_SCRIPT="$REPO_ROOT/shell/claude-session-hook.sh"
+
+if [ ! -f "$HOOK_SCRIPT" ]; then
+    echo "FAIL: hook script not found at $HOOK_SCRIPT" >&2
+    exit 1
+fi
+
+# Use an isolated tmux socket so we do not pollute the developer's tmux
+# server and so parallel CI runs cannot clobber each other.
+TMP_DIR="$(mktemp -d -t hippo-hook-test.XXXXXX)"
+TMUX_SOCKET="$TMP_DIR/tmux.sock"
+TMUX="tmux -S $TMUX_SOCKET"
+
+cleanup() {
+    $TMUX kill-server 2>/dev/null || true
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        echo "  [PASS] $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  [FAIL] $desc" >&2
+        echo "         condition: $cond" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: fix holds under the exact conditions that broke the pre-#48 code.
+#
+# Setup: session "1" (numeric name, matching the user's real setup) with
+# base-index=1 and window 1 already occupied. A bare `-t 1` would error with
+# "index 1 in use"; `-t "1:"` must succeed and pick the next free index.
+# ---------------------------------------------------------------------------
+echo "Test 1: tmux -t 'session:' picks next free index (no 'index N in use')"
+
+$TMUX new-session -d -s "1" -n "existing-1" "sleep 30"
+$TMUX set-option -t "1" base-index 1 >/dev/null
+
+# Representative env as set by the hook before the tmux branch.
+TMUX_TARGET_SESSION="1"
+WINDOW_NAME="🦛 hippo·abc123"
+TMUX_CMD="sleep 30"
+
+# Exercise the exact invocation shape from the hook. Capture stderr to catch
+# the "index N in use" regression explicitly.
+# shellcheck disable=SC2034  # hook_stderr is referenced inside `assert` eval strings
+hook_stderr="$($TMUX new-window -d -t "${TMUX_TARGET_SESSION}:" -n "$WINDOW_NAME" "$TMUX_CMD" 2>&1 1>/dev/null || true)"
+
+assert "no 'index N in use' error from tmux" \
+    "[ -z \"\$hook_stderr\" ]"
+
+# Verify the window landed in the correct session with the expected name.
+windows="$($TMUX list-windows -t "1" -F '#{window_index} #{window_name}')"
+assert "new window exists in session '1' with expected name" \
+    "echo \"\$windows\" | grep -qF '🦛 hippo·abc123'"
+
+# Verify it was auto-indexed (not 1, since 1 was already taken).
+new_idx="$(echo "$windows" | awk '/🦛 hippo·abc123/ {print $1}')"
+assert "new window auto-picked an index above base-index (got ${new_idx:-<none>})" \
+    "[ -n \"\$new_idx\" ] && [ \"\$new_idx\" -gt 1 ]"
+
+$TMUX kill-session -t "1"
+
+# ---------------------------------------------------------------------------
+# Test 2: end-to-end invocation of the hook script itself.
+#
+# Feeds representative SessionStart JSON on stdin (matching the Claude Code
+# hook contract) and asserts the hook logs "spawned tmux window in session="
+# for the target session. Uses TMUX_PANE to simulate being invoked from a
+# child of a tmux-attached Claude process.
+# ---------------------------------------------------------------------------
+echo
+echo "Test 2: end-to-end hook invocation creates window in target session"
+
+$TMUX new-session -d -s "worksess" -n "filler" "sleep 30"
+$TMUX set-option -t "worksess" base-index 1 >/dev/null
+
+# The hook wants a hippo binary to quote into the tmux command; a stub on
+# PATH satisfies the probe without requiring a real build.
+STUB_BIN="$TMP_DIR/bin"
+mkdir -p "$STUB_BIN"
+cat >"$STUB_BIN/hippo" <<'STUB'
+#!/usr/bin/env bash
+exec sleep 30
+STUB
+chmod +x "$STUB_BIN/hippo"
+
+# Redirect the hook's debug log into the temp dir so assertions can read it.
+HOOK_LOG_DIR="$TMP_DIR/log"
+mkdir -p "$HOOK_LOG_DIR"
+
+# Give the hook a transcript path that exists (its existence isn't checked by
+# the hook, but an empty file keeps the contract realistic). The hook derives
+# the window's short-id as the first 6 chars of the JSONL basename, so name
+# the file so we can assert that slice precisely (expected: `deadbe`).
+TRANSCRIPT="$TMP_DIR/deadbeef-cafe-1234.jsonl"
+: > "$TRANSCRIPT"
+
+# Get a real tmux pane id so the hook's `tmux display-message -t "$TMUX_PANE"`
+# call can resolve the session name. Use our isolated socket.
+pane_id="$($TMUX display-message -t "worksess:1" -p '#{pane_id}')"
+
+# Point the hook at our isolated tmux socket by shadowing the `tmux` command.
+# The hook invokes `tmux` (unqualified) in multiple places, all of which must
+# hit our private socket. Resolve the real tmux absolute path here — using
+# `env tmux` inside the stub would hit the stub again (infinite recursion)
+# because the stub itself is on PATH.
+REAL_TMUX="$(command -v tmux)"
+if [ -z "$REAL_TMUX" ] || [ "$REAL_TMUX" = "$STUB_BIN/tmux" ]; then
+    # Fall back to common install paths.
+    for candidate in /opt/homebrew/bin/tmux /usr/local/bin/tmux /usr/bin/tmux; do
+        if [ -x "$candidate" ]; then
+            REAL_TMUX="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "$REAL_TMUX" ]; then
+    echo "FAIL: could not locate real tmux binary" >&2
+    exit 1
+fi
+
+cat >"$STUB_BIN/tmux" <<STUB
+#!/usr/bin/env bash
+exec "$REAL_TMUX" -S "$TMUX_SOCKET" "\$@"
+STUB
+chmod +x "$STUB_BIN/tmux"
+
+# Run the hook. It reads JSON on stdin.
+hook_input=$(cat <<JSON
+{"transcript_path":"$TRANSCRIPT","cwd":"/tmp/fakeproject","session_id":"deadbeef-cafe"}
+JSON
+)
+
+PATH="$STUB_BIN:$PATH" \
+    XDG_DATA_HOME="$HOOK_LOG_DIR" \
+    TMUX_PANE="$pane_id" \
+    bash "$HOOK_SCRIPT" <<<"$hook_input"
+
+# Give tmux a beat to register the new window (new-window -d returns
+# immediately but list-windows can race on slow CI).
+sleep 0.2
+
+windows="$($TMUX list-windows -t "worksess" -F '#{window_index} #{window_name}')"
+
+assert "hook spawned a hippo window in target session 'worksess'" \
+    "echo \"\$windows\" | grep -qF '🦛 fakeproject'"
+
+assert "hook window name includes short session id prefix" \
+    "echo \"\$windows\" | grep -qF '·deadbe'"
+
+# Confirm the debug log captured the expected branch (proves `-t session:`
+# path was taken, not the fallback).
+# shellcheck disable=SC2034  # DEBUG_LOG is referenced inside `assert` eval strings
+DEBUG_LOG="$HOOK_LOG_DIR/hippo/session-hook-debug.log"
+assert "hook logged 'spawned tmux window in session=worksess'" \
+    "grep -q 'spawned tmux window in session=worksess' \"\$DEBUG_LOG\""
+
+# Explicit guard against the pre-#48 regression re-appearing.
+assert "hook did not error with 'index N in use'" \
+    "! grep -q 'index .* in use' \"\$DEBUG_LOG\""
+
+$TMUX kill-session -t "worksess" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Sev1 — every Claude session since 2026-04-21 23:41 UTC has been silently dropped

### Symptom

Commit [`1330113`](https://github.com/stevencarpenter/hippo/commit/1330113) (merged via #48 on 2026-04-21 23:41 UTC) removed the `-t &#34;$TMUX_TARGET_SESSION&#34;` flag from `tmux new-window` in `shell/claude-session-hook.sh`. The commit comment claimed *&#34;Omitting -t lets tmux pick the next free index&#34;* — **this is only true when the invoking process is inside a tmux pane** (i.e. when `$TMUX` is set in the environment).

The Claude Code `SessionStart` hook runs as a direct child of Claude Code, not of tmux, so `$TMUX` is **not** inherited. Without `-t`, tmux has no current session to target, and `tmux new-window -d` either fails silently or creates a window in the wrong server/session. The hook still logs `spawned tmux window in session=` because the log line runs unconditionally after the tmux call (no exit-code check), so the regression was invisible in the debug log.

**Impact:** zero `claude_sessions` rows written since 2026-04-21 23:41 UTC. Every Claude session — mine and anyone on `main` — has been dropping.

### Fix

Use `-t &#34;${TMUX_TARGET_SESSION}:&#34;` (trailing colon, empty window name). Per `tmux(1)`:

&gt; An empty window name specifies the next unused index if appropriate (for example the `new-window` and `link-window` commands)

This restores session targeting **and** avoids the original `create window failed: index N in use` bug that motivated #48. That bug was caused by the bare `-t session_name` form: when the session name has no colon, tmux parses it as a `target-window`, and with `base-index=1` + window 1 occupied the command collided at index 1. The trailing-colon form sidesteps that parsing entirely: tmux sees session + &#34;next unused index&#34; and auto-picks.

Same fix applied to the fallback `tmux has-session -t hippo` branch (`-t hippo` → `-t &#34;hippo:&#34;`).

### How this avoids the original &#34;index N in use&#34; issue

Reproduced locally on the user&#39;s live tmux session (name `1`, `base-index 1`, window 1 occupied):

```
$ tmux new-window -d -t &#34;1&#34; -n test &#34;sleep 1&#34;
create window failed: index 1 in use          ← original #48 bug

$ tmux new-window -d -t &#34;1:&#34; -n test &#34;sleep 1&#34;
(succeeds, picks index 5)                      ← this PR
```

### Tests

New `tests/shell/test-claude-session-hook.sh` covers both failure modes explicitly:

1. **Pre-#48 regression guard** — creates a session with `base-index=1` and an occupied window 1, runs the exact `tmux new-window -d -t &#34;${TMUX_TARGET_SESSION}:&#34; -n ... cmd` invocation, asserts no `&#34;index N in use&#34;` stderr and a new window appears at a free index &gt; base-index.
2. **End-to-end hook invocation** — spawns an isolated tmux server on a private socket, stubs `hippo` on PATH, feeds representative `SessionStart` JSON on stdin, and asserts (a) the hippo window appears in the target session, (b) the window name contains the expected short-id prefix, (c) the debug log recorded the `-t session:` branch, and (d) no `&#34;index N in use&#34;` error appeared.

### Verification

All checks run locally on the worktree before pushing:

- `cargo build` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo fmt --check` — pass
- `cargo test -p hippo-daemon` — pass (all existing tests)
- `shellcheck shell/claude-session-hook.sh tests/shell/test-claude-session-hook.sh` — pass
- `bash tests/shell/test-claude-session-hook.sh` — 7/7 pass

### Follow-ups surfaced

- The hook logs &#34;spawned tmux window&#34; unconditionally regardless of whether `tmux new-window` succeeded. Worth adding `|| log &#34;WARN: tmux new-window failed with $?&#34;` so a future regression of this class doesn&#39;t go silent for another ~12 hours.
- `hippo doctor` does not currently detect &#34;hook is configured and fires, but no `claude_sessions` rows are being produced.&#34; A staleness check against the most recent `claude_sessions.created_at_ms` (e.g. warn if &gt;24h despite a live daemon) would have surfaced this sev1 within hours.