### PR TITLE
fix(ingest): batch claude-session now writes claude_sessions rows (#58)

### DIFF
--- a/crates/hippo-daemon/src/claude_session.rs
+++ b/crates/hippo-daemon/src/claude_session.rs
@@ -8,6 +8,8 @@ use chrono::{DateTime, Utc};
 use hippo_core::events::{
     CapturedOutput, EventEnvelope, EventPayload, GitState, ShellEvent, ShellKind,
 };
+use hippo_core::redaction::RedactionEngine;
+use rusqlite::{Connection, params};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -15,6 +17,20 @@ use crate::commands::send_event_fire_and_forget;
 
 /// Maximum bytes to store in CapturedOutput
 const MAX_OUTPUT_BYTES: usize = 4096;
+
+/// Gap between user prompts that forces a new segment (5 minutes in ms).
+///
+/// Kept in lockstep with `TASK_GAP_MS` in
+/// `brain/src/hippo_brain/claude_sessions.py`. Tasks separated by more than
+/// this gap are considered distinct work units and get their own enrichment.
+const SEGMENT_GAP_MS: i64 = 5 * 60 * 1000;
+
+/// Maximum accumulated free-text chars before forcing a segment split.
+///
+/// Matches `max_prompt_chars` default in the Python `extract_segments`.
+/// Prevents runaway single segments from exceeding the enrichment model's
+/// context window.
+const MAX_SEGMENT_CHARS: usize = 12_000;
 
 /// Pending tool use waiting for its result
 struct PendingToolUse {
@@ -325,12 +341,613 @@ fn process_line(
     Ok(envelopes)
 }
 
+/// A parsed conversation segment to upsert into the `claude_sessions` table.
+///
+/// Mirrors the Python `SessionSegment` in
+/// `brain/src/hippo_brain/claude_sessions.py`. Populated directly from a
+/// Claude Code JSONL transcript without going through the daemon socket so
+/// the batch importer can survive without brain running.
+#[derive(Debug, Clone)]
+struct SessionSegment {
+    session_id: String,
+    project_dir: String,
+    cwd: String,
+    git_branch: Option<String>,
+    segment_index: i64,
+    start_time: i64,
+    end_time: i64,
+    user_prompts: Vec<String>,
+    assistant_texts: Vec<String>,
+    tool_calls: Vec<ToolCallSummary>,
+    message_count: i64,
+    token_count: i64,
+    source_file: String,
+    is_subagent: bool,
+    parent_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct ToolCallSummary {
+    name: String,
+    summary: String,
+}
+
+/// Describes how a JSONL path decomposes into the fields the `claude_sessions`
+/// row needs. We derive these from the filesystem layout Claude Code uses:
+///
+/// ```text
+/// <projects-root>/<project-encoded>/<session-uuid>.jsonl              (main)
+/// <projects-root>/<project-encoded>/<parent-uuid>/subagents/<id>.jsonl (subagent)
+/// ```
+///
+/// `project_dir` is the encoded project directory name (e.g.
+/// `-Users-carpenter-projects-hippo`). We keep the encoded form because the
+/// Python ingester uses the same value — mixing encodings between paths would
+/// make dedupe-by-(session_id, segment_index) lookups miss.
+struct SessionFile<'a> {
+    path: &'a Path,
+    project_dir: String,
+    session_id: String,
+    is_subagent: bool,
+    parent_session_id: Option<String>,
+}
+
+impl<'a> SessionFile<'a> {
+    fn from_path(path: &'a Path) -> Self {
+        let session_id = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        // Detect `<project>/<parent-uuid>/subagents/<id>.jsonl`.
+        let parent = path.parent();
+        let is_subagent =
+            parent.and_then(|p| p.file_name()).and_then(|n| n.to_str()) == Some("subagents");
+
+        let (project_dir, parent_session_id) = if is_subagent {
+            // parent = <project>/<parent-uuid>/subagents
+            // grandparent = <project>/<parent-uuid>
+            // great-grandparent = <project>
+            let grandparent = parent.and_then(|p| p.parent());
+            let project = grandparent.and_then(|p| p.parent());
+            let parent_uuid = grandparent
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .map(|s| s.to_string());
+            let project_name = project
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string();
+            (project_name, parent_uuid)
+        } else {
+            // parent = <project>
+            let project_name = parent
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string();
+            (project_name, None)
+        };
+
+        Self {
+            path,
+            project_dir,
+            session_id,
+            is_subagent,
+            parent_session_id,
+        }
+    }
+}
+
+/// Extract a concise summary from a `tool_use` content block. Port of the
+/// Python `_extract_tool_summary`.
+fn extract_tool_summary(block: &serde_json::Value) -> Option<ToolCallSummary> {
+    let name = block.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    if name.is_empty() {
+        return None;
+    }
+    let inp = block
+        .get("input")
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(Default::default()));
+
+    let summary = match name {
+        "Bash" => inp
+            .get("command")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .chars()
+            .take(200)
+            .collect::<String>(),
+        "Read" | "Write" | "Edit" => inp
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        "Grep" => {
+            let pattern = inp.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            let path = inp.get("path").and_then(|v| v.as_str()).unwrap_or("");
+            if path.is_empty() {
+                pattern.to_string()
+            } else {
+                format!("{} in {}", pattern, path)
+            }
+        }
+        "Glob" => inp
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        "Agent" => inp
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .chars()
+            .take(100)
+            .collect::<String>(),
+        _ => {
+            // Generic: stringify first key=value pair, trimmed to 80 chars.
+            if let Some(obj) = inp.as_object()
+                && let Some((k, v)) = obj.iter().next()
+            {
+                let v_str = match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                let truncated: String = v_str.chars().take(80).collect();
+                format!("{}={}", k, truncated)
+            } else {
+                String::new()
+            }
+        }
+    };
+
+    Some(ToolCallSummary {
+        name: name.to_string(),
+        summary,
+    })
+}
+
+/// Extract human-typed text from a `user` message, filtering out
+/// system/tool-result content. Port of the Python `_extract_user_text`.
+fn extract_user_text(msg: &serde_json::Value) -> Option<String> {
+    // msg can be a JSON string, or a dict with `content` that is either a
+    // string or an array of content blocks. Skip anything that looks like
+    // Claude-Code tooling noise (wrapped in `<...>` tags).
+    if let Some(s) = msg.as_str() {
+        let trimmed = s.trim();
+        if trimmed.is_empty() || trimmed.starts_with('<') {
+            return None;
+        }
+        return Some(trimmed.to_string());
+    }
+
+    let content = msg.get("content")?;
+    if let Some(s) = content.as_str() {
+        let trimmed = s.trim();
+        if trimmed.is_empty() || trimmed.starts_with('<') {
+            return None;
+        }
+        return Some(trimmed.to_string());
+    }
+
+    if let Some(arr) = content.as_array() {
+        let texts: Vec<String> = arr
+            .iter()
+            .filter_map(|block| {
+                if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                    let text = block.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() && !trimmed.starts_with('<') {
+                        Some(trimmed.to_string())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if texts.is_empty() {
+            None
+        } else {
+            Some(texts.join("\n"))
+        }
+    } else {
+        None
+    }
+}
+
+/// Extract text excerpts and tool calls from an assistant message. Port of
+/// the Python `_extract_assistant_text`.
+fn extract_assistant_content(msg: &serde_json::Value) -> (Vec<String>, Vec<ToolCallSummary>) {
+    let mut texts = Vec::new();
+    let mut tools = Vec::new();
+    let arr = match msg.get("content").and_then(|c| c.as_array()) {
+        Some(a) => a,
+        None => return (texts, tools),
+    };
+    for block in arr {
+        let ty = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if ty == "text" {
+            let text = block
+                .get("text")
+                .and_then(|t| t.as_str())
+                .unwrap_or("")
+                .trim();
+            if text.len() > 20 {
+                // Truncate long reasoning blocks.
+                let truncated: String = text.chars().take(300).collect();
+                texts.push(truncated);
+            }
+        } else if ty == "tool_use"
+            && let Some(tc) = extract_tool_summary(block)
+        {
+            tools.push(tc);
+        }
+    }
+    (texts, tools)
+}
+
+/// Stream a session JSONL and split it into task-boundary segments.
+///
+/// This is the Rust port of `extract_segments` in
+/// `brain/src/hippo_brain/claude_sessions.py`. The split rule matches the
+/// Python side (5-minute gap between user prompts OR accumulated content
+/// over `MAX_SEGMENT_CHARS`) so that backfills from this path produce the
+/// same `claude_sessions` rows a fresh brain scan would.
+///
+/// `redaction` — applied to `user_prompts`, `assistant_texts`, and each
+/// tool-call summary. Matches the Python `redact_segment_secrets` step; the
+/// builtin pattern set is shared with `hippo_brain.redaction`.
+fn extract_segments(
+    session_file: &SessionFile,
+    redaction: &RedactionEngine,
+) -> Result<Vec<SessionSegment>> {
+    let file = std::fs::File::open(session_file.path)
+        .with_context(|| format!("failed to open {}", session_file.path.display()))?;
+    let reader = std::io::BufReader::new(file);
+
+    let mut segments: Vec<SessionSegment> = Vec::new();
+    let mut current: Option<SessionSegment> = None;
+    let mut current_chars: usize = 0;
+    let mut last_user_time_ms: i64 = 0;
+
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let entry: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let entry_type = entry.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        // Skip noise entries that Python filters out. Keep this list in
+        // sync with the Python `extract_segments` skip list.
+        if matches!(
+            entry_type,
+            "file-history-snapshot" | "progress" | "queue-operation" | "last-prompt"
+        ) {
+            continue;
+        }
+
+        let ts_ms = entry
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+            .map(|dt| dt.timestamp_millis())
+            .unwrap_or(0);
+
+        let cwd = entry
+            .get("cwd")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let git_branch = entry
+            .get("gitBranch")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        // Initialize first segment on any meaningful entry.
+        if current.is_none() && matches!(entry_type, "user" | "assistant" | "system") {
+            let now_ms = if ts_ms > 0 {
+                ts_ms
+            } else {
+                Utc::now().timestamp_millis()
+            };
+            current = Some(SessionSegment {
+                session_id: session_file.session_id.clone(),
+                project_dir: session_file.project_dir.clone(),
+                cwd: cwd.clone(),
+                git_branch: git_branch.clone(),
+                segment_index: segments.len() as i64,
+                start_time: now_ms,
+                end_time: now_ms,
+                user_prompts: Vec::new(),
+                assistant_texts: Vec::new(),
+                tool_calls: Vec::new(),
+                message_count: 0,
+                token_count: 0,
+                source_file: session_file.path.to_string_lossy().into_owned(),
+                is_subagent: session_file.is_subagent,
+                parent_session_id: session_file.parent_session_id.clone(),
+            });
+        }
+
+        let seg = match current.as_mut() {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Check task boundary on user messages.
+        if entry_type == "user" && last_user_time_ms > 0 && ts_ms > 0 {
+            let gap = ts_ms - last_user_time_ms;
+            if gap > SEGMENT_GAP_MS || current_chars > MAX_SEGMENT_CHARS {
+                let has_content = !seg.user_prompts.is_empty()
+                    || !seg.tool_calls.is_empty()
+                    || !seg.assistant_texts.is_empty();
+                if has_content {
+                    let finished = current.take().expect("seg exists");
+                    let next_index = segments.len() as i64 + 1;
+                    segments.push(finished);
+                    current = Some(SessionSegment {
+                        session_id: session_file.session_id.clone(),
+                        project_dir: session_file.project_dir.clone(),
+                        cwd: if cwd.is_empty() {
+                            segments.last().map(|s| s.cwd.clone()).unwrap_or_default()
+                        } else {
+                            cwd.clone()
+                        },
+                        git_branch: git_branch
+                            .clone()
+                            .or_else(|| segments.last().and_then(|s| s.git_branch.clone())),
+                        segment_index: next_index - 1,
+                        start_time: ts_ms,
+                        end_time: ts_ms,
+                        user_prompts: Vec::new(),
+                        assistant_texts: Vec::new(),
+                        tool_calls: Vec::new(),
+                        message_count: 0,
+                        token_count: 0,
+                        source_file: session_file.path.to_string_lossy().into_owned(),
+                        is_subagent: session_file.is_subagent,
+                        parent_session_id: session_file.parent_session_id.clone(),
+                    });
+                    current_chars = 0;
+                }
+            }
+        }
+
+        let seg = match current.as_mut() {
+            Some(s) => s,
+            None => continue,
+        };
+
+        if ts_ms > 0 {
+            seg.end_time = seg.end_time.max(ts_ms);
+        }
+        seg.message_count += 1;
+
+        if !cwd.is_empty() {
+            seg.cwd = cwd;
+        }
+
+        if entry_type == "user" {
+            if ts_ms > 0 {
+                last_user_time_ms = ts_ms;
+            }
+            let msg = entry
+                .get("message")
+                .cloned()
+                .unwrap_or_else(|| entry.get("content").cloned().unwrap_or_default());
+            if let Some(text) = extract_user_text(&msg) {
+                let truncated: String = text.chars().take(500).collect();
+                current_chars += truncated.len();
+                seg.user_prompts.push(redaction.redact(&truncated).text);
+            }
+            if let Some(usage) = msg.get("usage")
+                && let Some(input_tokens) = usage.get("input_tokens").and_then(|v| v.as_i64())
+            {
+                seg.token_count += input_tokens;
+            }
+        } else if entry_type == "assistant" {
+            let msg = entry.get("message").cloned().unwrap_or_default();
+            let (texts, tools) = extract_assistant_content(&msg);
+            current_chars += texts.iter().map(|t| t.len()).sum::<usize>();
+            current_chars += tools.iter().map(|t| t.summary.len()).sum::<usize>();
+            for t in texts {
+                seg.assistant_texts.push(redaction.redact(&t).text);
+            }
+            for t in tools {
+                seg.tool_calls.push(ToolCallSummary {
+                    name: t.name,
+                    summary: redaction.redact(&t.summary).text,
+                });
+            }
+            if let Some(usage) = msg.get("usage")
+                && let Some(output_tokens) = usage.get("output_tokens").and_then(|v| v.as_i64())
+            {
+                seg.token_count += output_tokens;
+            }
+        }
+    }
+
+    // Finalize trailing segment if it has any content.
+    if let Some(last) = current
+        && (!last.user_prompts.is_empty()
+            || !last.tool_calls.is_empty()
+            || !last.assistant_texts.is_empty())
+    {
+        segments.push(last);
+    }
+
+    Ok(segments)
+}
+
+/// Build the human-readable `summary_text` column shipped to enrichment.
+///
+/// Match the Python `build_claude_enrichment_prompt` shape: a labeled header
+/// line, optional timestamp range, a bullet-list of user prompts, a
+/// bullet-list of tool calls, and a joined assistant-text blob. The brain
+/// consumes this text directly as the LLM prompt so the format needs to
+/// stay stable across Rust and Python writers.
+fn build_summary_text(seg: &SessionSegment) -> String {
+    let mut out = String::new();
+    let branch = seg.git_branch.as_deref().unwrap_or("unknown");
+    out.push_str(&format!(
+        "Claude Code session segment (project: {}, branch: {})\n",
+        seg.cwd, branch
+    ));
+    if seg.start_time > 0 && seg.end_time > 0 {
+        let start = DateTime::<Utc>::from_timestamp_millis(seg.start_time)
+            .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+            .unwrap_or_default();
+        let end = DateTime::<Utc>::from_timestamp_millis(seg.end_time)
+            .map(|d| d.format("%H:%M").to_string())
+            .unwrap_or_default();
+        out.push_str(&format!("Time: {} - {}\n", start, end));
+    }
+    if !seg.user_prompts.is_empty() {
+        out.push_str("\nUser prompts:\n");
+        for p in &seg.user_prompts {
+            out.push_str(&format!("- {}\n", p));
+        }
+    }
+    if !seg.tool_calls.is_empty() {
+        out.push_str(&format!("\nTool calls ({}):\n", seg.tool_calls.len()));
+        for t in &seg.tool_calls {
+            out.push_str(&format!("- {}: {}\n", t.name, t.summary));
+        }
+    }
+    if !seg.assistant_texts.is_empty() {
+        out.push_str("\nAssistant reasoning:\n");
+        out.push_str(&seg.assistant_texts.join("\n\n"));
+        out.push('\n');
+    }
+    out
+}
+
+/// Insert extracted segments into `claude_sessions` + enqueue them for
+/// enrichment. Returns `(inserted, skipped)`.
+///
+/// `INSERT OR IGNORE` handles re-imports idempotently against the
+/// `UNIQUE (session_id, segment_index)` constraint — same semantics as the
+/// Python `insert_segment` which swallows `UNIQUE constraint` errors.
+fn insert_segments(conn: &Connection, segments: &[SessionSegment]) -> Result<(usize, usize)> {
+    let mut inserted = 0usize;
+    let mut skipped = 0usize;
+    let now_ms = Utc::now().timestamp_millis();
+
+    for seg in segments {
+        let summary_text = build_summary_text(seg);
+        let tool_calls_json =
+            serde_json::to_string(&seg.tool_calls).unwrap_or_else(|_| "[]".into());
+        let user_prompts_json =
+            serde_json::to_string(&seg.user_prompts).unwrap_or_else(|_| "[]".into());
+        let is_subagent_int: i64 = if seg.is_subagent { 1 } else { 0 };
+
+        let res = conn.execute(
+            "INSERT OR IGNORE INTO claude_sessions
+                (session_id, project_dir, cwd, git_branch, segment_index,
+                 start_time, end_time, summary_text, tool_calls_json,
+                 user_prompts_json, message_count, token_count, source_file,
+                 is_subagent, parent_session_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            params![
+                seg.session_id,
+                seg.project_dir,
+                seg.cwd,
+                seg.git_branch,
+                seg.segment_index,
+                seg.start_time,
+                seg.end_time,
+                summary_text,
+                tool_calls_json,
+                user_prompts_json,
+                seg.message_count,
+                seg.token_count,
+                seg.source_file,
+                is_subagent_int,
+                seg.parent_session_id,
+                now_ms,
+            ],
+        )?;
+
+        if res == 0 {
+            // UNIQUE (session_id, segment_index) collided — already ingested.
+            skipped += 1;
+            continue;
+        }
+
+        let claude_session_id = conn.last_insert_rowid();
+        // Enqueue for enrichment. OR IGNORE so a replay doesn't trip the
+        // UNIQUE (claude_session_id) constraint — belt-and-suspenders since
+        // the parent INSERT was also OR IGNORE.
+        conn.execute(
+            "INSERT OR IGNORE INTO claude_enrichment_queue (claude_session_id, created_at)
+             VALUES (?1, ?2)",
+            params![claude_session_id, now_ms],
+        )?;
+        inserted += 1;
+    }
+
+    Ok((inserted, skipped))
+}
+
+/// Extract segments from a JSONL and upsert them into `claude_sessions`.
+///
+/// Logs but does not fail the caller on per-segment insert errors — the
+/// batch importer should still report event-sender progress honestly even
+/// if a single segment row fails.
+fn write_session_segments(db_path: &Path, path: &Path) -> (usize, usize, usize) {
+    let redaction = RedactionEngine::builtin();
+    let session_file = SessionFile::from_path(path);
+
+    let segments = match extract_segments(&session_file, &redaction) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(path = %path.display(), %e, "failed to extract session segments");
+            return (0, 0, 1);
+        }
+    };
+
+    if segments.is_empty() {
+        return (0, 0, 0);
+    }
+
+    let conn = match hippo_core::storage::open_db(db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(db = %db_path.display(), %e, "failed to open DB for segment write");
+            return (0, 0, 1);
+        }
+    };
+
+    match insert_segments(&conn, &segments) {
+        Ok((inserted, skipped)) => (inserted, skipped, 0),
+        Err(e) => {
+            error!(%e, "failed to insert claude_sessions segments");
+            (0, 0, 1)
+        }
+    }
+}
+
 /// Run the importer in batch mode: read all lines, send all events, exit.
 /// Returns (events_sent, errors).
 pub async fn ingest_batch(
     path: &Path,
     socket_path: &Path,
     timeout_ms: u64,
+    db_path: &Path,
 ) -> Result<(usize, usize)> {
     // path is a Claude session JSONL supplied by the user via `hippo ingest
     // claude-session --batch`. This is a local CLI operating on the user's
@@ -402,6 +1019,22 @@ pub async fn ingest_batch(
             }
         }
     }
+
+    // Second pass: extract conversation segments and upsert into
+    // `claude_sessions`. This is the population path that was missing in
+    // #58 — tool-call events were flowing into `events` but the session
+    // rows needed for enrichment never got written. We go direct to SQLite
+    // (instead of through the daemon socket) because segments don't map
+    // onto the existing event wire protocol and the daemon shares the DB.
+    let (segments_inserted, segments_skipped, segment_errors) =
+        write_session_segments(db_path, path);
+    if segments_inserted > 0 || segments_skipped > 0 || segment_errors > 0 {
+        info!(
+            segments_inserted,
+            segments_skipped, segment_errors, "claude_sessions segments upserted"
+        );
+    }
+    errors += segment_errors;
 
     Ok((sent, errors))
 }

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -715,8 +715,9 @@ async fn main() -> Result<()> {
                 let socket = config.socket_path();
                 let timeout = config.daemon.socket_timeout_ms;
                 if batch {
+                    let db = config.db_path();
                     let (sent, errors) =
-                        claude_session::ingest_batch(path, &socket, timeout).await?;
+                        claude_session::ingest_batch(path, &socket, timeout, &db).await?;
                     println!(
                         "Batch import complete: {} events sent, {} errors",
                         sent, errors

--- a/crates/hippo-daemon/tests/claude_session.rs
+++ b/crates/hippo-daemon/tests/claude_session.rs
@@ -6,6 +6,8 @@ mod common;
 
 use common::{test_config, wait_for_daemon};
 
+const FIXTURE_SESSION_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
 fn write_test_session_jsonl(dir: &std::path::Path) -> PathBuf {
     let path = dir.join("test-session.jsonl");
     let content = r#"{"type":"assistant","timestamp":"2026-03-28T10:00:00.000Z","sessionId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","cwd":"/projects/hippo","gitBranch":"main","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_test001","name":"Bash","input":{"command":"cargo test"}}]}}
@@ -38,6 +40,7 @@ async fn test_ingest_batch_full_pipeline() {
         &jsonl_path,
         &socket_path,
         config.daemon.socket_timeout_ms,
+        &db_path,
     )
     .await
     .unwrap();
@@ -192,6 +195,7 @@ async fn test_ingest_batch_dedup_on_reimport() {
         &jsonl_path,
         &socket_path,
         config.daemon.socket_timeout_ms,
+        &db_path,
     )
     .await
     .unwrap();
@@ -205,6 +209,7 @@ async fn test_ingest_batch_dedup_on_reimport() {
         &jsonl_path,
         &socket_path,
         config.daemon.socket_timeout_ms,
+        &db_path,
     )
     .await
     .unwrap();
@@ -227,6 +232,225 @@ async fn test_ingest_batch_dedup_on_reimport() {
     );
 
     // Shut down
+    let _ = hippo_daemon::commands::send_request(&socket_path, &DaemonRequest::Shutdown).await;
+    let _ = daemon_handle.await;
+}
+
+/// Regression test for #58: `hippo ingest claude-session --batch` must
+/// populate the `claude_sessions` table — not just `events`. Prior to the
+/// fix, the batch importer only fired tool-call events through the daemon
+/// socket and never wrote the session-segment rows that enrichment depends
+/// on, so the 272-session sev1 backfill reported success while landing
+/// zero rows.
+///
+/// This test writes a fixture session JSONL (with user prompts, assistant
+/// text, and 2 completed tool_use/tool_result pairs), ingests it with
+/// `ingest_batch`, and asserts both that:
+///
+/// 1. ≥1 row exists in `claude_sessions` with the fixture session_id.
+/// 2. The existing `source_kind='claude-tool'` event flow still fires.
+///
+/// If the segment-write half regresses, this test fails with 0 rows in
+/// `claude_sessions`.
+#[tokio::test]
+async fn test_ingest_batch_writes_claude_sessions_row() {
+    let config = test_config();
+    let socket_path = config.socket_path();
+    let db_path = config.db_path();
+
+    // Lay out the JSONL under a simulated `projects/<project>/<session>.jsonl`
+    // path so `SessionFile::from_path` can derive the project_dir from the
+    // parent directory name — same shape Claude Code uses in `~/.claude`.
+    let project_root = config
+        .storage
+        .data_dir
+        .parent()
+        .unwrap()
+        .join("projects")
+        .join("-home-user-projects-hippo");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let jsonl_path = project_root.join(format!("{}.jsonl", FIXTURE_SESSION_ID));
+
+    // Complete session: a user prompt, an assistant message with reasoning
+    // plus a tool_use, a tool_result, a second assistant+tool_use, and a
+    // second tool_result. Matches the entry shapes parsed by
+    // `extract_segments` and `process_line`.
+    let content = format!(
+        r#"{{"type":"user","timestamp":"2026-03-28T10:00:00.000Z","sessionId":"{sid}","cwd":"/projects/hippo","message":{{"role":"user","content":[{{"type":"text","text":"please run the test suite and show me any failures"}}]}}}}
+{{"type":"assistant","timestamp":"2026-03-28T10:00:01.000Z","sessionId":"{sid}","cwd":"/projects/hippo","gitBranch":"main","message":{{"role":"assistant","content":[{{"type":"text","text":"I'll run the tests now to see the current state of the suite."}},{{"type":"tool_use","id":"toolu_r1","name":"Bash","input":{{"command":"cargo test -p hippo-core"}}}}]}}}}
+{{"type":"user","timestamp":"2026-03-28T10:00:03.000Z","sessionId":"{sid}","cwd":"/projects/hippo","message":{{"role":"user","content":[{{"type":"tool_result","tool_use_id":"toolu_r1","content":"running 12 tests\ntest result: ok. 12 passed"}}]}}}}
+{{"type":"assistant","timestamp":"2026-03-28T10:00:04.000Z","sessionId":"{sid}","cwd":"/projects/hippo","gitBranch":"main","message":{{"role":"assistant","content":[{{"type":"text","text":"All 12 tests passed. I'll also verify the daemon crate compiles cleanly."}},{{"type":"tool_use","id":"toolu_r2","name":"Bash","input":{{"command":"cargo build -p hippo-daemon"}}}}]}}}}
+{{"type":"user","timestamp":"2026-03-28T10:00:07.000Z","sessionId":"{sid}","cwd":"/projects/hippo","message":{{"role":"user","content":[{{"type":"tool_result","tool_use_id":"toolu_r2","content":"Compiling hippo-daemon\n    Finished"}}]}}}}
+"#,
+        sid = FIXTURE_SESSION_ID,
+    );
+    std::fs::write(&jsonl_path, content).unwrap();
+
+    // Start the daemon.
+    let run_config = config.clone();
+    let daemon_handle = tokio::spawn(async move { hippo_daemon::daemon::run(run_config).await });
+    wait_for_daemon(&socket_path).await;
+
+    // Run the batch ingest.
+    let (sent, errors) = hippo_daemon::claude_session::ingest_batch(
+        &jsonl_path,
+        &socket_path,
+        config.daemon.socket_timeout_ms,
+        &db_path,
+    )
+    .await
+    .unwrap();
+    assert_eq!(errors, 0, "batch should report zero errors");
+    assert_eq!(
+        sent, 2,
+        "should fire two shell-shaped tool-call events (one per tool_use/result pair)"
+    );
+
+    // Wait for the flush interval so the daemon can drain the event buffer
+    // into the `events` table (flush_interval_ms is set to 100 in the test
+    // harness).
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let conn = hippo_core::storage::open_db(&db_path).unwrap();
+
+    // Primary assertion: the fix must write at least one row into
+    // `claude_sessions` for the fixture session_id.
+    let segment_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM claude_sessions WHERE session_id = ?1",
+            [FIXTURE_SESSION_ID],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        segment_rows >= 1,
+        "expected ≥1 claude_sessions row for fixture session, got {}",
+        segment_rows
+    );
+
+    // Confirm the row has meaningful payload (we're writing real data, not
+    // a stub), so the enrichment queue actually has something to process.
+    let (message_count, tool_calls_json, project_dir): (i64, String, String) = conn
+        .query_row(
+            "SELECT message_count, tool_calls_json, project_dir FROM claude_sessions
+             WHERE session_id = ?1 ORDER BY segment_index ASC LIMIT 1",
+            [FIXTURE_SESSION_ID],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert!(
+        message_count > 0,
+        "segment should have a positive message_count, got {}",
+        message_count
+    );
+    assert!(
+        tool_calls_json.contains("cargo test") || tool_calls_json.contains("cargo build"),
+        "tool_calls_json should capture at least one tool invocation, got: {}",
+        tool_calls_json
+    );
+    assert_eq!(
+        project_dir, "-home-user-projects-hippo",
+        "project_dir should be derived from the parent directory name"
+    );
+
+    // Enrichment queue should have gotten an entry per segment, or the
+    // brain will never pick it up.
+    let queue_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM claude_enrichment_queue ceq
+             JOIN claude_sessions cs ON ceq.claude_session_id = cs.id
+             WHERE cs.session_id = ?1",
+            [FIXTURE_SESSION_ID],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        queue_count, segment_rows,
+        "every claude_sessions row must have a matching enrichment queue entry"
+    );
+
+    // Secondary assertion: we didn't break the original tool-call event
+    // flow. Events should still land in the `events` table as
+    // `source_kind='claude-tool'`.
+    let tool_event_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM events WHERE source_kind = 'claude-tool'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        tool_event_count > 0,
+        "existing source_kind='claude-tool' event flow should still fire, got {}",
+        tool_event_count
+    );
+
+    // Shut down.
+    let _ = hippo_daemon::commands::send_request(&socket_path, &DaemonRequest::Shutdown).await;
+    let _ = daemon_handle.await;
+}
+
+/// Re-ingesting the same session file must be idempotent — the
+/// `UNIQUE (session_id, segment_index)` constraint plus `INSERT OR IGNORE`
+/// in the segment writer should leave the table unchanged on the second
+/// pass. Guards against a future refactor that swaps `INSERT OR IGNORE`
+/// for a plain `INSERT` and starts erroring (or, worse, double-writing).
+#[tokio::test]
+async fn test_ingest_batch_claude_sessions_is_idempotent() {
+    let config = test_config();
+    let socket_path = config.socket_path();
+    let db_path = config.db_path();
+
+    let project_root = config
+        .storage
+        .data_dir
+        .parent()
+        .unwrap()
+        .join("projects")
+        .join("-home-user-projects-hippo");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let jsonl_path = project_root.join(format!("{}.jsonl", FIXTURE_SESSION_ID));
+
+    let content = format!(
+        r#"{{"type":"user","timestamp":"2026-03-28T10:00:00.000Z","sessionId":"{sid}","cwd":"/p","message":{{"role":"user","content":[{{"type":"text","text":"run the build"}}]}}}}
+{{"type":"assistant","timestamp":"2026-03-28T10:00:01.000Z","sessionId":"{sid}","cwd":"/p","gitBranch":"main","message":{{"role":"assistant","content":[{{"type":"text","text":"I'll start the build now and watch for any errors."}},{{"type":"tool_use","id":"toolu_x1","name":"Bash","input":{{"command":"cargo build"}}}}]}}}}
+{{"type":"user","timestamp":"2026-03-28T10:00:03.000Z","sessionId":"{sid}","cwd":"/p","message":{{"role":"user","content":[{{"type":"tool_result","tool_use_id":"toolu_x1","content":"ok"}}]}}}}
+"#,
+        sid = FIXTURE_SESSION_ID,
+    );
+    std::fs::write(&jsonl_path, content).unwrap();
+
+    let run_config = config.clone();
+    let daemon_handle = tokio::spawn(async move { hippo_daemon::daemon::run(run_config).await });
+    wait_for_daemon(&socket_path).await;
+
+    for _ in 0..2 {
+        hippo_daemon::claude_session::ingest_batch(
+            &jsonl_path,
+            &socket_path,
+            config.daemon.socket_timeout_ms,
+            &db_path,
+        )
+        .await
+        .unwrap();
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let conn = hippo_core::storage::open_db(&db_path).unwrap();
+    let segment_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM claude_sessions WHERE session_id = ?1",
+            [FIXTURE_SESSION_ID],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        segment_rows, 1,
+        "re-ingesting should be idempotent — expected exactly 1 row, got {}",
+        segment_rows
+    );
+
     let _ = hippo_daemon::commands::send_request(&socket_path, &DaemonRequest::Shutdown).await;
     let _ = daemon_handle.await;
 }


### PR DESCRIPTION
## Root cause

`hippo ingest claude-session --batch` fired tool-call events through the daemon socket but never populated the `claude_sessions` table — the segment-extraction + insert logic only existed in `scripts/hippo-ingest-claude.py`, which this CLI path never invokes. The daemon&#39;s `flush_events` only writes `events` and `browser_events`; there is no `claude_sessions` writer in the Rust side at all. Result: CLI reported &#34;N events sent, 0 errors&#34; while landing zero session rows, blocking the 272-file sev1 backfill.

Note: the task brief&#39;s hypothesis that `ingest_tail` also writes `claude_sessions` turned out to be incorrect — a `grep -rn INSERT.*claude_sessions crates/hippo-daemon/` returns empty. The tailer has the same gap, but this PR scopes the fix to the batch path to match the sev1 need.

## Fix

Ported the segment extractor from `brain/src/hippo_brain/claude_sessions.py` into `crates/hippo-daemon/src/claude_session.rs`. After `ingest_batch` finishes sending events, it does a second pass:

- Parses the JSONL into `SessionSegment`s using the same 5-minute-gap and 12k-char split rules as the Python side.
- Applies the shared `hippo_core::redaction::RedactionEngine` to user prompts, assistant text, and tool-call summaries (matches the Python `redact_segment_secrets`).
- Upserts rows into `claude_sessions` + `claude_enrichment_queue` via `INSERT OR IGNORE` (idempotent against the `UNIQUE (session_id, segment_index)` constraint).

Writes go direct to SQLite — both processes already share the DB, so this avoids a wire-protocol change and works even when brain is offline.

## Regression tests

`crates/hippo-daemon/tests/claude_session.rs`:

- **`test_ingest_batch_writes_claude_sessions_row`** — writes a fixture session with user prompts, assistant text, and 2 tool_use/tool_result pairs, runs `ingest_batch`, then asserts:
  1. ≥1 row exists in `claude_sessions` for the fixture session_id (this is the primary regression guard — fails on main with `got 0`).
  2. The segment row has a positive `message_count` and `tool_calls_json` capturing the invoked commands.
  3. `project_dir` is derived correctly from the parent directory name.
  4. Every `claude_sessions` row has a matching `claude_enrichment_queue` entry.
  5. Existing `source_kind=&#39;claude-tool&#39;` event flow still fires (no regression).
- **`test_ingest_batch_claude_sessions_is_idempotent`** — re-ingesting the same file leaves the table at exactly 1 row, guarding the `INSERT OR IGNORE` contract.

**Verified the primary test fails on main:** with the `write_session_segments` call stubbed out, the test fails with `expected ≥1 claude_sessions row for fixture session, got 0`. With the fix restored, all 4 tests in the file pass.

## Verification

- `cargo build` — PASS
- `cargo clippy --all-targets -- -D warnings` — PASS
- `cargo fmt --check` — PASS
- `cargo test -p hippo-daemon` — PASS (79 + 18 + 4 + 12 + 6 + 1 + 1 = 121 tests)
- `cargo test -p hippo-core` — PASS (100 + 5 + 3 + 3 + 3 + 1 = 115 tests)

## Backfill results

Ran the 272-file backfill using the newly built `target/release/hippo` binary against the installed daemon/DB.

| Metric | Before | After | Delta |
|---|---|---|---|
| `claude_sessions` rows (start_time ≥ 2026-04-08) | 12 | 392 | +380 |
| Distinct session_ids (start_time ≥ 2026-04-08) | 7 | 244 | +237 |
| Files processed | — | 273 | — |
| Files reporting `0 errors` | — | 273 | — |
| Files yielding ≥1 segment row | — | 244 | — |

29 of 273 files produced no segments (expected — matches the task description&#39;s note about `queue-operation`-only JSONLs and other non-Claude content). All 273 invocations reported `Batch import complete: N events sent, 0 errors`.

## Follow-ups (deferred)

- The **live tailer path** (`ingest_tail`) has the same gap — it fires events but never writes `claude_sessions`. Live sessions are currently backfilled later by `scripts/hippo-ingest-claude.py`. A follow-up PR should share `write_session_segments` between tailer (on drain) and batch so live sessions don&#39;t require a post-hoc script run. Not scoped here to keep the diff narrow.
- The segment-extraction logic is now duplicated across Rust (`crates/hippo-daemon/src/claude_session.rs`) and Python (`brain/src/hippo_brain/claude_sessions.py`). The split-rule constants (`SEGMENT_GAP_MS`, `MAX_SEGMENT_CHARS`) and the summary-text format both have `&#34;keep in sync with Python&#34;` comments. If this starts to drift, consolidating the scanner in one process is worth revisiting.