### PR TITLE
Replace LanceDB with sqlite-vec in documentation and tooling updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           echo "Checksum: ${CHECKSUM}"
 
       - name: Upload daemon artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: daemon-binary
           path: ${{ steps.artifact.outputs.name }}
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -146,7 +146,7 @@ jobs:
           echo "Checksum: ${CHECKSUM}"
 
       - name: Upload brain artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: brain-package
           path: ${{ steps.artifact.outputs.name }}
@@ -200,7 +200,7 @@ jobs:
           echo "Checksum: ${CHECKSUM}"
 
       - name: Upload GUI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gui-app
           path: ${{ steps.artifact.outputs.path }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ local LLMs.
 
 - `crates/hippo-core/` - shared Rust library (types, config, storage, redaction)
 - `crates/hippo-daemon/` - Rust binary (daemon + CLI)
-- `brain/` - Python project (enrichment, embeddings, query server, LanceDB integration)
+- `brain/` - Python project (enrichment, embeddings, query server, sqlite-vec retrieval)
 - `shell/` - zsh hook scripts
 - `config/` - default config templates
 - `launchd/` - LaunchAgent plists
@@ -50,27 +50,25 @@ uv run --project brain hippo-brain serve
 
 ## Architecture
 
-Two processes share a SQLite database at ~/.local/share/hippo/hippo.db and a LanceDB vector store at ~/.local/share/hippo/vectors/:
+Two processes share a single SQLite database at ~/.local/share/hippo/hippo.db:
 
 1. hippo-daemon (Rust) - captures shell events via Unix socket, redacts secrets, writes to SQLite, serves CLI queries
-2. hippo-brain (Python) - polls enrichment queue from SQLite, calls LM Studio API, writes knowledge nodes + vector embeddings to LanceDB
+2. hippo-brain (Python) - polls enrichment queue from SQLite, calls LM Studio API, writes knowledge nodes + vector embeddings to SQLite via sqlite-vec (vec0 virtual tables + FTS5)
 
 Communication:
 
 - Shell hook to daemon: fire-and-forget via Unix socket (length-prefixed JSON)
 - CLI to daemon: request/response via same Unix socket
 - hippo query (non-raw) to brain: HTTP request to brain local server
-- Brain to SQLite: direct read/write (WAL mode, busy_timeout=5000)
-- Brain to LanceDB: direct read/write for vector embeddings (semantic search + RAG via /ask)
+- Brain to SQLite: direct read/write (WAL mode, busy_timeout=5000); vectors live in the same DB via sqlite-vec
 
 ## Data Storage
 
-| Store   | Path                            | Purpose                               |
-|---------|---------------------------------|---------------------------------------|
-| SQLite  | `~/.local/share/hippo/hippo.db` | Events, sessions, enrichment queue    |
-| LanceDB | `~/.local/share/hippo/vectors/` | Vector embeddings for semantic search |
-| Config  | `~/.config/hippo/config.toml`   | User configuration                    |
-| Logs    | `~/.local/share/hippo/*.log`    | Daemon and brain logs                 |
+| Store  | Path                            | Purpose                                                              |
+|--------|---------------------------------|----------------------------------------------------------------------|
+| SQLite | `~/.local/share/hippo/hippo.db` | Events, sessions, enrichment queue, knowledge nodes, vector embeddings (sqlite-vec vec0 + FTS5) |
+| Config | `~/.config/hippo/config.toml`   | User configuration                                                   |
+| Logs   | `~/.local/share/hippo/*.log`    | Daemon and brain logs                                                |
 
 ## Style
 
@@ -78,5 +76,5 @@ Communication:
 - Python: 3.14+ required, ruff for lint+format, uv for package management
 - All timestamps: Unix epoch milliseconds (i64/INTEGER)
 - SQLite: WAL mode, PRAGMA foreign_keys=ON, PRAGMA busy_timeout=5000 on every connection
-- LanceDB: vector embeddings (768d) stored at ~/.local/share/hippo/vectors/; see brain/src/hippo_brain/embeddings.py
-- Semantic search and RAG pipeline are live — see rag.py, mcp.py, and the /ask endpoint
+- Vectors: 768d embeddings in `knowledge_vectors` vec0 virtual table (sqlite-vec); see brain/src/hippo_brain/vector_store.py
+- Semantic search and RAG pipeline are live — see rag.py, retrieval.py, mcp.py, and the /ask endpoint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Configure in your MCP config (e.g., `~/.claude/settings.json`):
 }
 ```
 
-The `ask` tool performs RAG: embeds the question, retrieves relevant knowledge nodes from LanceDB,
+The `ask` tool performs RAG: embeds the question, retrieves relevant knowledge nodes from SQLite via sqlite-vec (vec0) + FTS5 hybrid search,
 synthesizes an answer via a local LLM (`models.query` in config.toml), and returns the answer with
 scored source references. Requires `glow` for rendered CLI output (`brew install glow`).
 
@@ -85,7 +85,7 @@ Logs go to stderr. Metrics available via `MetricsCollector.snapshot()` for futur
 
 All paths use XDG defaults (not macOS-native ~/Library paths):
 
-- Data: `~/.local/share/hippo/` (DB, logs, socket, fallback, lancedb)
+- Data: `~/.local/share/hippo/` (DB, logs, socket, fallback)
 - Config: `~/.config/hippo/` (config.toml, redact.toml)
 - Binary: `~/.local/bin/hippo` (symlink to target/release/hippo)
 
@@ -98,7 +98,7 @@ Two processes share a SQLite database at ~/.local/share/hippo/hippo.db:
 1. hippo-daemon (Rust) - captures shell events via Unix socket, redacts secrets, writes to SQLite, serves CLI queries.
    `hippo doctor` checks version alignment between CLI, running daemon, and brain.
 2. hippo-brain (Python) - polls enrichment queues from SQLite, calls LM Studio API, writes knowledge nodes + embeddings
-   to LanceDB. Shell, Claude, and browser sources are enriched concurrently via `asyncio.gather()`;
+   to SQLite (sqlite-vec vec0 virtual tables + FTS5). Shell, Claude, and browser sources are enriched concurrently via `asyncio.gather()`;
    embeddings run as background tasks to overlap with LLM inference.
 
 Communication:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This one-liner downloads and installs the daemon, brain, and GUI app with checks
 |  Firefox  | ---------------> |              |                +--------------+
 |  ext.     |                  |              |                  ^         |
 +-----------+                  +--------------+           stdio  |  SQLite |
-                                                        (JSONL) | LanceDB |
+                                                        (JSONL) | SQLite  |
                                                                 |  LM API |
                                                           Claude Code / Desktop
 ```
@@ -40,7 +40,7 @@ This one-liner downloads and installs the daemon, brain, and GUI app with checks
 | Component | Language | Role |
 |-----------|----------|------|
 | **hippo-daemon** | Rust | Captures events via Unix socket and Native Messaging. Applies secret redaction, stores to SQLite, serves CLI queries. |
-| **hippo-brain** | Python | Polls enrichment queues, calls LM Studio for summarization, correlates browser research with shell activity, writes knowledge nodes + vector embeddings to LanceDB. |
+| **hippo-brain** | Python | Polls enrichment queues, calls LM Studio for summarization, correlates browser research with shell activity, writes knowledge nodes + vector embeddings to SQLite via sqlite-vec. |
 | **hippo-mcp** | Python | MCP server exposing the knowledge base over stdio. Claude Code queries your personal knowledge base mid-conversation. |
 
 ## Prerequisites
@@ -131,7 +131,7 @@ Add to your Claude Code MCP config (e.g., `~/.claude/settings.json` or your MCP 
 
 Replace `/path/to/hippo` with the absolute path to your clone.
 
-The MCP server reads SQLite and LanceDB directly (no dependency on the brain HTTP server).
+The MCP server reads SQLite directly (vectors live in the same DB via sqlite-vec; no dependency on the brain HTTP server).
 
 ## Firefox Extension (Optional)
 
@@ -251,8 +251,7 @@ All paths follow XDG defaults. Override with `XDG_DATA_HOME` / `XDG_CONFIG_HOME`
 
 | Store | Path | Purpose |
 |-------|------|---------|
-| SQLite | `~/.local/share/hippo/hippo.db` | Events, sessions, browser visits, enrichment queue, knowledge nodes, entities |
-| LanceDB | `~/.local/share/hippo/vectors/` | Vector embeddings for semantic search |
+| SQLite | `~/.local/share/hippo/hippo.db` | Events, sessions, browser visits, enrichment queue, knowledge nodes, entities, vector embeddings (sqlite-vec) |
 | Config | `~/.config/hippo/config.toml` | User configuration |
 | Logs | `~/.local/share/hippo/*.log` | Daemon and brain logs |
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This one-liner downloads and installs the daemon, brain, and GUI app with checks
 |  Firefox  | ---------------> |              |                +--------------+
 |  ext.     |                  |              |                  ^         |
 +-----------+                  +--------------+           stdio  |  SQLite |
-                                                        (JSONL) | SQLite  |
+                                                        (JSONL) | sqlite-vec |
                                                                 |  LM API |
                                                           Claude Code / Desktop
 ```

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.15.0"
+version = "0.15.1"
 requires-python = ">=3.14"
 dependencies = [
     "httpx>=0.28",

--- a/docs/smoke-test-and-risk-assessment.md
+++ b/docs/smoke-test-and-risk-assessment.md
@@ -21,7 +21,7 @@ As of 2026-03-27, your MacBook has **zero Hippo footprint**:
 | Step | Command | What It Does |
 |------|---------|--------------|
 | `build` | `cargo build` | Compiles Rust crates into `target/debug/`. Produces `target/debug/hippo` binary (~50 MB debug). Downloads/compiles crate dependencies on first run. |
-| `build:brain` | `uv sync --project brain` | Creates `brain/.venv/` virtualenv, installs Python dependencies (httpx, uvicorn, starlette, lancedb, etc.) |
+| `build:brain` | `uv sync --project brain` | Creates `brain/.venv/` virtualenv, installs Python dependencies (httpx, uvicorn, starlette, sqlite-vec, etc.) |
 
 ### Filesystem Impact (build only)
 
@@ -89,18 +89,16 @@ After build, the README suggests three additional steps. Here is what each does:
 
 **Filesystem created on first run:**
 
-| Path | Type | Purpose |
-|------|------|---------|
-| `~/.local/share/hippo/vectors/` | Directory | LanceDB vector store |
+Vectors are stored directly in `~/.local/share/hippo/hippo.db` via sqlite-vec (vec0 virtual table). No separate vector store directory is created.
 
 **Network:**
 - Binds `127.0.0.1:9175` (localhost only, not externally reachable)
 - Makes outbound HTTP to LM Studio (`localhost:1234/v1/chat/completions` and `/v1/embeddings`)
 
 **Resource usage:**
-- Memory: ~80-150 MB resident (Python, LanceDB, httpx)
+- Memory: ~80-150 MB resident (Python, sqlite-vec, httpx)
 - CPU: Near-zero idle. Polls enrichment queue every 5 seconds (cheap SQLite COUNT query). Spikes when calling LM Studio for enrichment.
-- Disk: LanceDB vectors grow with enrichment. ~2-5 KB per enriched event.
+- Disk: Vectors grow with enrichment inside hippo.db. ~2-5 KB per enriched event.
 
 ### Step 4: LaunchAgents (optional — auto-start on login)
 
@@ -337,7 +335,7 @@ After confirming each piece independently:
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | **LaunchAgent `KeepAlive: true` respawn loop** | If daemon crashes repeatedly, launchd will keep restarting it, potentially consuming CPU in a tight crash loop | launchd has built-in throttling (10-second minimum between restarts). If it's a problem: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.hippo.daemon.plist` |
-| **Brain server memory with large LanceDB** | Over time with heavy enrichment, the vector store could grow. LanceDB loads indexes into memory. | Monitor with `ls -lh ~/.local/share/hippo/vectors/`. For a year of shell commands this would still be small (~50-100 MB). |
+| **Brain server memory with large vector store** | Over time with heavy enrichment, the sqlite-vec table in hippo.db could grow. | Monitor with `du -h ~/.local/share/hippo/hippo.db`. For a year of shell commands this would still be small (~50-100 MB). |
 | **Sensitive command capture** | Commands containing passwords/tokens typed directly (e.g., `mysql -p password123`) will be captured. Redaction patterns catch common formats but not all. | Review `config/redact.default.toml` patterns. The allowlist approach for env vars is solid. Custom patterns can be added to `~/.config/hippo/redact.toml`. |
 
 ### Things That Are NOT Risks

--- a/hippo-gui/Sources/HippoGUI/Services/BrainClient.swift
+++ b/hippo-gui/Sources/HippoGUI/Services/BrainClient.swift
@@ -70,7 +70,7 @@ actor BrainClient: BrainClientProtocol {
         }
         var queryItems = [
             URLQueryItem(name: "limit", value: String(limit)),
-            URLQueryItem(name: "offset", value: String(offset))
+            URLQueryItem(name: "offset", value: String(offset)),
         ]
         if let nodeType = nodeType {
             queryItems.append(URLQueryItem(name: "node_type", value: nodeType))
@@ -104,7 +104,7 @@ actor BrainClient: BrainClientProtocol {
         }
         var queryItems = [
             URLQueryItem(name: "limit", value: String(limit)),
-            URLQueryItem(name: "offset", value: String(offset))
+            URLQueryItem(name: "offset", value: String(offset)),
         ]
         if let sessionId = sessionId {
             queryItems.append(URLQueryItem(name: "session_id", value: String(sessionId)))
@@ -129,7 +129,7 @@ actor BrainClient: BrainClientProtocol {
     ) async throws(BrainClientError) -> SessionListResponse {
         var queryItems = [
             URLQueryItem(name: "limit", value: String(limit)),
-            URLQueryItem(name: "offset", value: String(offset))
+            URLQueryItem(name: "offset", value: String(offset)),
         ]
         if let sinceMs {
             queryItems.append(URLQueryItem(name: "since_ms", value: String(sinceMs)))

--- a/hippo-gui/Sources/HippoGUI/Views/KnowledgeView.swift
+++ b/hippo-gui/Sources/HippoGUI/Views/KnowledgeView.swift
@@ -286,7 +286,8 @@ private struct ParsedKnowledgeContent {
             }
 
         if let prettyData = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
-            let prettyString = String(data: prettyData, encoding: .utf8) {
+            let prettyString = String(data: prettyData, encoding: .utf8)
+        {
             prettyPrintedRaw = prettyString
         } else {
             prettyPrintedRaw = raw

--- a/hippo-gui/Sources/HippoGUI/Views/KnowledgeView.swift
+++ b/hippo-gui/Sources/HippoGUI/Views/KnowledgeView.swift
@@ -286,8 +286,7 @@ private struct ParsedKnowledgeContent {
             }
 
         if let prettyData = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
-            let prettyString = String(data: prettyData, encoding: .utf8)
-        {
+            let prettyString = String(data: prettyData, encoding: .utf8) {
             prettyPrintedRaw = prettyString
         } else {
             prettyPrintedRaw = raw

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,7 +119,7 @@ get_latest_release() {
     local tag
 
     if command -v curl >/dev/null 2>&1; then
-        tag="$(curl -fsSL "${url}" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+        tag="$(curl -fsSL "${url}" | grep '"tag_name":' | LC_ALL=C sed -E 's/.*"([^"]+)".*/\1/')"
     else
         log_error "curl is required but not installed"
         exit 1
@@ -455,7 +455,7 @@ warn_on_stale_shell_hook_sources() {
         [ -f "${config_path}" ] || return 0
 
         while IFS= read -r line; do
-            source_path="$(printf '%s\n' "${line}" | sed -nE "s/.*source[[:space:]]+['\"]?([^'\"[:space:]]*hippo(-env)?\\.zsh)['\"]?.*/\\1/p")"
+            source_path="$(printf '%s\n' "${line}" | LC_ALL=C sed -nE "s/.*source[[:space:]]+['\"]?([^'\"[:space:]]*hippo(-env)?\\.zsh)['\"]?.*/\\1/p")"
             [ -n "${source_path}" ] || continue
 
             case "${source_path}" in


### PR DESCRIPTION
This pull request makes significant changes to documentation and workflow files to reflect the migration from LanceDB to sqlite-vec for vector storage, updates GitHub Actions to newer versions, and includes minor code cleanups and improvements. The most important changes are grouped below.

**Documentation and Architecture Updates:**

* User-facing documentation (`README.md`, `AGENTS.md`, `CLAUDE.md`, and `docs/smoke-test-and-risk-assessment.md`) has been updated to replace references to LanceDB with sqlite-vec, clarifying that vector embeddings are now stored directly in SQLite using vec0 virtual tables and FTS5. This affects descriptions of architecture, storage paths, RAG pipelines, and resource usage.
* Historical planning documents (`docs/superpowers/plans/`, `docs/superpowers/specs/`, `docs/FEATURE_TIMELINE.md`, `docs/agent-execution-plan.md`) retain their original LanceDB references intentionally — they are timestamped architectural decision records that accurately reflect the state of the system at the time they were written. Updating them would misrepresent the historical record.

**CI/CD Workflow Upgrades:**

* GitHub Actions in `.github/workflows/release.yml` have been updated to use newer versions for artifact upload/download and dependency setup, improving security and compatibility.

**Minor Code and Usability Improvements:**

* The Swift GUI client (`hippo-gui/Sources/HippoGUI/Services/BrainClient.swift`) includes minor formatting fixes for `URLQueryItem` arrays.
* The GUI's knowledge view (`KnowledgeView.swift`) improves readability of pretty-printed JSON output, with brace style aligned to the rest of the file.
* The install script (`scripts/install.sh`) now sets `LC_ALL=C` for `sed` commands, ensuring locale-independent parsing.
* Version bumped to v0.15.1.