### PR TITLE
chore(release): bump version to v0.13.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.13.4"
+version = "0.13.5"
 requires-python = ">=3.14"
 dependencies = [
     "httpx>=0.28",

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.13.4"
+version = "0.13.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump workspace version (Cargo.toml, Cargo.lock) from 0.13.4 → 0.13.5
- Bump brain version (brain/pyproject.toml, brain/uv.lock) from 0.13.4 → 0.13.5

Patch bump to cut a new tag for release pipeline testing. Includes the source_health tracking feat (9caad39) since v0.13.4.

## Test plan
- [x] CI green on this PR
- [x] Merge and tag v0.13.5 to trigger release workflow
- [x] Verify release artifacts build and publish