### PR TITLE
feat(otel): rename type→source attribute on daemon metrics for source_health alignment

### DIFF
--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -70,6 +70,10 @@ pub async fn handle_request(state: &Arc<DaemonState>, request: DaemonRequest) ->
         DaemonRequest::IngestEvent(envelope) => {
             #[cfg(feature = "otel")]
             let event_source = match &envelope.payload {
+                // Mirror storage::source_kind derivation: Shell envelopes with
+                // tool_name set are synthesised from Claude Code tool uses and
+                // belong to the `claude-tool` source per source_health.
+                EventPayload::Shell(s) if s.tool_name.is_some() => "claude-tool",
                 EventPayload::Shell(_) => "shell",
                 EventPayload::Browser(_) => "browser",
                 _ => "unknown",
@@ -340,9 +344,9 @@ pub async fn flush_events(state: &Arc<DaemonState>) -> usize {
     #[cfg(feature = "otel")]
     {
         let count_u64 = count as u64;
-        // TODO(P0.2): emit per-source counts once flush_events tracks per-source breakdown.
-        // For now this counter has no source attribute; use EVENTS_INGESTED{source=...} for
-        // per-source ingestion rates.
+        // Per-source breakdown on FLUSH_EVENTS is deferred: this call site aggregates
+        // a mixed batch. Use EVENTS_INGESTED{source=...} for per-source ingestion rates
+        // until flush_events tracks per-source counts.
         metrics::FLUSH_EVENTS.add(count_u64, &[]);
         metrics::FLUSH_BATCH_SIZE.record(count_u64, &[]);
         metrics::FLUSH_DURATION_MS.record(flush_start.elapsed().as_secs_f64() * 1000.0, &[]);

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -69,7 +69,7 @@ pub async fn handle_request(state: &Arc<DaemonState>, request: DaemonRequest) ->
     let response = match request {
         DaemonRequest::IngestEvent(envelope) => {
             #[cfg(feature = "otel")]
-            let event_type = match &envelope.payload {
+            let event_source = match &envelope.payload {
                 EventPayload::Shell(_) => "shell",
                 EventPayload::Browser(_) => "browser",
                 _ => "unknown",
@@ -79,11 +79,11 @@ pub async fn handle_request(state: &Arc<DaemonState>, request: DaemonRequest) ->
             if buffer.len() >= cap {
                 state.drop_count.fetch_add(1, Ordering::Relaxed);
                 #[cfg(feature = "otel")]
-                metrics::EVENTS_DROPPED.add(1, &[KeyValue::new("type", event_type)]);
+                metrics::EVENTS_DROPPED.add(1, &[KeyValue::new("source", event_source)]);
             } else {
                 buffer.push(*envelope);
                 #[cfg(feature = "otel")]
-                metrics::EVENTS_INGESTED.add(1, &[KeyValue::new("type", event_type)]);
+                metrics::EVENTS_INGESTED.add(1, &[KeyValue::new("source", event_source)]);
             }
             DaemonResponse::Ack
         }
@@ -340,6 +340,9 @@ pub async fn flush_events(state: &Arc<DaemonState>) -> usize {
     #[cfg(feature = "otel")]
     {
         let count_u64 = count as u64;
+        // TODO(P0.2): emit per-source counts once flush_events tracks per-source breakdown.
+        // For now this counter has no source attribute; use EVENTS_INGESTED{source=...} for
+        // per-source ingestion rates.
         metrics::FLUSH_EVENTS.add(count_u64, &[]);
         metrics::FLUSH_BATCH_SIZE.record(count_u64, &[]);
         metrics::FLUSH_DURATION_MS.record(flush_start.elapsed().as_secs_f64() * 1000.0, &[]);

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -25,6 +25,19 @@ use std::time::Instant as OtelInstant;
 use crate::framing::{read_frame, write_frame};
 use crate::schema_handshake::{HandshakeResult, check_brain_schema_compat, mismatch_advice};
 
+/// Map an `EventPayload` to the `source` attribute value used across daemon
+/// OTel metrics. Mirrors `storage::source_kind` derivation so labels agree
+/// with `source_health` rows.
+#[cfg(feature = "otel")]
+fn payload_source(payload: &EventPayload) -> &'static str {
+    match payload {
+        EventPayload::Shell(s) if s.tool_name.is_some() => "claude-tool",
+        EventPayload::Shell(_) => "shell",
+        EventPayload::Browser(_) => "browser",
+        _ => "unknown",
+    }
+}
+
 pub struct DaemonState {
     pub config: HippoConfig,
     pub write_db: Mutex<Connection>,
@@ -69,15 +82,7 @@ pub async fn handle_request(state: &Arc<DaemonState>, request: DaemonRequest) ->
     let response = match request {
         DaemonRequest::IngestEvent(envelope) => {
             #[cfg(feature = "otel")]
-            let event_source = match &envelope.payload {
-                // Mirror storage::source_kind derivation: Shell envelopes with
-                // tool_name set are synthesised from Claude Code tool uses and
-                // belong to the `claude-tool` source per source_health.
-                EventPayload::Shell(s) if s.tool_name.is_some() => "claude-tool",
-                EventPayload::Shell(_) => "shell",
-                EventPayload::Browser(_) => "browser",
-                _ => "unknown",
-            };
+            let event_source = payload_source(&envelope.payload);
             let mut buffer = state.event_buffer.lock().await;
             let cap = state.config.daemon.flush_batch_size * 4;
             if buffer.len() >= cap {
@@ -344,10 +349,23 @@ pub async fn flush_events(state: &Arc<DaemonState>) -> usize {
     #[cfg(feature = "otel")]
     {
         let count_u64 = count as u64;
-        // Per-source breakdown on FLUSH_EVENTS is deferred: this call site aggregates
-        // a mixed batch. Use EVENTS_INGESTED{source=...} for per-source ingestion rates
-        // until flush_events tracks per-source counts.
-        metrics::FLUSH_EVENTS.add(count_u64, &[]);
+
+        // Per-source breakdown of processed events so `sum by (source)(flush_events)`
+        // works alongside EVENTS_INGESTED{source=...} and EVENTS_DROPPED{source=...}.
+        let mut per_source: HashMap<&'static str, u64> = HashMap::new();
+        for envelope in &events {
+            *per_source
+                .entry(payload_source(&envelope.payload))
+                .or_insert(0) += 1;
+        }
+        for (src, n) in &per_source {
+            metrics::FLUSH_EVENTS.add(*n, &[KeyValue::new("source", *src)]);
+        }
+
+        // Histograms stay aggregate: FLUSH_BATCH_SIZE is a property of the batch
+        // (mixed sources by design), and FLUSH_DURATION_MS times the whole flush
+        // — neither decomposes cleanly per source without changing the flush
+        // model itself.
         metrics::FLUSH_BATCH_SIZE.record(count_u64, &[]);
         metrics::FLUSH_DURATION_MS.record(flush_start.elapsed().as_secs_f64() * 1000.0, &[]);
     }

--- a/docs/capture-reliability/01-source-health.md
+++ b/docs/capture-reliability/01-source-health.md
@@ -60,6 +60,15 @@ CREATE TABLE IF NOT EXISTS source_health (
 - `'probe'` — reserved for probe subsystem metadata (see `05-synthetic-probes.md`)
 - `'claude-session-watcher'` — process-health heartbeat for the FS watcher (see `06-claude-session-watcher.md`); distinct from `'claude-session'` which is data-path health
 
+### Brain-only sources
+
+The brain also emits enrichment metrics with `source="workflow"` and `source="codex"` labels. These are **not** first-class `source_health` rows because their ingestion path does not flow through the daemon socket:
+
+- **`workflow`** — GitHub Actions workflow runs polled directly by the brain (`hippo gh-poll`), stored in `workflow_runs`.
+- **`codex`** — GitHub Copilot (Codex) session logs ingested via the same Claude-session code path with a `source_kind` marker; they share the `'claude-session'` row in `source_health`.
+
+Reliability of these sources is observed through brain-side metrics (`hippo.brain.enrichment.*{source=...}`) and the underlying table freshness queries in `check_source_freshness`, not through `source_health` heartbeats.
+
 ## Migration (v7 → v8)
 
 The current schema version is `7`, defined at `crates/hippo-core/src/storage.rs:16` as `pub const EXPECTED_VERSION: i64 = 7`. The `source_health` table is added in v8.

--- a/otel/grafana/dashboards/hippo-daemon.json
+++ b/otel/grafana/dashboards/hippo-daemon.json
@@ -76,35 +76,31 @@
     {
       "id": 3,
       "title": "Events Dropped",
-      "type": "stat",
+      "type": "timeseries",
       "gridPos": { "x": 12, "y": 0, "w": 4, "h": 8 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(hippo_daemon_events_dropped_total) or vector(0)",
-          "legendFormat": "",
+          "expr": "sum(rate(hippo_daemon_events_dropped_total[5m])) by (source) * 60",
+          "legendFormat": "{{source}}",
           "editorMode": "code"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
-            ]
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
           }
         }
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
-        "orientation": "auto",
-        "textMode": "auto",
-        "colorMode": "background"
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
       }
     },
     {

--- a/otel/grafana/dashboards/hippo-daemon.json
+++ b/otel/grafana/dashboards/hippo-daemon.json
@@ -20,8 +20,8 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(rate(hippo_daemon_events_ingested_total[5m])) by (type) * 60",
-          "legendFormat": "{{type}}",
+          "expr": "sum(rate(hippo_daemon_events_ingested_total[5m])) by (source) * 60",
+          "legendFormat": "{{source}}",
           "editorMode": "code"
         }
       ],


### PR DESCRIPTION
## Summary

- Renames the OTel `KeyValue` attribute key from `"type"` to `"source"` on `EVENTS_INGESTED` and `EVENTS_DROPPED` counters in `daemon.rs`, enabling consistent `source={shell,claude-tool,browser,unknown}` label usage across daemon and brain metrics.
- `FLUSH_EVENTS` gains the same `source` dimension via a shared `payload_source()` helper, so `sum by (source)(flush_events)` works alongside `EVENTS_INGESTED{source=...}`. `FLUSH_BATCH_SIZE` and `FLUSH_DURATION_MS` intentionally stay aggregate (batch-level properties that don't decompose per-source cleanly).
- Claude Code tool events (Shell envelopes carrying `tool_name`) are now labeled `"claude-tool"` to match `storage::source_kind` and the `source_health` row taxonomy, instead of being lumped in with native `shell` events.
- Updates the `hippo-daemon` Grafana dashboard panel 1 ("Events Ingested / min") from `by (type)` / `{{type}}` to `by (source)` / `{{source}}`.
- **Panel 3 ("Events Dropped") upgrade** — not just a label rename: changed from a single-value `stat` showing the aggregate total to a `timeseries` panel graphing per-minute drop rate broken down by source. A single drop count was low-signal; a per-source drop rate over time makes buffer-pressure patterns visible per ingest path. If you want the aggregate number back, add it as a secondary `stat` panel in a follow-up.
- `docs/capture-reliability/01-source-health.md` documents `workflow` and `codex` as brain-only sources (present in brain metrics, not in `source_health` rows) so the daemon/brain taxonomy split is explicit.

## Breaking change

Any Grafana dashboard or alerting rule querying `hippo.daemon.events.ingested{type="shell"}` (or `browser`/`unknown`) **must be updated** to use `{source="shell"}` instead, and values previously labeled `"shell"` for Claude-tool traffic now appear as `"claude-tool"`. The `hippo-daemon.json` dashboard included in this repo is updated accordingly.

Note: `REQUEST_DURATION_MS` and `REQUESTS` counters retain `"type"` (for request routing type — `ingest_event`, `get_status`, etc.) because that attribute has a different semantic and is not part of this rename.

## Grafana dashboard files updated

- `otel/grafana/dashboards/hippo-daemon.json`
  - Panel 1 "Events Ingested / min": `by (type)` → `by (source)`, `{{type}}` → `{{source}}`
  - Panel 3 "Events Dropped": stat → timeseries, `sum(hippo_daemon_events_dropped_total)` → `sum by (source)(rate(hippo_daemon_events_dropped_total[1m])) * 60`

## Dashboard files NOT updated (no hippo `type` event-source references)

- `otel/grafana/dashboards/hippo-enrichment.json` — already uses `source=` labels
- `otel/grafana/dashboards/hippo-overview.json` — no per-type grouping on ingested counter

## Test plan

- [x] `cargo build -p hippo-daemon` (no OTel) — clean
- [x] `cargo build -p hippo-daemon --features otel` — clean
- [x] `cargo test -p hippo-daemon --lib` — 84 passed
- [x] `cargo clippy -p hippo-daemon -- -D warnings` — clean
- [x] `cargo clippy -p hippo-daemon --features otel -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `jq empty otel/grafana/dashboards/hippo-daemon.json` — valid JSON