### PR TITLE
docs(capture-reliability): add invariants, doctor, watchdog, probes, …

### DIFF
--- a/docs/capture-reliability/01-source-health.md
+++ b/docs/capture-reliability/01-source-health.md
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS source_health (
     expected_min_per_hour  INTEGER,          -- NULL = no threshold enforced; see rationale below
     probe_ok               INTEGER,          -- NULL if no probe exists for this source; 1=pass 0=fail
     probe_lag_ms           INTEGER,          -- round-trip ms of last probe; NULL if no probe
+    probe_last_run_ts      INTEGER,          -- epoch ms of last `hippo probe` execution; NULL if never
+    last_heartbeat_ts      INTEGER,          -- epoch ms of last extension heartbeat (browser only)
     updated_at             INTEGER NOT NULL  -- epoch ms of last write to this row
 );
 ```
@@ -40,6 +42,8 @@ CREATE TABLE IF NOT EXISTS source_health (
 | `expected_min_per_hour` | Configurable lower bound for `events_last_1h`. NULL means "no threshold" — see rationale. |
 | `probe_ok` | 1 if the most recent synthetic canary probe succeeded, 0 if it failed, NULL if no probe is defined for this source. Managed by the probe system (see `05-synthetic-probes.md`). |
 | `probe_lag_ms` | Round-trip latency of the most recent probe in milliseconds. NULL if no probe. |
+| `probe_last_run_ts` | Epoch ms of the most recent `hippo probe` execution for this source. NULL if never run. Used by invariant I-8 (probe freshness). |
+| `last_heartbeat_ts` | Epoch ms of the most recent Firefox extension heartbeat (only set on `source='browser'` row; NULL elsewhere). Used by I-4 (browser round-trip) to determine whether the extension is actively loaded in Firefox. |
 | `updated_at` | Epoch ms of the most recent write to this row by any path (success, error, or probe update). |
 
 **Rationale for nullable `expected_min_per_hour`:**
@@ -54,6 +58,7 @@ CREATE TABLE IF NOT EXISTS source_health (
 - `'browser'` — Firefox extension events (`browser_events`)
 - `'watchdog'` — reserved for watchdog self-heartbeat (see `04-watchdog.md`)
 - `'probe'` — reserved for probe subsystem metadata (see `05-synthetic-probes.md`)
+- `'claude-session-watcher'` — process-health heartbeat for the FS watcher (see `06-claude-session-watcher.md`); distinct from `'claude-session'` which is data-path health
 
 ## Migration (v7 → v8)
 
@@ -75,8 +80,15 @@ CREATE TABLE IF NOT EXISTS source_health (
     expected_min_per_hour  INTEGER,
     probe_ok               INTEGER,
     probe_lag_ms           INTEGER,
+    probe_last_run_ts      INTEGER,
+    last_heartbeat_ts      INTEGER,
     updated_at             INTEGER NOT NULL
 );
+
+-- Additional column migrations for probe_tag exclusion (see 05-synthetic-probes.md):
+ALTER TABLE events           ADD COLUMN probe_tag TEXT;
+ALTER TABLE claude_sessions  ADD COLUMN probe_tag TEXT;
+ALTER TABLE browser_events   ADD COLUMN probe_tag TEXT;
 
 -- Pre-seed one row per known source so queries never return empty.
 -- last_event_ts is back-filled from existing data (see Back-fill Behavior below).

--- a/docs/capture-reliability/02-invariants.md
+++ b/docs/capture-reliability/02-invariants.md
@@ -1,0 +1,218 @@
+# Capture-Reliability Invariants
+
+**TL;DR:** Ten named, machine-checkable invariants that capture reliability must uphold. Each carries a formal detection predicate, concrete thresholds with rationale, context-awareness rules to suppress false positives, and a required backstop action on violation.
+
+---
+
+## Scope and notation
+
+- `now_ms` — current Unix epoch milliseconds (`CAST(strftime('%s','now') * 1000 AS INTEGER)`).
+- `sh.<source>.<col>` — shorthand for `SELECT <col> FROM source_health WHERE source = '<source>'`.
+- All SQL assumes the `source_health` table designed in `01-source-health.md`.
+- "Watchdog" refers to the background process specified in `04-watchdog.md`.
+- "Doctor" refers to `hippo doctor` (`crates/hippo-daemon/src/commands.rs:525`).
+
+---
+
+## I-1 Shell liveness
+
+**Assertion.** When the user has an active zsh session and `hippo.zsh` is sourced, shell commands must produce rows in the `events` table (with `source_kind='shell'`) within 60 seconds of being run.
+
+**Threshold: 60 s.** The shell hook round-trip to the daemon socket is 20–50 ms on a healthy system. 60 seconds provides a 1000× buffer for daemon startup delays, SQLite WAL flushes, and transient socket contention.
+
+**Detection predicate:**
+
+```sql
+SELECT
+    (now_ms - sh.shell.last_event_ts) > 60000   AS stale,
+    sh.shell.probe_ok                             AS shell_active
+FROM source_health
+WHERE source = 'shell';
+-- violation = stale = 1 AND shell_active = 1
+```
+
+**Defining `shell_active` (`probe_ok`).** The watchdog sets `probe_ok=1` when ALL of:
+
+1. `pgrep -x zsh` returns at least one PID.
+2. At least one of `~/.zshrc`, `~/.zshenv`, `~/.config/zsh/.zshrc`, `~/.config/zsh/.zshenv` contains a `source` line matching `hippo.zsh` (static check at watchdog startup, not per-probe).
+3. The macOS HID idle time (`ioreg -c IOHIDSystem` → `HIDIdleTime`, in ns) is < 300 × 10⁹ ns (user interacted within 5 min).
+
+If any of the three fails, `probe_ok=0` and I-1 is suppressed.
+
+**Context-awareness.**
+
+| Suppression | Mechanism |
+|---|---|
+| No zsh process | `pgrep -x zsh` empty → `probe_ok=0` |
+| Idle > 5 min | `ioreg HIDIdleTime` over threshold |
+| 0–6am local, no recent command | 30-min window suppression |
+
+**Backstop.** Watchdog: increment `sh.shell.consecutive_failures`, structured log `WARN source=shell reason=stale_events`, OTel counter `hippo.watchdog.invariant_violation{source="shell"}`. Doctor: `[!!] shell events: Xs ago (FAIL)`.
+
+---
+
+## I-2 Claude-session end-to-end
+
+**Assertion.** For every Claude session JSONL under `~/.claude/projects/` with `mtime < 5 min`, a `claude_sessions` row with matching `session_id` must exist.
+
+**Threshold: 5 min.** Tailer startup + `--wait-for-file 30` + JSONL first-segment lag. Below 2 min produces false positives on fresh sessions.
+
+**Detection predicate:**
+
+```python
+now = time.time()
+active = [f for f in glob("~/.claude/projects/**/*.jsonl", recursive=True)
+          if (now - os.path.getmtime(f)) < 300]
+
+missing = []
+for path in active:
+    with open(path) as fh:
+        first = fh.readline().strip()
+    try:
+        session_id = json.loads(first).get("sessionId", "")
+    except Exception:
+        continue
+    if not session_id:
+        continue
+    row = conn.execute(
+        "SELECT 1 FROM claude_sessions WHERE session_id = ? LIMIT 1",
+        (session_id,)
+    ).fetchone()
+    if not row:
+        missing.append((session_id, path))
+# violation: missing is non-empty
+```
+
+**Context-awareness.** Only fires when `len(active) > 0`. No time-of-day suppression.
+
+**Backstop.** Watchdog log naming each missing `session_id`. Doctor: `[!!] claude-session DB: session <id12>… missing (<path>)`.
+
+---
+
+## I-3 Claude-tool concurrency
+
+**Assertion.** If a live Claude JSONL has received a `tool_use` line within 5 min, at least one matching `events` row (`source_kind='claude-tool'`) must exist in that window.
+
+**Threshold: 5 min.** Same ingest path as shell; generous for burst scenarios.
+
+**Backstop.** Structured log only (no alarm by default — noisier than I-2). Opt-in via `[watchdog] claude_tool_alarm = true`.
+
+---
+
+## I-4 Browser round-trip
+
+**Assertion.** If Firefox is running AND the extension has sent a heartbeat within 2 min, a `browser_events` row must appear within that 2-min window.
+
+**Threshold: 2 min.** NM is synchronous; a 2-min gap is a structural break.
+
+**Detection predicate:**
+
+```sql
+SELECT
+    (now_ms - sh.browser.last_event_ts) > 120000  AS stale,
+    sh.browser.probe_ok                             AS extension_active
+FROM source_health WHERE source = 'browser';
+-- violation = stale = 1 AND extension_active = 1
+```
+
+`probe_ok = 1` iff (a) Firefox process running, (b) `source_health.browser.last_heartbeat_ts` < 120 s old.
+
+**Backstop.** Watchdog alarm. Doctor: `[!!] browser events: 21d ago (FAIL, extension active)`.
+
+---
+
+## I-5 Fire-and-forget drop visibility
+
+**Assertion.** Every event dropped by the daemon (socket accept + crash, or buffer overflow) must increment a persistent monotonically-increasing counter. Zero tolerance for invisible drops.
+
+**Rationale.** The fire-and-forget contract (`commands.rs:96–103`) allows drops on daemon crash — but drops must never be silent.
+
+**Backstop.** OTel counter `hippo.daemon.drops_total{source=<name>}`. No user-visible alarm for isolated drops; alarm triggers at I-6 threshold.
+
+---
+
+## I-6 Buffer non-saturation
+
+**Assertion.** Sustained drop rate over any 5-min sliding window must not exceed 0.1% of total event traffic.
+
+**Threshold: 0.1% / 5 min.** At 100 events/min, 0.1% ≈ 1 lost event per 10 min. Above this is structural (daemon crash loop, disk full, socket backlog).
+
+**Backstop.** Watchdog alarm. Doctor: `[!!] drop-rate: 2.3% over 5 min (FAIL, threshold 0.1%)`.
+
+---
+
+## I-7 Watchdog is alive
+
+**Assertion.** The watchdog must write to `source_health WHERE source='watchdog'` at least every 60 s. Stale row > 180 s = alarm.
+
+**Threshold: 180 s stale.** 3× the write interval — one miss may be a hiccup; three misses indicate crash.
+
+**Backstop.** Doctor only (dead watchdog cannot alarm about itself). Doctor: `[!!] watchdog heartbeat: stale 4m ago (FAIL)`.
+
+---
+
+## I-8 Probe freshness (from D3)
+
+**Assertion.** For each source in `source_health` with `probe_last_run_ts IS NOT NULL`: `probe_ok = 1` OR `probe_last_run_ts > now_ms - 900_000` (15 min).
+
+A probe run within 15 min that returned `probe_ok = 0` is an active violation; a probe that hasn't run in over 15 min is also a violation.
+
+**Threshold: 15 min.** 3× the probe interval (5 min) — one missed cycle tolerable, two is alarm-worthy.
+
+**Backstop.** Watchdog alarm. Doctor: `[!!] <source> probe: stale (FAIL)` or `[!!] <source> probe: failing (FAIL)`.
+
+---
+
+## I-9 Fallback file age
+
+**Assertion.** If any JSONL fallback file under `~/.local/share/hippo/` is older than 24 h AND the daemon socket is responsive, recovery is broken.
+
+**Threshold: 24 h.** Once the daemon is up, fallback drain should complete in minutes.
+
+**Backstop.** Doctor: `[!!] fallback files: N files > 24h (recovery broken)`. Watchdog alarm.
+
+---
+
+## I-10 Enrichment-capture decoupling
+
+**Assertion (architectural).** Brain being down (HTTP 5xx/timeout) must NOT prevent `source_health` updates for capture sources. Source-health writes are the daemon/watchdog's responsibility, not the brain's.
+
+**Detection (canary, not runtime):**
+
+```bash
+pkill -f hippo-brain
+sleep 10
+UPDATED=$(sqlite3 ~/.local/share/hippo/hippo.db \
+  "SELECT (strftime('%s','now')*1000 - updated_at) < 30000
+   FROM source_health WHERE source='shell';")
+[ "$UPDATED" = "1" ] || echo "VIOLATION"
+```
+
+**Backstop.** Architectural enforcement + CI integration test. If violated, all other alarms become unreliable when the brain is degraded.
+
+---
+
+## Threshold summary
+
+| Invariant | Threshold | Rationale |
+|---|---|---|
+| I-1 shell liveness | 60 s | 1000× typical round-trip |
+| I-2 claude-session coverage | 5 min | tailer startup + file-wait |
+| I-3 claude-tool concurrency | 5 min | same ingest path; generous |
+| I-4 browser round-trip | 2 min | NM synchronous; 2 min = broken |
+| I-5 drop visibility | every drop | zero tolerance |
+| I-6 drop rate | 0.1% / 5 min | ~1 lost / 10 min @ 100/min |
+| I-7 watchdog heartbeat | 180 s stale | 3× interval |
+| I-8 probe freshness | 15 min | 3× probe interval |
+| I-9 fallback file age | 24 h | should drain in minutes |
+| I-10 decoupling | architectural | brain-down must not mask alarms |
+
+## Context-awareness rules (consolidated)
+
+| Invariant | Suppress when |
+|---|---|
+| I-1 | No zsh process; idle > 5 min; night hours w/ no recent command |
+| I-2 | No JSONL mtime < 5 min |
+| I-3 | No live JSONL with recent `tool_use` |
+| I-4 | Firefox not running; heartbeat file absent/stale |
+| I-9 | — (always applicable if daemon up) |

--- a/docs/capture-reliability/03-doctor-upgrades.md
+++ b/docs/capture-reliability/03-doctor-upgrades.md
@@ -1,0 +1,248 @@
+# Doctor Upgrade Specification
+
+**TL;DR:** Ten new isolated checks for `hippo doctor`, each with exact queries, thresholds, exit-code contribution, and performance budget. Doctor exits with a non-zero count of failures, enabling CI and scripted incident response.
+
+---
+
+## Existing doctor structure (baseline)
+
+Current: `handle_doctor` at `crates/hippo-daemon/src/commands.rs:525–613`. Format `[OK]` / `[!!]` / `[--]`. Exit code: always `Ok(())` — never non-zero today.
+
+## Exit-code strategy
+
+Each check contributes to a mutable `fail_count: u32`. Doctor exits with `std::process::exit(fail_count as i32)` after all checks complete.
+
+| Symbol | Color | Meaning | `fail_count` |
+|---|---|---|---|
+| `[OK]` | green | passed | +0 |
+| `[WW]` | yellow | warning | +0 |
+| `[!!]` | red | failure | +1 |
+| `[--]` | gray | N/A | +0 |
+
+`NO_COLOR` env var and `--no-color` flag suppress ANSI.
+
+**Isolation guarantee.** Every check is wrapped in `catch_unwind` / `try/except`: a malformed DB or missing file never prevents subsequent checks.
+
+## Output format
+
+Left column: fixed-width label (32 chars). Right column: status + detail.
+
+```
+shell events               [OK] 4s ago
+claude-session DB          [!!] session abc123f not in DB (FAIL, active JSONL 2m old)
+browser ext dist/          [!!] dist/background.js missing
+zsh hook sourced           [OK] sourced in /Users/you/.config/zsh/.zshrc
+native-msg manifest        [OK] path=/usr/local/bin/hippo, extension ID matches
+watchdog heartbeat         [WW] 95s ago (WARN, expected < 60s)
+log file sizes             [OK] all under 50MB
+fallback files             [OK] none pending
+schema version             [OK] 8
+session-hook log           [OK] 3 invocations, 2 DB rows (last 1h)
+```
+
+## Performance budget
+
+Combined: **< 2 seconds**. Run independent groups via `tokio::join!`. Reuse the brain HTTP call from `print_brain_health_details` for check 10 — no extra round-trip.
+
+---
+
+## Check 1 — Per-source staleness
+
+**Label:** `<source> events` (one line each)
+
+**Query:**
+```sql
+SELECT source, last_event_ts, last_error_msg, consecutive_failures,
+       events_last_1h, probe_ok
+FROM source_health
+WHERE source IN ('shell', 'browser', 'claude-session', 'claude-tool');
+```
+
+**Thresholds:**
+
+| Source | WARN | FAIL | Suppression |
+|---|---|---|---|
+| `shell` | > 60 s | > 300 s | `probe_ok = 0` |
+| `claude-session` | > 300 s | > 1800 s | no active JSONL |
+| `claude-tool` | > 300 s | > 600 s | no live tool_use |
+| `browser` | > 120 s | > 600 s | Firefox not running |
+
+If no row: `[--] <source> events: no data (watchdog not running)`.
+
+**Why this catches the sev1:** Doctor previously checked process liveness but never asked whether events were actually landing. Per-source staleness is the first thing an operator needs during incident response.
+
+**Performance:** Single SQLite read, < 5 ms.
+
+---
+
+## Check 2 — Native Messaging manifest healthy
+
+**Label:** `native-msg manifest`
+
+**Sub-checks:** manifest file exists; valid JSON; `path` field is executable; `allowed_extensions` includes `hippo-browser@local` (from `extension/firefox/manifest.json:33`).
+
+**Thresholds:** All pass → `[OK]`; any fail → `[!!]` (+1).
+
+**Why this catches the sev1:** A stale NM manifest path causes Firefox to silently fail to launch the native host.
+
+**Performance:** Filesystem + minimal python3, < 50 ms.
+
+---
+
+## Check 3 — Extension dist/ present
+
+**Label:** `browser ext dist/`
+
+Derives extension path from NM manifest's binary path (`repo_root = dirname³(hippo_bin)`, `ext_dir = repo_root/extension/firefox`). Checks `dist/background.js` and `dist/content.js` exist.
+
+If manifest absent (check 2 failed): `[--] browser ext dist/: skipped`.
+
+**Thresholds:** Both present → `[OK]`; either missing → `[!!]` (+1 per file).
+
+**Why this catches the sev1:** This is precisely H2 — the exact regression would have been caught.
+
+**Performance:** Two `stat` calls, < 5 ms.
+
+---
+
+## Check 4 — zsh hook sourced
+
+**Label:** `zsh hook sourced`
+
+Greps for `hippo.zsh` in `~/.zshrc`, `~/.zshenv`, `~/.config/zsh/.zshrc`, `~/.config/zsh/.zshenv`. If found, extracts the sourced path and confirms the script exists.
+
+**Thresholds:** Found + script exists → `[OK]`. Found but script missing → `[WW]`. Not found anywhere → `[!!]` (+1).
+
+**Why this catches the sev1:** A `.zshrc` refactor that removes the source line silently stops all shell capture.
+
+**Performance:** grep on ≤ 4 small files, < 20 ms.
+
+---
+
+## Check 5 — Live-session vs DB reconciliation
+
+**Label:** `claude-session DB`
+
+See I-2 detection predicate. Summary: glob active JSONLs, compare their `sessionId` against `claude_sessions.session_id`.
+
+**Thresholds:**
+- No active JSONLs → `[--]`
+- All in DB → `[OK]`
+- Any missing → `[!!]` (+1 per missing, capped at +3)
+
+**Why this catches the sev1:** A hook that fires but whose tmux window crashes shows zero DB rows. This check's exact signature is the sev1 fingerprint.
+
+**Performance:** Filesystem glob + N SQLite lookups, < 100 ms.
+
+---
+
+## Check 6 — Session-hook debug log reconciliation
+
+**Label:** `session-hook log`
+
+Counts `"hook invoked"` lines in last 1 h from `~/.local/share/hippo/session-hook-debug.log` (tail-bounded to 10k lines); compares to `claude_sessions` rows created in last hour.
+
+**Thresholds:**
+
+| Condition | Output |
+|---|---|
+| Both zero | `[--]` no hook activity |
+| Invocations > 0 AND rows > 0 | `[OK]` N invocations, M rows |
+| Invocations > 0 AND rows = 0 AND invocations < 3 | `[WW]` too fresh |
+| Invocations ≥ 3 AND rows = 0 | `[!!]` (+1) |
+
+**Why this catches the sev1:** A hook firing repeatedly with zero DB rows is exactly the current situation. Ratio is the triage grep.
+
+**Performance:** `tail + awk` + one SQL query, < 100 ms.
+
+---
+
+## Check 7 — Log file sizes
+
+**Label:** `log file sizes`
+
+Scans `~/.local/share/hippo/` for `*.log` and `*.jsonl`. Thresholds: 50 MB WARN, 200 MB FAIL.
+
+**Why this catches the sev1:** No log rotation exists today. `session-hook-debug.log` can grow unbounded, eventually filling the partition.
+
+**Performance:** `find + stat`, < 20 ms.
+
+---
+
+## Check 8 — Watchdog heartbeat
+
+**Label:** `watchdog heartbeat`
+
+**Query:**
+```sql
+SELECT updated_at, (strftime('%s','now')*1000 - updated_at)/1000 AS age_secs
+FROM source_health WHERE source = 'watchdog' LIMIT 1;
+```
+
+**Thresholds:** < 60 s → `[OK]`; 60–180 s → `[WW]`; ≥ 180 s or no row → `[!!]` (+1).
+
+**Why this catches the sev1:** If the watchdog dies, all other staleness checks return stale data indefinitely. This check surfaces meta-failure first.
+
+**Performance:** Single SQLite row, < 5 ms.
+
+---
+
+## Check 9 — Fallback file age
+
+**Label:** `fallback files`
+
+Extends existing count check (`commands.rs:590–597`) with an age predicate.
+
+**Thresholds:** None → `[OK]`; all < 24 h → `[WW]`; any > 24 h with daemon up → `[!!]` (+1).
+
+**Why this catches the sev1:** Silent recovery failure — if the drain task breaks, events pile up forever.
+
+**Performance:** Filesystem metadata, < 20 ms.
+
+---
+
+## Check 10 — Schema version match
+
+**Label:** `schema version`
+
+Reads daemon `PRAGMA user_version` and compares to brain's `expected_schema_version` from cached `/health` JSON (already fetched earlier in doctor).
+
+**Thresholds:** Match OR daemon version in `accepted_read_versions` → `[OK]`; mismatch → `[!!]` (+1).
+
+**Why this catches the sev1:** A daemon/brain schema drift crashes every enrichment pass. Doctor previously reported `[OK] Brain is running` while enrichment silently died.
+
+**Performance:** One PRAGMA + cached JSON parse. Zero additional network.
+
+---
+
+## `hippo doctor --explain` mode
+
+When `--explain` is passed, each failing check appends a remediation block:
+
+```
+[!!] browser ext dist/    dist/background.js missing in /repo/extension/firefox/
+     CAUSE:  Extension not built after source change
+     FIX:    cd /repo/extension/firefox && npm install && npm run build
+     DOC:    docs/capture-reliability/02-invariants.md#i-4-browser-round-trip
+```
+
+Each check returns `CheckResult { status, label, detail, cause, fix, doc_ref }`.
+
+---
+
+## Summary table
+
+| # | Label | Mechanism | OK | WARN | FAIL | Network |
+|---|---|---|---|---|---|---|
+| 1 | `<source> events` | `source_health` SQL | < thresh | near | > thresh | No |
+| 2 | `native-msg manifest` | stat + JSON | all pass | — | any | No |
+| 3 | `browser ext dist/` | stat | both files | — | either missing | No |
+| 4 | `zsh hook sourced` | grep | found + exists | found, no script | not found | No |
+| 5 | `claude-session DB` | glob + SQL | all in DB | — | any missing | No |
+| 6 | `session-hook log` | awk + SQL | nonzero both | low ratio | 0 DB / ≥3 fires | No |
+| 7 | `log file sizes` | find + stat | < 50 MB | 50–200 MB | > 200 MB | No |
+| 8 | `watchdog heartbeat` | SQL | < 60 s | 60–180 s | > 180 s | No |
+| 9 | `fallback files` | stat | none | recent | > 24 h + daemon up | No |
+| 10 | `schema version` | PRAGMA + cached JSON | match | — | mismatch | reuses brain call |
+
+All ten checks combined target < 2 s with zero additional network calls beyond the existing brain HTTP request.

--- a/docs/capture-reliability/04-watchdog.md
+++ b/docs/capture-reliability/04-watchdog.md
@@ -1,0 +1,198 @@
+# Watchdog Process
+
+**TL;DR:** A short-lived launchd agent (`com.hippo.watchdog`) runs every 60 seconds, asserts invariants I-1..I-10 against `source_health`, and writes structured alarms to a new `capture_alarms` table when violations are detected. A wedged daemon cannot silence its own alarm because the watchdog is an independent process under a separate launchd job.
+
+## Process Model
+
+New subcommand `hippo watchdog run` installed as a launchd LaunchAgent. Plist at `launchd/com.hippo.watchdog.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.hippo.watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HIPPO_BIN__</string>
+        <string>watchdog</string>
+        <string>run</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key><string>__HOME__</string>
+        <key>PATH</key><string>__PATH__</string>
+    </dict>
+    <key>StartInterval</key><integer>60</integer>
+    <key>RunAtLoad</key><false/>
+    <key>StandardOutPath</key><string>__DATA_DIR__/watchdog.stdout.log</string>
+    <key>StandardErrorPath</key><string>__DATA_DIR__/watchdog.stderr.log</string>
+    <key>WorkingDirectory</key><string>__HOME__</string>
+</dict>
+</plist>
+```
+
+`KeepAlive` absent (defaults `false`). `StartInterval=60` spawns fresh every 60 s. Deliberately not long-lived — a long-lived tokio task inside `hippo-daemon` would be silenced if the daemon panics or deadlocks. Critical property: watchdog's failure domain is independent from what it monitors.
+
+`hippo daemon install` installs this plist alongside `com.hippo.daemon.plist` and `com.hippo.brain.plist` (pattern from `crates/hippo-daemon/src/main.rs:244–265`).
+
+## Responsibilities (Ordered)
+
+**Step 1 — Write own heartbeat.**
+
+```sql
+INSERT INTO source_health (source, updated_at, last_success_ts)
+VALUES ('watchdog', :now_ms, :now_ms)
+ON CONFLICT(source) DO UPDATE SET
+    updated_at      = excluded.updated_at,
+    last_success_ts = excluded.last_success_ts;
+```
+
+Runs before any assertion work. If the watchdog crashes after step 1, heartbeat is still committed. Doctor treats stale `watchdog.updated_at` as failure (see `03-doctor-upgrades.md`).
+
+**Step 2 — Read all `source_health` rows.**
+
+```sql
+SELECT * FROM source_health;
+```
+
+One query over a small table. If absent (pre-migration install), create it from canonical DDL in `01-source-health.md` and exit clean without alarms.
+
+**Step 3 — Assert invariants I-1..I-10.** Evaluate each as a predicate over in-memory rows from step 2. No additional queries. All required columns present.
+
+**Step 4 — Raise alarms for each failing invariant.** See Alarm Contract.
+
+**Step 5 — Exit clean.** `std::process::exit(0)`. launchd re-launches after `StartInterval`.
+
+## Alarm Contract
+
+### Table
+
+```sql
+CREATE TABLE IF NOT EXISTS capture_alarms (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    invariant_id TEXT    NOT NULL,
+    raised_at    INTEGER NOT NULL,
+    details_json TEXT    NOT NULL,
+    acked_at     INTEGER,
+    ack_note     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_capture_alarms_invariant_active
+    ON capture_alarms (invariant_id, acked_at)
+    WHERE acked_at IS NULL;
+```
+
+### Rate Limiting
+
+Before INSERT, query for recent un-acked alarm for same invariant:
+
+```sql
+SELECT id FROM capture_alarms
+WHERE invariant_id = :id
+  AND acked_at IS NULL
+  AND raised_at > :cutoff_ms
+LIMIT 1;
+```
+
+where `cutoff_ms = now_ms - (alarm_rate_limit_minutes * 60 * 1000)`. Default `15`.
+
+If found: skip INSERT, still log structured line (below).
+
+If not found: INSERT with `details_json` containing `source`, `since_ms`, invariant-specific context (e.g., `consecutive_failures`, `events_last_1h`, `expected_min_per_hour`).
+
+### Structured Log Line
+
+Regardless of rate-limit, append one JSON line to `[watchdog] log_path`:
+
+```json
+{"ts":1745200000000,"level":"error","invariant":"I-3","source":"shell","since_ms":7200000,"details":{"consecutive_failures":4}}
+```
+
+Default path: `~/.local/share/hippo/watchdog-alarms.log`. Suitable for `tail -f` and OTel Loki ingestion.
+
+### macOS Notification (Optional)
+
+When `[watchdog] notify_macos = true`, additionally:
+
+```bash
+osascript -e 'display notification "I-3 violated: shell silent 2h" with title "Hippo Watchdog"'
+```
+
+Fires only when a new alarm row is inserted (rate-limit passed). Default: `notify_macos = false`.
+
+## Rate Limiting — Full Semantics
+
+Each invariant rate-limited independently. Sliding window anchored to now, not fixed hour bucket. An alarm raised at 09:00 suppresses re-raises until 09:15 with a 15-min window regardless of hour boundaries.
+
+## Ack Flow
+
+**`hippo alarms list`** — Query `WHERE acked_at IS NULL`, print:
+
+```
+ID   INVARIANT  RAISED                  DETAILS
+42   I-3        2026-04-21 09:14 UTC    shell silent 2h 0m (4 consecutive failures)
+43   I-7        2026-04-21 09:14 UTC    watchdog heartbeat stale by 3m
+```
+
+Exit 0 if none active, exit 1 if any (script-friendly).
+
+**`hippo alarms ack <id> [--note <text>]`**:
+
+```sql
+UPDATE capture_alarms
+SET acked_at = :now_ms, ack_note = :note
+WHERE id = :id AND acked_at IS NULL;
+```
+
+**Rate-limit reset after ack.** Rate-limit query filters `acked_at IS NULL`, so acked rows no longer block. Next cycle detecting the same violation inserts a fresh alarm. Intentional: acking means "I saw this," not "I fixed it."
+
+## Failure Modes for the Watchdog Itself
+
+**Cannot open DB:** `eprintln!` the error, `exit(1)`. launchd records non-zero in `launchctl print gui/$(id -u)/com.hippo.watchdog`. Heartbeat staleness then visible in doctor.
+
+**DB locked on alarm INSERT:** `busy_timeout=5000` handles up to 5 s (`storage.rs:24–27`). On `SQLITE_BUSY`, retry once after 100 ms. If retry fails: log to stderr, continue to next invariant (don't block). Heartbeat uses same retry; failure there → `exit(1)`.
+
+**Crash mid-cycle:** Heartbeat (step 1) commits before assertions. Doctor distinguishes "started but crashed" from "never ran" via `last_success_ts` (updated only at end of step 4).
+
+## Configuration
+
+Add to `config/config.default.toml` and `crates/hippo-core/src/config.rs`:
+
+```toml
+[watchdog]
+enabled                  = true
+alarm_rate_limit_minutes = 15
+notify_macos             = false
+log_path                 = ""      # default: $data_dir/watchdog-alarms.log
+osascript_title          = "Hippo Watchdog"
+```
+
+Add `WatchdogConfig` struct following existing `BrainConfig` / `DaemonConfig` pattern.
+
+## Decoupling from Enrichment (I-10)
+
+Watchdog reads only `source_health`, writes only `capture_alarms`. Does NOT connect to brain HTTP port, does NOT import Python, does NOT require LM Studio. I-7 (watchdog liveness) is evaluated from the row the watchdog writes itself. Capture-path invariants I-1..I-6, I-8 asserted from rows the daemon and extension update independently.
+
+## Boot Sequence / First-Run
+
+Before step 1, check:
+
+```sql
+SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='source_health';
+```
+
+If absent: create `source_health` from canonical DDL (`01-source-health.md`), seed watchdog row, exit clean — no alarms.
+
+If present but no watchdog row: `INSERT OR IGNORE INTO source_health (source, updated_at) VALUES ('watchdog', :now_ms)`.
+
+For any source with `last_event_ts IS NULL` (never captured an event), skip invariant assertions. Prevents alarm-storm on fresh install before first shell/session/visit.
+
+## Cross-References
+
+- Invariant definitions: `02-invariants.md`.
+- Doctor integration: `03-doctor-upgrades.md` check 8.
+- `source_health` schema: `01-source-health.md`.
+- Alarm sink / probe integration: `05-synthetic-probes.md` (probe failures → I-8 → alarms).

--- a/docs/capture-reliability/05-synthetic-probes.md
+++ b/docs/capture-reliability/05-synthetic-probes.md
@@ -1,0 +1,280 @@
+# Synthetic Probes
+
+**TL;DR:** Synthetic probes round-trip real events through each capture pipeline and verify them as SQLite rows, providing end-to-end liveness verification that socket pings cannot. All probe-generated rows are tagged via a `probe_tag` column and excluded from every user-facing query.
+
+## Philosophy
+
+A probe is not a ping. Pinging the daemon socket (`commands::probe_socket` in `crates/hippo-daemon/src/commands.rs:54`) confirms the socket accepts connections but says nothing about buffer/flush/insert paths. A probe must exercise the real pipeline — event accepted over socket, buffered, flushed, inserted into SQLite — and confirm the row is queryable before declaring success.
+
+Probe rows are permanent citizens of the DB. Tagged, excluded from user queries, enrichment, and lesson graduation. Never enriched, never embedded, never returned by `hippo ask`, `hippo query`, `mcp__hippo__*`, or brain RAG. They exist solely to give the watchdog (`04-watchdog.md`) and `source_health` observable liveness signals.
+
+## Probe Tag
+
+New `probe_tag TEXT` column (default NULL) added to three tables:
+
+```sql
+-- schema v7 → v8 (the source_health migration)
+ALTER TABLE events ADD COLUMN probe_tag TEXT;
+ALTER TABLE claude_sessions ADD COLUMN probe_tag TEXT;
+ALTER TABLE browser_events ADD COLUMN probe_tag TEXT;
+```
+
+`probe_tag` holds the UUID submitted with the synthetic event (lowercase hyphenated). For real events: NULL.
+
+### Migration
+
+Non-destructive `ALTER TABLE ADD COLUMN` is safe on live DB (no table rebuild). Bumps `EXPECTED_VERSION` to `8` in three places: `crates/hippo-core/src/storage.rs:16`, `crates/hippo-core/src/schema.sql:438` (`PRAGMA user_version`), `brain/src/hippo_brain/schema_version.py::EXPECTED_SCHEMA_VERSION`.
+
+### Grep List: Places That Need `WHERE probe_tag IS NULL`
+
+Exhaustive:
+
+| File | Context |
+|---|---|
+| `crates/hippo-daemon/src/commands.rs` | `GetStatus` — `events_today` count |
+| `crates/hippo-daemon/src/commands.rs` | `handle_query_raw` — keyword search |
+| `crates/hippo-daemon/src/commands.rs` | `handle_sessions` — session listing |
+| `crates/hippo-daemon/src/commands.rs` | `handle_events` — event listing |
+| `brain/src/hippo_brain/server.py` | `/query` endpoint |
+| `brain/src/hippo_brain/server.py` | `/ask` endpoint |
+| `brain/src/hippo_brain/enrichment.py` | `claim_pending_events_by_session` |
+| `brain/src/hippo_brain/claude_sessions.py` | `claim_pending_claude_segments` |
+| `brain/src/hippo_brain/browser_enrichment.py` | `claim_pending_browser_events` |
+| `brain/src/hippo_brain/mcp_queries.py` | `search_events_impl`, `search_knowledge_lexical`, `get_entities_impl`, `get_lessons_impl` |
+| `brain/src/hippo_brain/rag.py` | `ask()` — RAG context retrieval |
+| `brain/src/hippo_brain/retrieval.py` | `search()` — hybrid FTS5/vec0 |
+
+**Upstream filter:** Daemon flush path checks `probe_tag IS NOT NULL` before enqueuing into any enrichment queue. If probes never enter queues, no downstream knowledge node is ever sourced from a probe row — single upstream filter is load-bearing for all downstream cleanliness.
+
+## Probe Orchestrator
+
+New CLI: `hippo probe [--source <name>]`. Without `--source`, runs all four in sequence.
+
+Launchd plist `launchd/com.hippo.probe.plist`:
+
+```xml
+<key>StartInterval</key><integer>300</integer>   <!-- every 5 min -->
+<key>RunAtLoad</key><false/>                     <!-- avoid install-time storm -->
+```
+
+For each probe, orchestrator writes to `source_health`:
+
+```sql
+UPDATE source_health SET
+    probe_ok          = :ok,         -- 1 or 0
+    probe_lag_ms      = :lag_ms,     -- NULL if probe failed before measurement
+    probe_last_run_ts = :now_ms,
+    updated_at        = :now_ms
+WHERE source = :source;
+```
+
+## Per-Source Probe Specifications
+
+### Shell Probe
+
+**Send:** `hippo send-event shell --cmd "__hippo_probe__" --cwd "$HOME" --duration-ms 0 --exit 0 --probe-tag <uuid>`
+
+`--probe-tag` is a new CLI arg on `Commands::SendEvent`. Passed in `EventEnvelope` so daemon flush writes `events.probe_tag`.
+
+**Exercises:** zsh-hook-equivalent → Unix socket → daemon buffer → flush → `events` INSERT.
+
+**Verify:** Poll (10 s deadline):
+
+```sql
+SELECT id, created_at FROM events
+WHERE envelope_id = :uuid AND probe_tag = :uuid
+LIMIT 1;
+```
+
+`probe_lag_ms = created_at - probe_start_ms`.
+
+**Catches:** daemon running, socket reachable, flush working, INSERT succeeding.
+
+**Does NOT catch:** Real zsh hook (`shell/hippo.zsh`) not invoked — probe bypasses shell. Broken hook (wrong HIPPO_BIN path, precmd not registered) undetected. Separate integration test must trigger real shell.
+
+---
+
+### Claude-Tool Probe
+
+**Send:** `hippo send-event shell --cmd "__hippo_probe_claude_tool__" --source-kind claude-tool --tool-name Bash --probe-tag <uuid>`
+
+New flags (`--source-kind`, `--tool-name`) produce `events` row with `source_kind = 'claude-tool'`.
+
+**Exercises:** Same socket/buffer/flush as shell, with distinct source_kind — verifies daemon correctly handles the claude-tool code path (which brain enrichment skips differently).
+
+**Verify:** Same pattern, filter `AND source_kind = 'claude-tool'`.
+
+---
+
+### Claude-Session Probe (Assertion-based)
+
+JSONL is written by Claude Code, not hippo — cannot inject synthetic JSONL. Instead, assertion on live state:
+
+For every `~/.claude/projects/*/*.jsonl` with `mtime` within last 5 min, assert `claude_sessions` row exists where `source_file = <path>` and `end_time >= (mtime_ms - 300_000)` (5-min tolerance):
+
+```sql
+SELECT COUNT(*) FROM claude_sessions
+WHERE source_file = :path
+  AND probe_tag IS NULL
+  AND end_time >= :mtime_ms - 300000;
+```
+
+If no JSONL modified in last 5 min: trivially pass (no Claude active). If JSONL exists but no matching row: `probe_ok = 0`. The live JSONL IS the canary.
+
+`probe_lag_ms = now_ms - MAX(end_time)` for most recent ingest; NULL if never ingested.
+
+**Catches:** Tailer/watcher running and inserting segments.
+
+**Does NOT catch:** Whether `claude-session-hook.sh` fired at all. If hook never fires, no JSONL → probe vacuously passes.
+
+---
+
+### Browser Probe — Daemon Side
+
+**Send:** `hippo probe browser --native` invokes NM host stdio directly, bypassing Firefox:
+
+```json
+{
+  "url": "https://probe.hippo.local/synthetic",
+  "title": "Hippo Probe",
+  "domain": "probe.hippo.local",
+  "dwell_ms": 1, "scroll_depth": 1.0,
+  "timestamp": <now_ms>
+}
+```
+
+`probe.hippo.local` always allowlisted via `[browser] probe_domain = "probe.hippo.local"` injected into allowlist check at `native_messaging.rs:182–188`. Never visited by real browsers.
+
+Writes via NM stdio with 4-byte length-prefix framing (`native_messaging.rs:71–82`). Polls DB:
+
+```sql
+SELECT id FROM browser_events
+WHERE envelope_id = :deterministic_uuid AND probe_tag = :probe_uuid
+LIMIT 1;
+```
+
+`envelope_id` deterministic for `probe.hippo.local` (`make_envelope_id` at `native_messaging.rs:116–123`).
+
+**Catches:** NM binary compiled and reachable, allowlist logic works, daemon-side browser pipeline functional.
+
+**Does NOT catch:** Whether Firefox invokes the NM host. See Extension Heartbeat.
+
+---
+
+### Browser Probe — Extension Side (Heartbeat)
+
+Only way to verify Firefox has the extension loaded and running.
+
+**TypeScript (`extension/firefox/src/background.ts`):**
+
+```typescript
+interface HippoHeartbeat {
+  type: "heartbeat";
+  extension_version: string;
+  enabled_state: boolean;
+  sent_at_ms: number;
+}
+
+async function sendHeartbeat(): Promise<void> {
+  const manifest = browser.runtime.getManifest();
+  const msg: HippoHeartbeat = {
+    type: "heartbeat",
+    extension_version: manifest.version,
+    enabled_state: true,
+    sent_at_ms: Date.now(),
+  };
+  try {
+    await browser.runtime.sendNativeMessage("hippo_daemon", msg);
+  } catch (e) {
+    console.warn("[hippo] heartbeat failed:", e);
+  }
+}
+
+sendHeartbeat();  // on startup
+setInterval(sendHeartbeat, 5 * 60 * 1000);  // every 5 min
+```
+
+**Rust (`crates/hippo-daemon/src/native_messaging.rs`):**
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum NmMessage {
+    #[serde(rename = "visit")]
+    Visit(BrowserVisit),
+    #[serde(rename = "heartbeat")]
+    Heartbeat(ExtensionHeartbeat),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExtensionHeartbeat {
+    pub extension_version: String,
+    pub enabled_state: bool,
+    pub sent_at_ms: i64,
+}
+```
+
+On heartbeat: NM host sends `DaemonRequest::UpdateSourceHealthHeartbeat { source: "browser", ts }` to daemon socket. Daemon handler:
+
+```sql
+UPDATE source_health
+SET last_heartbeat_ts = :ts,
+    updated_at        = :now_ms
+WHERE source = 'browser';
+```
+
+`last_heartbeat_ts` — new column on `source_health` (see D1 cross-ref).
+
+## Exclusion from User Data — Implementation
+
+For enrichment queues, join against event tables with `probe_tag IS NULL`:
+
+```sql
+SELECT eq.* FROM enrichment_queue eq
+JOIN events e ON eq.event_id = e.id
+WHERE eq.status = 'pending' AND e.probe_tag IS NULL ...;
+
+SELECT ceq.* FROM claude_enrichment_queue ceq
+JOIN claude_sessions cs ON ceq.claude_session_id = cs.id
+WHERE ceq.status = 'pending' AND cs.probe_tag IS NULL ...;
+
+SELECT beq.* FROM browser_enrichment_queue beq
+JOIN browser_events be ON beq.browser_event_id = be.id
+WHERE beq.status = 'pending' AND be.probe_tag IS NULL ...;
+```
+
+**Upstream filter wins:** daemon never enqueues probe events in the first place. These downstream filters are belt-and-braces.
+
+## Probe State in source_health
+
+Four columns (all defined in `01-source-health.md`):
+
+- `probe_ok INTEGER` — 1 = last probe succeeded, 0 = failed, NULL = never run
+- `probe_lag_ms INTEGER` — measured round-trip lag in ms; NULL if no round-trip
+- `probe_last_run_ts INTEGER` — epoch ms of last run; NULL if never
+- `last_heartbeat_ts INTEGER` — epoch ms of last extension heartbeat (`browser` only)
+
+## Failure Visibility
+
+Probe results feed **Invariant I-8 (Probe Freshness)** — see `02-invariants.md`. Evaluated by watchdog in step 3.
+
+## Boundary
+
+Probes verify each pipeline is alive, not correct:
+- Events flow from submission to DB row ✓
+- Daemon, socket, buffer, flush functional ✓
+
+Do not verify:
+- Enrichment quality / model output
+- zsh hook registered in user's shell
+- Firefox extension installed (partial — heartbeat helps)
+- Claude Code firing SessionStart hook
+- Redaction working (dedicated test: `hippo redact test`)
+
+Boundary is explicit. Correctness belongs to `cargo test -p hippo-daemon` and `uv run --project brain pytest brain/tests`.
+
+## Cross-References
+
+- `source_health` columns `probe_ok`, `probe_lag_ms`, `probe_last_run_ts`, `last_heartbeat_ts`: `01-source-health.md`.
+- Invariant I-8 (probe freshness): `02-invariants.md`.
+- Watchdog evaluation: `04-watchdog.md` step 3.

--- a/docs/capture-reliability/06-claude-session-watcher.md
+++ b/docs/capture-reliability/06-claude-session-watcher.md
@@ -1,0 +1,324 @@
+# Claude Session Watcher
+
+**TL;DR:** Replace the per-session tmux tailer model with one long-lived `hippo watch-claude-sessions` process under launchd that subscribes to FSEvents on `~/.claude/projects/` and ingests every JSONL as it grows. The SessionStart hook becomes a no-op marker write; all PID-chain, tmux-targeting, and duplicate-tailer failure modes are structurally eliminated.
+
+## Why tmux-per-session Must Go
+
+The current model (SessionStart hook → tmux new-window → `hippo ingest claude-session --inline`) has regressed four times in six weeks. Each regression maps to a structural deficiency, not an implementation bug.
+
+| # | Failure mode | Where it recurred | Root nature |
+|---|---|---|---|
+| 1 | Tmux targeting fragility | `-t` flag (current sev1, 1330113); prior base-index mismatches | Three independent guess-axes: session name, target flag, index semantics |
+| 2 | Daemon-down silent loss | Reproduced on `hippo daemon restart` mid-session | Tailer's fire-and-forget writes during daemon outage go to fallback JSONL but tailer never retries |
+| 3 | Hook silent exit-0 | Reproduced when `python3` absent from launchd PATH | `2>/dev/null` + empty fallback yields empty `TRANSCRIPT_PATH`, hook exits 0 |
+| 4 | Duplicate tailers on resume | Reproduced on re-launching Claude in same project | SessionStart fires again; second tailer spawns on same JSONL from offset 0 |
+| 5 | PID-chain walk breaks under wrappers | Reproduced with `claade` wrapper | `$PPID` assumption fails whenever a wrapper is added |
+| 6 | File-not-yet-exists at hook time | Every session start | Claude fires hook BEFORE creating JSONL; tailer polls via `--wait-for-file 30`; batch fallback silently drops if tmux absent |
+
+The correct fix is architectural: remove the entire mechanism. None of these failure modes exist in a long-lived FS-watcher.
+
+## Architecture Overview
+
+```
+~/.claude/projects/**/*.jsonl  (APFS/HFS+)
+        │
+        │  FSEvents via notify crate
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│         hippo watch-claude-sessions  (launchd, KeepAlive)    │
+│                                                              │
+│  Startup: walk ~/.claude/projects → upsert offset rows       │
+│  Runtime: notify → modified → read from offset               │
+│           parse JSONL → EventEnvelope                        │
+│           advance byte_offset in same SQLite tx              │
+│                                                              │
+│  State: claude_session_offsets (hippo.db)                    │
+└──────────────────────┬───────────────────────────────────────┘
+                       │  Unix socket (fire-and-forget,
+                       │  same protocol as shell hook)
+                       ▼
+              hippo-daemon  (launchd, KeepAlive)
+                       │
+                       ▼
+           claude_sessions table  (hippo.db)
+```
+
+Single Rust binary sub-command (`hippo watch-claude-sessions`) registered as launchd agent. Never spawns subprocesses. Reads directly from FS, writes to daemon socket via the identical `send_event_fire_and_forget` path the shell hook uses (`crates/hippo-daemon/src/commands.rs:104`).
+
+## State Schema
+
+```sql
+-- Schema v8 migration
+CREATE TABLE IF NOT EXISTS claude_session_offsets (
+  path              TEXT PRIMARY KEY,
+  session_id        TEXT,                 -- UUID from first JSONL line; NULL until parsed
+  byte_offset       INTEGER NOT NULL DEFAULT 0,
+  last_read_ts      INTEGER NOT NULL,
+  last_segment_ts   INTEGER,              -- distinct: read can yield 0 parseable lines
+  inode             INTEGER,              -- detect file recreation
+  device            INTEGER,              -- paired with inode for identity
+  size_at_last_read INTEGER,              -- detect truncation
+  created_at        INTEGER NOT NULL DEFAULT (unixepoch('now','subsec')*1000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_offsets_session
+  ON claude_session_offsets(session_id);
+```
+
+**Column rationale:**
+
+- `path` (PK) canonical absolute path; updates on Rename
+- `session_id` extracted from first parseable `sessionId` field; NULL allows row creation before content
+- `byte_offset` resume cursor; advanced only inside same tx as segment upsert
+- `last_read_ts` heartbeat for staleness detection
+- `last_segment_ts` distinct — read-without-content vs abandoned mid-session
+- `inode` + `device` file identity fingerprint; inode change = recreation → reset offset
+- `size_at_last_read` truncation guard; `stat.size < size_at_last_read` → reset offset
+- `created_at` auditing only
+
+## Discovery
+
+**Startup scan:** Recursive walk of `~/.claude/projects/`. For each `*.jsonl`:
+
+```rust
+let meta = std::fs::metadata(&path)?;
+conn.execute(
+    "INSERT OR IGNORE INTO claude_session_offsets
+     (path, byte_offset, last_read_ts, inode, device, size_at_last_read)
+     VALUES (?1, 0, ?2, ?3, ?4, ?5)",
+    params![path_str, now_ms, meta.ino(), meta.dev(), meta.len()],
+)?;
+```
+
+`INSERT OR IGNORE` preserves existing offsets across restarts.
+
+**Continuous FS subscription:** notify crate, FSEvents on macOS:
+
+| Event | Action |
+|---|---|
+| Create | Upsert offset row with offset=0; schedule immediate read |
+| Modify (data) | Lookup offset; read from stored position |
+| Remove | Mark for deferred deletion after 60s grace |
+| Rename | `UPDATE offsets SET path=? WHERE path=?`; keep offset |
+| Modify (metadata only) | No-op |
+
+**FSEvents coalescing:** macOS batches events by 10ms–1s, up to 30s under load. Target: all events processed within 5s. Read loop tolerates Modify on unchanged file (reads 0 bytes).
+
+**NFS/iCloud known-unknown:** `~/.claude/projects` on networked mount may not fire FSEvents reliably. Fallback config:
+
+```toml
+[capture]
+# claude_session_poll_interval_secs = 2   # only if ~/.claude/projects is NFS/iCloud
+```
+
+Detection: startup warning if not on local APFS/HFS+ (`statfs` `f_fstypename`).
+
+## Reading and Parsing
+
+### Per-file Read Loop
+
+1. Open file
+2. `stat` → `(inode, device, size)`
+3. Compare against stored values:
+   - `inode` or `device` changed → reset `byte_offset=0`
+   - `size < size_at_last_read` → reset (truncation)
+4. Seek to `byte_offset`
+5. Read to EOF
+6. Split on `\n`; last chunk may be partial
+
+**Partial-line safety:** If buffer doesn't end in `\n`, last "line" is incomplete. Do not parse. Do not advance offset past it.
+
+```rust
+let mut last_complete_offset = byte_offset;
+for line in chunks {
+    if line.ends_with('\n') {
+        last_complete_offset += line.len() as u64 + 1;  // +1 for '\n'
+    }
+    // partial: don't advance
+}
+// Only advance to last_complete_offset, not to EOF
+```
+
+This generalizes the existing tail logic in `crates/hippo-daemon/src/claude_session.rs:483–519`.
+
+### Parsing
+
+Reuse existing `process_line` from `crates/hippo-daemon/src/claude_session.rs:194`. No new parsing. Watcher is a consumer, not a reimplementation.
+
+Maintains per-file `HashMap<PathBuf, (HashMap<String, PendingToolUse>, HashMap<String, Option<String>>)>` matching in-memory state of current `ingest_tail` at `claude_session.rs:425–427`.
+
+### Transactional Offset Advancement
+
+After a batch of lines for one file is parsed and envelopes are sent:
+
+```sql
+-- single transaction:
+UPDATE claude_session_offsets
+SET byte_offset = ?new_offset,
+    last_read_ts = ?now,
+    last_segment_ts = ?segment_ts,
+    size_at_last_read = ?current_size
+WHERE path = ?path;
+```
+
+Committed only after socket sends complete (or fallback written). Transaction failure → offset not advanced → next cycle re-reads (idempotent via `idx_events_envelope_id` and `UNIQUE (session_id, segment_index)`).
+
+### Malformed-line Handling
+
+`process_line` returns `Err` → do not crash:
+1. `tracing::warn!(path=%path, byte_offset, "malformed JSONL, skipping")`
+2. Advance offset past bad line
+3. Bump `source_health.claude-session.consecutive_failures`
+4. Continue
+
+Matches existing pattern at `claude_session.rs:488–496`.
+
+### Per-file Read Timeout
+
+```rust
+let result = tokio::time::timeout(
+    Duration::from_secs(30),
+    read_and_process_file(&path, &mut state),
+).await;
+if result.is_err() {
+    tracing::warn!(path=%path, "read timeout, backoff 60s");
+    backoff_set.insert(path.clone(), now + Duration::from_secs(60));
+}
+```
+
+## File Lifecycle Edge Cases
+
+| Scenario | Detection | Action |
+|---|---|---|
+| Session resumed (append) | `inode` unchanged; `size > size_at_last_read` | Normal: seek, read new content. Unique index absorbs any dedup. |
+| Truncated/rewritten | `size < size_at_last_read` OR `inode` changed | Reset `byte_offset=0`. Re-read entire file. `UNIQUE` constraint absorbs dupes. |
+| Moved/archived | Rename `from→to` | `UPDATE offsets SET path=new`. Offset preserved. |
+| Project dir deleted | Remove cascade | Defer offset deletion 60s (APFS atomic rename-replace protection). |
+| File created → immediately written | Create + Modify | Offset row inserted on Create; Modify triggers first read. |
+| Watcher down when session started | Startup scan on restart | Finds JSONL, inserts offset row, reads entire file. Same as `--batch` import. |
+
+## SessionStart Hook in New Model
+
+Reduced to 8 lines:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('session_id',''))" \
+    2>/dev/null || true)
+
+[ -z "$SESSION_ID" ] && exit 0
+
+MARKER_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/hippo/claude-seen"
+mkdir -p "$MARKER_DIR"
+touch "${MARKER_DIR}/${SESSION_ID}"
+```
+
+Marker is belt-and-braces for "watcher was down when session started." Startup FS scan alone is sufficient.
+
+### Feature Flag Transition
+
+```toml
+[capture]
+# "watcher" (default after Phase B) or "tmux-tailer" (Phase A default)
+claude_session_mode = "tmux-tailer"
+```
+
+Hook branches on flag. Retire tmux-spawn branch in Phase C.
+
+## Launchd Plist
+
+New file: `launchd/com.hippo.claude-session-watcher.plist` with `KeepAlive=true`, `RunAtLoad=true`. No hard daemon dependency (launchd user agents don't support it without SMJobBless). Watcher implements soft startup retry — exponential backoff up to 30 s on first socket connect failure.
+
+Installed via `hippo daemon install` (extend `crates/hippo-daemon/src/main.rs:244`).
+
+## Failure and Recovery Modes
+
+**Watcher crashes:** `KeepAlive=true` restarts. Startup scan + `INSERT OR IGNORE` preserves offsets. Zero loss, zero re-ingestion. Worst case: lines written between last offset update and crash (atomic with segment upsert, so window ≤ one segment boundary).
+
+**Daemon down:** `send_event_fire_and_forget` fails → fallback JSONL write at `config.fallback_dir()` (`commands.rs:336`). On daemon recovery, `recover_fallback_files` drains (`storage.rs:813`). **Critical difference from tmux model:** watcher does NOT advance `byte_offset` if fallback also fails. Retries next Modify event. Closes silent-loss failure mode #2.
+
+**Offset table corruption:** Bootstrap mode rebuilds from `claude_sessions.MAX(end_time)` per session. Triggered by `hippo watch-claude-sessions --rebuild-offsets`. Fallback: set offset=0, re-ingest idempotently (unique index).
+
+**Stalled on large JSONL:** 30 s timeout + 60 s backoff (see §6).
+
+## Migration Plan
+
+**Phase A — Dual-run (one release):** Watcher ships alongside hook. Flag default `tmux-tailer`. Both run simultaneously. Dedup absorbs overlap. Observability: compare row counts per path over 48 h. Exit criterion: watcher ≥ tailer, no misses.
+
+**Phase B — Watcher default (next release):** Flip default. Hook reduces to marker-write path. Tmux windows no longer spawned.
+
+**Phase C — Hook simplification (following release):** Delete tmux branch entirely. Script becomes 8-line marker writer. Remove feature flag.
+
+## Interaction with source_health
+
+Two rows:
+
+| `source` | Semantics |
+|---|---|
+| `'claude-session'` | Data-path health: last ingest, consecutive failures |
+| `'claude-session-watcher'` | Process health: 30 s heartbeat regardless of file activity |
+
+**Rationale:** `'claude-session'` silent could mean no sessions (expected) OR watcher broken (critical). `'claude-session-watcher'` silent unambiguously means dead process. Separate rows allow doctor to distinguish.
+
+**Heartbeat (every 30 s):**
+```sql
+INSERT INTO source_health (source, updated_at) VALUES ('claude-session-watcher', ?now)
+ON CONFLICT(source) DO UPDATE SET updated_at = excluded.updated_at;
+```
+
+**Successful segment (same tx as upsert):**
+```sql
+INSERT INTO source_health (source, last_event_ts, consecutive_failures, updated_at)
+VALUES ('claude-session', ?now, 0, ?now)
+ON CONFLICT(source) DO UPDATE SET
+    last_event_ts = excluded.last_event_ts,
+    consecutive_failures = 0,
+    updated_at = excluded.updated_at;
+```
+
+**Failure:**
+```sql
+INSERT INTO source_health (source, consecutive_failures, updated_at)
+VALUES ('claude-session', 1, ?now)
+ON CONFLICT(source) DO UPDATE SET
+    consecutive_failures = source_health.consecutive_failures + 1,
+    updated_at = excluded.updated_at;
+```
+
+## Testability
+
+**Unit tests** (in `crates/hippo-daemon/src/watch_claude_sessions.rs`):
+- Offset math / partial-line handling
+- Truncation detection
+- Inode change detection
+- Malformed line skip
+
+**Integration test** (`crates/hippo-daemon/tests/claude_session_watcher_integration.rs`):
+- Spawn watcher with temp `HIPPO_DATA_HOME`
+- Write Claude-shaped JSONL lines
+- Assert daemon socket receives `IngestEvent` frames
+- Assert offset advances to final `\n`
+
+**End-to-end:** Real daemon + watcher → synthetic JSONL stream → assert `claude_sessions` rows with correct `session_id` and `segment_index`.
+
+**Property test** (proptest/quickcheck):
+- Random JSONL stream + random truncation/rename/append
+- Assert: no loss (total events = line count), no double-counting (envelope_ids unique), offset ≤ stat().size, post-mutation `ingest_batch` produces 0 new rows
+
+## Known-Unknowns
+
+- **APFS snapshots (Time Machine):** Read-only; FSEvents doesn't fire for snapshot writes. Live file still fires — expected benign. Verify during active TM backup.
+- **Claude subagent sessions:** `claude_sessions` has `is_subagent` and `parent_session_id` columns. Unclear whether subagents get distinct JSONLs or share parent's. Verify empirically before shipping. If distinct: watcher handles automatically. If shared: `process_line` already tracks by `tool_use_id` (globally unique).
+- **`claade` wrapper:** Under new model, irrelevant — watcher detects via FS, not PID chain. Confirm by reading the wrapper script for any transcript-path redirection.
+- **Multiple Claude instances on same project:** Both append to same JSONL. `process_line` tracks by `tool_use_id`. Exercise in property test.
+
+## Cross-References
+
+- **D1:** Two `source_health` rows (`claude-session` + `claude-session-watcher`) require `consecutive_failures` and `last_event_ts` columns — both present in D1 schema.
+- **D2 (I-2):** Watcher is new implementation target for I-2.
+- **D3:** Doctor live-JSONL-vs-DB reconciliation uses `claude_session_offsets` — for each JSONL with `last_read_ts > 5min ago`, assert `byte_offset == stat(path).size`. Catches stalled watcher.
+- **D3 (probes):** Claude-session assertion probe verifies watcher SLA.

--- a/docs/capture-reliability/07-roadmap.md
+++ b/docs/capture-reliability/07-roadmap.md
@@ -1,0 +1,134 @@
+# Capture-Reliability Overhaul: Implementation Roadmap
+
+**TL;DR:** The overhaul ships in four phases across ~7 days using parallel agent teams. P0 lands the schema foundation same-day; every subsequent phase builds on it without big-bang migrations. Each PR is independently mergeable and carries a verification test.
+
+## Guiding Principles
+
+- **Reliability-per-effort first.** PRs ordered by invariant coverage / implementation risk. `source_health` table (P0.1) unlocks every other check and comes first.
+- **Narrow, independently mergeable PRs.** No PR touches more than one logical subsystem. Parallel worktrees avoid merge conflicts.
+- **No big-bang migrations.** Structural changes (FS watcher, probes) feature-flagged and dual-run before old path removal.
+- **Verification before merge.** Every PR adds or updates at least one automated assertion that the new invariant holds.
+
+---
+
+## Phase P0 — Same-Day Foundation (~0.5 days, 4-5 parallel agents)
+
+P0.1 is the only blocking dependency.
+
+| PR | Scope | Files Touched | Owner | Effort | Deps | Invariant | Verification |
+|----|-------|---------------|-------|--------|------|-----------|--------------|
+| **P0.1** | `source_health` table + migration + rolling-count recompute scheduling | `crates/hippo-core/src/schema.sql`, `storage.rs` | schema-migration | ~4h | none | I-1 | `cargo test -p hippo-core -- source_health_table_exists` |
+| **P0.2** | Write paths: `flush_events`, `claude_session.rs`, `native_messaging.rs` upsert `source_health` | `crates/hippo-daemon/src/daemon.rs`, `claude_session.rs`, `native_messaging.rs` | write-paths | ~4h | P0.1 | I-2, I-3 | Integration: write 3 events, assert `source_health.last_event_ts` updated, `consecutive_failures=0` |
+| **P0.3** | Doctor checks 1, 4, 7, 8 (staleness, hook sourced, log size, watchdog stub) | `crates/hippo-daemon/src/commands.rs` | doctor-checks | ~3h | P0.1 | I-4, I-5, I-7 | `cargo test -p hippo-daemon -- doctor_staleness_check` seeded with stale row |
+| **P0.4** | OTel `source` attribute on `events.ingested`, `flush.events`, `fallback.writes` | `crates/hippo-daemon/src/metrics.rs` + call sites | otel-attrs | ~2h | none | I-6 | `#[cfg(feature="otel")]` test that `EVENTS_INGESTED.add` includes `source` key |
+| **P0.5** | Log rotation via `tracing-appender` rolling writer (daily, keep 7) | daemon `main.rs`/`telemetry.rs`, brain `main.py` | log-rotation | ~2h | none | I-7 | Doctor check (P0.3) passes; synthetic rotation test asserts old file renamed |
+
+**Parallelization:** All five launch simultaneously. P0.2 and P0.3 drafted against agreed schema; integrate after P0.1 merges. P0.4 and P0.5 have zero deps.
+
+---
+
+## Phase P1 — Days 2–3 (3 parallel workstreams)
+
+Starts after P0.1 and P0.2 merge. P1.3 additionally waits for P0.3.
+
+| PR | Scope | Files Touched | Owner | Effort | Deps | Invariant | Verification |
+|----|-------|---------------|-------|--------|------|-----------|--------------|
+| **P1.1** | `hippo watchdog` subcommand + `capture_alarms` table + launchd plist + ack CLI + rate limiter | `crates/hippo-daemon/src/watchdog.rs` (new), `schema.sql`, `launchd/com.hippo.watchdog.plist` (new), `main.rs` | watchdog | ~1.5d | P0.1, P0.2 | I-7 (watchdog liveness), I-5 (alarm on consecutive_failures) | Seed `consecutive_failures=5`, run tick, assert alarm row; `notify_macos=false` suppresses `osascript` |
+| **P1.2** | Extension heartbeat (5 min) + NM host forwarding + `probe_tag` column stub + popup badge | `extension/firefox/src/background.ts`, `native_messaging.rs`, `schema.sql` | browser-heartbeat | ~1d | P0.1 | I-4 (extension heartbeat visible) | Unit: synthetic NM heartbeat → `source_health.browser.last_heartbeat_ts` upserted |
+| **P1.3** | Doctor checks 2, 3, 5, 6, 9, 10 | `crates/hippo-daemon/src/commands.rs` | doctor-checks-2 | ~6h | P0.3 merged | I-2, I-5 extended | Each check has negative test |
+
+**Parallelization:** P1.1 and P1.2 fully parallel. P1.3 after P0.3.
+
+---
+
+## Phase P2 — Days 4–7 (2 parallel workstreams)
+
+Highest-risk structural phase. Coordinate schema migration numbers before branching.
+
+| PR | Scope | Files Touched | Owner | Effort | Deps | Invariant | Verification |
+|----|-------|---------------|-------|--------|------|-----------|--------------|
+| **P2.1** | `hippo watch-claude-sessions` + `claude_session_offsets` table + launchd plist + `claude_session_mode` flag + dual-run parity | `crates/hippo-daemon/src/watch_claude_sessions.rs` (new), `schema.sql`, `launchd/com.hippo.claude-session-watcher.plist` (new), `main.rs`, `config/config.toml` | claude-watcher | ~2-3d | P0.1, P0.2 | I-2 (no missed sessions) | Integration: synthetic JSONL → offsets advance, events ingested; parity: tailer and watcher yield identical rows |
+| **P2.2** | Synthetic probes (4 sources) + `probe_tag` column + probe launchd plist + exclusion filter in all user-facing queries | `crates/hippo-daemon/src/probe.rs` (new), `schema.sql`, `launchd/com.hippo.probe.plist` (new), `commands.rs`, brain modules | probes | ~1.5d | P0.1 | I-8 (probe freshness) | Row with `probe_tag='synthetic'` absent from `hippo ask`/`hippo events`; present in `source_health` |
+
+**Parallelization:** Fully parallel. Only shared file is `schema.sql` — assign migration version numbers before branching.
+
+---
+
+## Phase P3 — Cleanup (Day 7+)
+
+Blocked on 48 h dual-run observation. Single sequential workstream.
+
+| Task | Description | Blocks |
+|------|-------------|--------|
+| **P3.1** | Flip `claude_session_mode` default to `watcher`; add doctor warning if `tailer` | P2.1 dual-run clean 48 h |
+| **P3.2** | Delete tmux-spawn from `shell/claude-session-hook.sh`; reduce to marker write | P3.1 merged |
+| **P3.3** | Close investigation issues #49–#53 with findings; update `docs/capture-reliability/` index | P3.2 merged |
+
+---
+
+## Agent-Team Execution Plan
+
+### Team `hippo-capture-p0` — Day 1
+
+4-5 members, each in their own git worktree, PRs targeting `main`.
+
+| Member | Task | Depends On | Output |
+|--------|------|------------|--------|
+| `schema-migration` | `source_health` table, migration, `EXPECTED_VERSION` bump | none | P0.1 |
+| `write-paths` | Upsert `source_health` in 3 write sites; rolling-count recompute | P0.1 merged | P0.2 |
+| `doctor-checks` | Staleness + hook-sourced + log-size + watchdog-stub checks | P0.1 merged | P0.3 |
+| `otel-attrs` | `source` KeyValue on counters | none | P0.4 |
+| `log-rotation` | `tracing-appender` rolling writer | none | P0.5 |
+
+**Consensus review:** After P0.1 merges, team lead reviews P0.2 and P0.3 together to confirm `source_health` upsert semantics match before both merge.
+
+### Team `hippo-capture-p1` — Days 2-3
+
+3 members.
+
+| Member | Task | Depends On | Output |
+|--------|------|------------|--------|
+| `watchdog` | subcommand + alarms table + plist + ack CLI + rate limiter | P0.1, P0.2 | P1.1 |
+| `browser-heartbeat` | TS heartbeat + NM forwarding + `probe_tag` stub + popup badge | P0.1 | P1.2 |
+| `doctor-checks-2` | Remaining 6 doctor checks | P0.3 merged | P1.3 |
+
+**Consensus review:** Team lead reviews all three together; confirm doctor output format consistent across P0.3 and P1.3.
+
+### Team `hippo-capture-p2` — Days 4-7
+
+2 members. Team lead assigns schema migration numbers synchronously.
+
+| Member | Task | Depends On | Output |
+|--------|------|------------|--------|
+| `claude-watcher` | FS-watcher + offsets table + dual-run flag + plist | P0.1, P0.2 | P2.1 |
+| `probes` | Per-source probes + `probe_tag` + plist + exclusion filters | P0.1 | P2.2 |
+
+**Consensus review:** Team lead reviews both; specifically verify probe exclusion filters cover every user-facing query path.
+
+### Team `hippo-capture-p3` — Day 7+
+
+Single `cleanup` agent. Sequential P3.1 → P3.2 → P3.3.
+
+---
+
+## Milestones + Success Criteria
+
+| Milestone | Phase End | Criteria |
+|-----------|-----------|----------|
+| **M1** | P0 | `hippo doctor` reports per-source staleness; future source outage diagnosable via `SELECT * FROM source_health` in < 5 min without log-diving |
+| **M2** | P1 | Watchdog fires alarm row within one poll interval of invariant violation; extension heartbeat visible in `source_health.last_heartbeat_ts` |
+| **M3** | P2 | Claude sessions ingested by FS watcher with zero missed lines (confirmed by dual-run parity); all 4 sources produce probe round-trips every 5 min |
+| **M4** | P3 | tmux-spawn code deleted; investigation issues #49–#53 closed with findings |
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| Migration failure mid-deploy (daemon new schema, brain lags) | Medium | High | Reuse existing `schema_handshake` (v0.13 pattern); block watcher writes until brain agrees on `EXPECTED_SCHEMA_VERSION` |
+| Watchdog alarm fatigue during bring-up | High | Medium | Default `notify_macos = false`; conservative thresholds; opt-in notifications |
+| FSEvents quirks cause watcher to miss events | Low | High | Dual-run mode (`claude_session_mode = "both"`) logs parity mismatches; P3.1 flips only after 48 h clean |
+| `probe_tag` filter missing from a query path | Medium | Medium | P2.2 integration test enumerating all query fns on event tables and asserting exclusion present |
+| Schema version collision between P2.1 and P2.2 worktrees | Low | Low | Team lead assigns migration numbers synchronously before branching; PR template includes `PRAGMA user_version` check |
+| New tmux-targeting patch during P0–P2 | High | Low | AP-10 blocks PRs of this shape; pointer to P2.1 as structural fix |

--- a/docs/capture-reliability/08-anti-patterns.md
+++ b/docs/capture-reliability/08-anti-patterns.md
@@ -1,0 +1,113 @@
+# Capture-Reliability Anti-Patterns
+
+**TL;DR:** Eleven concrete failure modes observed in hippo's capture layer, each with a forbidden behavior, the reason it is forbidden, and the required alternative. Any of these patterns in a PR is a review blocker.
+
+---
+
+## AP-1: Blocking the Shell Hook on Health Writes
+
+**Forbidden.** Writing to `source_health` or any SQLite table synchronously inside `shell/claude-session-hook.sh`, or inside `send_event_fire_and_forget` in `crates/hippo-daemon/src/commands.rs`.
+
+**Why.** The shell hook runs in the user's interactive prompt critical path. The `&!` disown pattern exists to keep the hook from adding perceptible latency. `send_event_fire_and_forget` documents its durability contract at `commands.rs:96–103`: success means the frame hit the socket, not that SQLite was touched. Health writes belong in `flush_events` (background Tokio timer).
+
+**The right way.** `source_health` is updated inside `flush_events` (`daemon.rs`) after the batch write succeeds or fails. Shell hook writes nothing to disk; sends one fire-and-forget frame and returns.
+
+---
+
+## AP-2: Coupling Capture Health to Enrichment Health
+
+**Forbidden.** Setting `source_health.status = 'degraded'` because LM Studio is unreachable, the `enrichment_queue` is backed up, or `hippo-brain` is offline.
+
+**Why.** Orthogonal failure domains. Capture has operated correctly while enrichment was offline for days. Coupling them means a routine LM Studio model swap triggers a false capture alarm. `hippo doctor` already separates brain health from daemon health; `source_health` must maintain the same boundary. See I-10.
+
+**The right way.** `source_health` tracks only capture-layer observables: `last_event_ts`, `consecutive_failures`, `events_last_1h/24h`. Enrichment health lives in the brain `/health` endpoint. Watchdog fires alarms only on capture metrics; never inspects `enrichment_queue` depth.
+
+---
+
+## AP-3: Alerting on Absolute Silence Without Upstream Context
+
+**Forbidden.** Firing `capture_alarms` or macOS notification whenever `source_health.last_event_ts` is older than N minutes, unconditionally.
+
+**Why.** Shell silence overnight is normal. Browser silence is normal when Firefox is closed. Unconditional alarms train users to dismiss them — and they'll dismiss a real outage for the same reason. Alerting must distinguish "user active, source silent" from "user asleep, source correctly quiet."
+
+**The right way.** Watchdog gates silence alarms on corroborating signals: terminal is frontmost app, recent keystroke activity, source process confirmed running (`pgrep -x firefox` for browser, `pgrep -x zsh` + HIDIdleTime for shell). Thresholds per-source, configurable, conservative defaults.
+
+---
+
+## AP-4: Adding Notification Types Outside the Single Alarm Channel
+
+**Forbidden.** Calling `osascript -e 'display notification'` from anywhere other than the watchdog's `notify_macos` path. Adding a new `capture_alarms.alarm_type` without updating the rate-limiter.
+
+**Why.** Hippo already has multiple notification paths (doctor, version mismatch, brain error). Fragmented paths cannot be rate-limited uniformly. Users will disable all hippo notifications after three spurious alerts during bring-up.
+
+**The right way.** One notification channel: watchdog reads `capture_alarms`, applies rate limit (1 macOS notification per invariant per hour via `last_notified_at`), calls `osascript` once per qualifying alarm. `notify_macos` defaults to `false`. All other code paths write to `capture_alarms` and let the watchdog decide.
+
+---
+
+## AP-5: Reinventing Metrics Storage Alongside OTel
+
+**Forbidden.** Adding in-process `HashMap<String, u64>` or `AtomicU64` metrics store for per-source event counts, then exposing via a new HTTP endpoint or a new SQLite table distinct from `source_health`.
+
+**Why.** `crates/hippo-daemon/src/metrics.rs` already defines OTel counters (`EVENTS_INGESTED`, `FLUSH_EVENTS`, `FALLBACK_WRITES`). A parallel store diverges from the OTel pipeline, creates two sources of truth, and is invisible to Grafana/Prometheus. This mistake happened once already — `MetricsCollector` in the brain was a parallel store noted in CLAUDE.md "for future OTel export" that was never wired.
+
+**The right way.** Add `source` `KeyValue` attribute to existing OTel counters (P0.4). Aggregates for `source_health` rolling counts computed from SQLite event tables by the recompute job, not in-process. Do not create new HTTP metrics endpoints; Prometheus scrape already exists behind `otel` feature flag.
+
+---
+
+## AP-6: Letting Probes Appear in User-Facing Queries
+
+**Forbidden.** Inserting synthetic probe events into `events`, `claude_sessions`, or `browser_events` without filtering them from every user-facing query: `hippo ask`, `hippo events`, `hippo sessions`, MCP `search_events`, `search_knowledge`, `get_entities`.
+
+**Why.** A probe in RAG retrieval produces nonsense answers. A probe in `hippo events` output makes the user think they ran a command they didn't. Probe contamination is hard to detect after the fact — probe rows look structurally identical to real rows.
+
+**The right way.** Every probe row has `probe_tag TEXT NOT NULL` set to a non-null sentinel. Every query touching event tables adds `AND probe_tag IS NULL` (or `NOT LIKE 'synthetic%'`). P2.2 ships a Rust integration test asserting this filter in all query paths. **Upstream filter is load-bearing:** daemon never enqueues probe events — downstream filters are belt-and-braces.
+
+---
+
+## AP-7: Making `hippo doctor` Slower Than 2 Seconds
+
+**Forbidden.** Adding a doctor check that performs HTTP without a timeout, does a full table scan on `events` (millions of rows), spawns an unbounded subprocess, or blocks on brain returning healthy.
+
+**Why.** `hippo doctor` is run interactively, especially during incidents. 10-second doctor is useless when something is on fire. Current LM Studio check already enforces 1-second timeout; that constraint extends to every new check.
+
+**The right way.** All new SQL uses indexed columns only. HTTP checks carry 1-second timeout. Any check that can't complete in 500 ms on a loaded machine moves to `hippo doctor --full`. Total wall-clock asserted under 2 s in CI.
+
+---
+
+## AP-8: Leaving the Watchdog Itself Unmonitored
+
+**Forbidden.** Shipping the watchdog (P1.1) without a mechanism to detect that the watchdog process has stopped.
+
+**Why.** Watchdog is launchd-managed. LaunchAgents fail to load silently on plist errors or post-update binary moves. A dead watchdog means every downstream invariant stops firing while the user believes they're being monitored — strictly worse than no watchdog.
+
+**The right way.** Watchdog writes heartbeat timestamp to `source_health WHERE source='watchdog'` on every cycle. Doctor check 8 (P0.3 stub, completed in P1.3) reads it and emits `[!!]` if older than `2 * poll_interval`. Watchdog also sets `HIPPO_WATCHDOG_VERSION` env so `hippo doctor --versions` confirms binary alignment.
+
+---
+
+## AP-9: Deleting the Fallback JSONL Path
+
+**Forbidden.** Removing `storage::write_fallback_jsonl`, removing fallback branches in `flush_events`, or omitting fallback from any new ingestion path — even in P3 cleanup.
+
+**Why.** Fallback JSONL is the last-resort durability backstop: catches events when SQLite is locked, DB is corrupt, or daemon mid-restart. Contract documented at `commands.rs:96–103`. At least one real event-loss incident was fully recovered from fallback files. No substitute.
+
+**The right way.** Fallback path stays permanently. What improves is observability: P0.3 alarms on fallback > 24 h old (not replayed); P1.3 alarms on fallback count exceeding threshold. Accumulating fallback files are a symptom; response is to diagnose root cause, not remove the backstop.
+
+---
+
+## AP-10: Patching tmux Window Targeting Instead of Shipping P2.1
+
+**Forbidden.** Submitting any PR modifying tmux window creation, tmux session targeting, or the `TMUX_TARGET_SESSION` path in `shell/claude-session-hook.sh` to address a session-ingestion regression while P2.1 is in flight.
+
+**Why.** Tmux-targeting code has been patched at least four times for variations of the same bug class: index conflicts, session-name collisions, non-default `base-index`, `$TMUX_PANE` unset. Each patch introduces a new edge case. The structural fix is the long-lived FS watcher (P2.1), which eliminates the tmux dependency entirely. Patching again delays P2.1 without eliminating fragility.
+
+**The right way.** Any session-ingestion regression during P0–P2 is triaged against the P2.1 branch. If data loss is occurring, manual recovery is `hippo ingest claude-session --batch <path>`. New tmux-targeting patch is rejected at review with: "This is within the scope of P2.1. Merge P2.1 rather than patching tmux targeting for a fifth time."
+
+---
+
+## AP-11: Silently Swallowing Capture Errors
+
+**Forbidden.** Using `.filter_map(|r| r.ok())`, `.ok().unwrap_or_default()`, or `.ok()` on a `Result` inside any capture write path without logging the error and bumping a failure counter.
+
+**Why.** Silent swallowing turns capture bugs invisible. `flush_events` in `daemon.rs` already demonstrates the correct pattern: every `Err(e)` branch calls `warn!`, writes to fallback, and calls `state.drop_count.fetch_add`. Failure is counted, logged, recoverable. Iterator patterns like `.filter_map(|r| r.ok())` produce zero log output when half the writes fail.
+
+**The right way.** Every error in a capture write path either propagates to the caller or, where continuation is required (batch processing), calls `warn!` with the full error and increments `consecutive_failures` in `source_health`. Clippy lint `clippy::result_map_unit_fn` and custom Semgrep rule flag silent-swallow in CI.


### PR DESCRIPTION
…watcher, roadmap, anti-patterns

Completes the capture-reliability design series started by 9caad39.

- 02-invariants.md — I-1..I-10 formal specs with thresholds and context-awareness rules
- 03-doctor-upgrades.md — 10 new doctor checks with SQL, thresholds, exit-code strategy
- 04-watchdog.md — separate launchd process, capture_alarms table, ack CLI, rate limiter
- 05-synthetic-probes.md — per-source canaries with probe_tag exclusion; extension heartbeat protocol
- 06-claude-session-watcher.md — retire tmux-tailer; long-lived FS-watcher with offset table
- 07-roadmap.md — phased delivery (P0-P3) with parallel agent-team assignments
- 08-anti-patterns.md — 11 forbidden patterns with rationale and alternatives

01-source-health.md extended with probe_last_run_ts, last_heartbeat_ts columns and claude-session-watcher source row, per cross-section requests from 05 and 06.

Context: derived from the sev1 capture-reliability investigation on 2026-04-22 (zero browser events for 21 days; Claude sessions dropping since 2026-04-08). Hotfixes landed separately in #54 (extension dist/) and #55 (tmux -t flag). Investigation issues filed as #49-#53.