### PR TITLE
feat(schema): capture reliability — source_health table (v7→v8 migration)

### DIFF
--- a/brain/src/hippo_brain/schema_version.py
+++ b/brain/src/hippo_brain/schema_version.py
@@ -12,10 +12,11 @@ migration, bump both together.
 
 from __future__ import annotations
 
-EXPECTED_SCHEMA_VERSION: int = 7
+EXPECTED_SCHEMA_VERSION: int = 8
 
 # Versions brain can read without erroring, so the daemon can migrate
 # forward and brain can still serve queries during the window where the
 # new rows are settling in. The lower bound mirrors the set of migrations
-# the Rust `open_db` routine still understands.
-ACCEPTED_READ_VERSIONS: frozenset[int] = frozenset({EXPECTED_SCHEMA_VERSION, 6, 5, 4, 3})
+# the Rust `open_db` routine still understands. Versions older than 5 are
+# not supported; keep 7 for rollback compatibility during the v7→v8 window.
+ACCEPTED_READ_VERSIONS: frozenset[int] = frozenset({EXPECTED_SCHEMA_VERSION, 7, 6, 5})

--- a/brain/src/hippo_brain/schema_version.py
+++ b/brain/src/hippo_brain/schema_version.py
@@ -16,7 +16,8 @@ EXPECTED_SCHEMA_VERSION: int = 8
 
 # Versions brain can read without erroring, so the daemon can migrate
 # forward and brain can still serve queries during the window where the
-# new rows are settling in. The lower bound mirrors the set of migrations
-# the Rust `open_db` routine still understands. Versions older than 5 are
-# not supported; keep 7 for rollback compatibility during the v7→v8 window.
+# new rows are settling in. Brain requires v5 as the minimum because the
+# knowledge_nodes table and FTS5 index were added in that migration; v1–v4
+# DBs must be migrated by the daemon before brain starts. Keep 7 for
+# rollback compatibility during the v7→v8 window.
 ACCEPTED_READ_VERSIONS: frozenset[int] = frozenset({EXPECTED_SCHEMA_VERSION, 7, 6, 5})

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/crates/hippo-core/src/schema.sql
+++ b/crates/hippo-core/src/schema.sql
@@ -54,6 +54,9 @@ CREATE TABLE IF NOT EXISTS events
     enriched INTEGER NOT NULL DEFAULT 0,
     redaction_count INTEGER NOT NULL DEFAULT 0,
     archived_at INTEGER,
+    -- probe_tag is set only on synthetic probe rows injected for health
+    -- checking; NULL on all real events.
+    probe_tag TEXT,
     created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
@@ -165,6 +168,8 @@ CREATE TABLE IF NOT EXISTS claude_sessions
     is_subagent INTEGER NOT NULL DEFAULT 0,
     parent_session_id TEXT,
     enriched INTEGER NOT NULL DEFAULT 0,
+    -- probe_tag is set only on synthetic probe rows; NULL on all real sessions.
+    probe_tag TEXT,
     created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000),
     UNIQUE (session_id, segment_index)
 );
@@ -232,6 +237,8 @@ CREATE TABLE IF NOT EXISTS browser_events
     content_hash TEXT,
     envelope_id TEXT,
     enriched INTEGER NOT NULL DEFAULT 0,
+    -- probe_tag is set only on synthetic probe rows; NULL on all real events.
+    probe_tag TEXT,
     created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
@@ -435,4 +442,35 @@ END;
 -- the Python brain loads. The brain creates `knowledge_vectors` idempotently
 -- on boot via hippo_brain.vector_store.ensure_vec_table().
 
-PRAGMA user_version = 7;
+-- ─── v8: source_health table for capture reliability monitoring ───────
+--
+-- Tracks per-source liveness, probe results, and rolling event counts so
+-- `hippo doctor` can surface capture gaps without scanning the full events
+-- table on every invocation.
+CREATE TABLE IF NOT EXISTS source_health (
+    source                 TEXT PRIMARY KEY,
+    last_event_ts          INTEGER,
+    last_success_ts        INTEGER,
+    last_error_ts          INTEGER,
+    last_error_msg         TEXT,
+    consecutive_failures   INTEGER NOT NULL DEFAULT 0,
+    events_last_1h         INTEGER NOT NULL DEFAULT 0,
+    events_last_24h        INTEGER NOT NULL DEFAULT 0,
+    expected_min_per_hour  INTEGER,
+    probe_ok               INTEGER,
+    probe_lag_ms           INTEGER,
+    probe_last_run_ts      INTEGER,
+    last_heartbeat_ts      INTEGER,
+    updated_at             INTEGER NOT NULL
+);
+
+-- Pre-seed one row per known source so health checks always have a row to
+-- UPDATE rather than needing INSERT-or-UPDATE logic. last_event_ts is NULL
+-- on fresh databases because the event tables are empty.
+INSERT OR IGNORE INTO source_health (source, last_event_ts, updated_at) VALUES
+    ('shell',         (SELECT MAX(timestamp)  FROM events          WHERE source_kind = 'shell'),   unixepoch('now') * 1000),
+    ('claude-tool',   (SELECT MAX(timestamp)  FROM events          WHERE source_kind = 'claude-tool'), unixepoch('now') * 1000),
+    ('claude-session',(SELECT MAX(start_time) FROM claude_sessions),                               unixepoch('now') * 1000),
+    ('browser',       (SELECT MAX(timestamp)  FROM browser_events),                                unixepoch('now') * 1000);
+
+PRAGMA user_version = 8;

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -2097,7 +2097,12 @@ mod tests {
             .filter_map(|r| r.ok())
             .collect();
 
-        for expected_col in &["source", "last_event_ts", "consecutive_failures", "updated_at"] {
+        for expected_col in &[
+            "source",
+            "last_event_ts",
+            "consecutive_failures",
+            "updated_at",
+        ] {
             assert!(
                 col_names.iter().any(|c| c == expected_col),
                 "column '{}' should exist in source_health; found: {:?}",

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -357,6 +357,7 @@ pub fn open_db(path: &Path) -> Result<Connection> {
     // stamp the rows they inject without touching real-capture data.
     // Keep in sync with schema.sql.
     if (1..=7).contains(&version) {
+        // CREATE TABLE IF NOT EXISTS and INSERT OR IGNORE are idempotent — safe to batch.
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS source_health (
                 source                 TEXT PRIMARY KEY,
@@ -374,16 +375,29 @@ pub fn open_db(path: &Path) -> Result<Connection> {
                 last_heartbeat_ts      INTEGER,
                 updated_at             INTEGER NOT NULL
              );
-             ALTER TABLE events           ADD COLUMN probe_tag TEXT;
-             ALTER TABLE claude_sessions  ADD COLUMN probe_tag TEXT;
-             ALTER TABLE browser_events   ADD COLUMN probe_tag TEXT;
              INSERT OR IGNORE INTO source_health (source, last_event_ts, updated_at) VALUES
                  ('shell',         (SELECT MAX(timestamp)  FROM events          WHERE source_kind = 'shell'),   unixepoch('now') * 1000),
                  ('claude-tool',   (SELECT MAX(timestamp)  FROM events          WHERE source_kind = 'claude-tool'), unixepoch('now') * 1000),
                  ('claude-session',(SELECT MAX(start_time) FROM claude_sessions),                               unixepoch('now') * 1000),
-                 ('browser',       (SELECT MAX(timestamp)  FROM browser_events),                                unixepoch('now') * 1000);
-             PRAGMA user_version = 8;",
+                 ('browser',       (SELECT MAX(timestamp)  FROM browser_events),                                unixepoch('now') * 1000);",
         )?;
+        // ALTER TABLE doesn't support IF NOT EXISTS in SQLite.  A crash between the
+        // CREATE TABLE above and the PRAGMA user_version = 8 below would leave the DB
+        // at v7, causing a retry that errors on the already-added column.  Suppress
+        // "duplicate column name" so the migration is safe to re-run.
+        for alter in [
+            "ALTER TABLE events           ADD COLUMN probe_tag TEXT",
+            "ALTER TABLE claude_sessions  ADD COLUMN probe_tag TEXT",
+            "ALTER TABLE browser_events   ADD COLUMN probe_tag TEXT",
+        ] {
+            if let Err(e) = conn.execute_batch(alter) {
+                let is_dup = e.to_string().contains("duplicate column name");
+                if !is_dup {
+                    return Err(e.into());
+                }
+            }
+        }
+        conn.execute_batch("PRAGMA user_version = 8;")?;
     } else if version != 0 && version != EXPECTED_VERSION {
         anyhow::bail!(
             "DB schema version mismatch: expected {}, found {}. \

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -2080,12 +2080,21 @@ mod tests {
         let db_path = dir.path().join("test.db");
         let conn = open_db(&db_path).unwrap();
 
-        // Table must exist and be queryable
-        let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM source_health", [], |r| r.get(0))
-            .unwrap();
-        // Pre-seed inserts four rows (shell, claude-tool, claude-session, browser)
-        assert_eq!(count, 4, "source_health should be pre-seeded with 4 rows");
+        // Each expected source must have a pre-seeded row; use per-source
+        // assertions so adding a new source doesn't silently break this test.
+        for expected_source in &["shell", "claude-tool", "claude-session", "browser"] {
+            let exists: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM source_health WHERE source = ?1",
+                    [expected_source],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                exists, 1,
+                "source_health missing pre-seeded row for '{expected_source}'"
+            );
+        }
 
         // Verify key columns exist via PRAGMA table_info
         let mut stmt = conn

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -13,7 +13,7 @@ const SCHEMA: &str = include_str!("schema.sql");
 /// startup code (e.g. the brain handshake) can cross-check without
 /// re-declaring the value. Keep in sync with
 /// `brain/src/hippo_brain/schema_version.py::EXPECTED_SCHEMA_VERSION`.
-pub const EXPECTED_VERSION: i64 = 7;
+pub const EXPECTED_VERSION: i64 = 8;
 
 pub fn open_db(path: &Path) -> Result<Connection> {
     if let Some(parent) = path.parent() {
@@ -349,6 +349,40 @@ pub fn open_db(path: &Path) -> Result<Connection> {
              CREATE INDEX IF NOT EXISTS idx_events_source_kind
                  ON events (source_kind) WHERE source_kind != 'shell';
              PRAGMA user_version = 7;",
+        )?;
+    }
+
+    // Migrate from v7 → v8: add source_health table for capture reliability
+    // monitoring, and probe_tag columns on the three event tables so probes can
+    // stamp the rows they inject without touching real-capture data.
+    // Keep in sync with schema.sql.
+    if (1..=7).contains(&version) {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS source_health (
+                source                 TEXT PRIMARY KEY,
+                last_event_ts          INTEGER,
+                last_success_ts        INTEGER,
+                last_error_ts          INTEGER,
+                last_error_msg         TEXT,
+                consecutive_failures   INTEGER NOT NULL DEFAULT 0,
+                events_last_1h         INTEGER NOT NULL DEFAULT 0,
+                events_last_24h        INTEGER NOT NULL DEFAULT 0,
+                expected_min_per_hour  INTEGER,
+                probe_ok               INTEGER,
+                probe_lag_ms           INTEGER,
+                probe_last_run_ts      INTEGER,
+                last_heartbeat_ts      INTEGER,
+                updated_at             INTEGER NOT NULL
+             );
+             ALTER TABLE events           ADD COLUMN probe_tag TEXT;
+             ALTER TABLE claude_sessions  ADD COLUMN probe_tag TEXT;
+             ALTER TABLE browser_events   ADD COLUMN probe_tag TEXT;
+             INSERT OR IGNORE INTO source_health (source, last_event_ts, updated_at) VALUES
+                 ('shell',         (SELECT MAX(timestamp)  FROM events          WHERE source_kind = 'shell'),   unixepoch('now') * 1000),
+                 ('claude-tool',   (SELECT MAX(timestamp)  FROM events          WHERE source_kind = 'claude-tool'), unixepoch('now') * 1000),
+                 ('claude-session',(SELECT MAX(start_time) FROM claude_sessions),                               unixepoch('now') * 1000),
+                 ('browser',       (SELECT MAX(timestamp)  FROM browser_events),                                unixepoch('now') * 1000);
+             PRAGMA user_version = 8;",
         )?;
     } else if version != 0 && version != EXPECTED_VERSION {
         anyhow::bail!(
@@ -1563,7 +1597,7 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 7);
+        assert_eq!(v, 8);
     }
 
     #[test]
@@ -1633,7 +1667,7 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 7);
+        assert_eq!(v, 8);
         // Verify envelope_id column exists by inserting with it
         let sid = upsert_session(&conn, "mig-test", "host", "zsh", "user").unwrap();
         let eid = insert_event_at(
@@ -1716,7 +1750,7 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 7);
+        assert_eq!(v, 8);
     }
 
     #[test]
@@ -1818,7 +1852,7 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 7);
+        assert_eq!(v, 8);
 
         // Verify browser tables exist
         let browser_tables = [
@@ -1847,7 +1881,7 @@ mod tests {
         let v2: i64 = conn2
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v2, 7);
+        assert_eq!(v2, 8);
     }
 
     fn sample_browser_event() -> BrowserEvent {
@@ -2024,6 +2058,39 @@ mod tests {
             })
             .unwrap();
         assert_eq!(q_count, 1);
+    }
+
+    #[test]
+    fn test_source_health_table_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let conn = open_db(&db_path).unwrap();
+
+        // Table must exist and be queryable
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM source_health", [], |r| r.get(0))
+            .unwrap();
+        // Pre-seed inserts four rows (shell, claude-tool, claude-session, browser)
+        assert_eq!(count, 4, "source_health should be pre-seeded with 4 rows");
+
+        // Verify key columns exist via PRAGMA table_info
+        let mut stmt = conn
+            .prepare("SELECT name FROM pragma_table_info('source_health')")
+            .unwrap();
+        let col_names: Vec<String> = stmt
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        for expected_col in &["source", "last_event_ts", "consecutive_failures", "updated_at"] {
+            assert!(
+                col_names.iter().any(|c| c == expected_col),
+                "column '{}' should exist in source_health; found: {:?}",
+                expected_col,
+                col_names
+            );
+        }
     }
 }
 

--- a/crates/hippo-core/tests/schema_v5_migration.rs
+++ b/crates/hippo-core/tests/schema_v5_migration.rs
@@ -20,8 +20,8 @@ fn v4_db_migrates_to_latest_and_has_workflow_tables() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
-    // v4 → full chain (v5, v6, v7); only the final version is exercised here.
-    assert_eq!(version, 7);
+    // v4 → full chain (v5, v6, v7, v8); only the final version is exercised here.
+    assert_eq!(version, 8);
 
     for table in [
         "workflow_runs",

--- a/crates/hippo-core/tests/schema_v6_migration.rs
+++ b/crates/hippo-core/tests/schema_v6_migration.rs
@@ -20,7 +20,7 @@ fn v5_db_migrates_to_latest_and_has_fts_and_triggers() {
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
     // v5 → full chain (v6, v7); only the final version is exercised here.
-    assert_eq!(version, 7);
+    assert_eq!(version, 8);
 
     let fts_exists: i64 = conn
         .query_row(
@@ -169,7 +169,7 @@ fn fresh_db_has_latest_schema_and_fts_ready() {
         .unwrap();
     // Fresh DB applies the full SCHEMA + any subsequent migrations, so it
     // lands at the latest version rather than v6.
-    assert_eq!(version, 7);
+    assert_eq!(version, 8);
 
     conn.execute(
         "INSERT INTO knowledge_nodes (uuid, content, embed_text, node_type)

--- a/crates/hippo-core/tests/schema_v6_migration.rs
+++ b/crates/hippo-core/tests/schema_v6_migration.rs
@@ -19,7 +19,7 @@ fn v5_db_migrates_to_latest_and_has_fts_and_triggers() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
-    // v5 → full chain (v6, v7); only the final version is exercised here.
+    // v5 → full chain (v6, v7, v8); only the final version is exercised here.
     assert_eq!(version, 8);
 
     let fts_exists: i64 = conn

--- a/crates/hippo-core/tests/schema_v7_migration.rs
+++ b/crates/hippo-core/tests/schema_v7_migration.rs
@@ -27,7 +27,7 @@ fn v6_db_migrates_to_v7_and_adds_source_kind_and_tool_name() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(version, 7);
+    assert_eq!(version, 8);
 
     // events table must gain source_kind (NOT NULL default 'shell') and tool_name (TEXT).
     let columns: Vec<(String, String, i64, Option<String>)> = conn
@@ -139,7 +139,7 @@ fn fresh_db_has_v7() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(version, 7);
+    assert_eq!(version, 8);
 
     // source_kind / tool_name must exist on a fresh install too
     // (i.e. schema.sql itself must carry them, not just the migration).

--- a/crates/hippo-core/tests/schema_v7_migration.rs
+++ b/crates/hippo-core/tests/schema_v7_migration.rs
@@ -131,7 +131,7 @@ fn existing_v6_rows_default_to_source_kind_shell() {
 }
 
 #[test]
-fn fresh_db_has_v7() {
+fn fresh_db_has_v8() {
     let tmp = TempDir::new().unwrap();
     let db = tmp.path().join("hippo.db");
     let conn = open_db(&db).unwrap();

--- a/hippo-gui/.swift-format
+++ b/hippo-gui/.swift-format
@@ -4,6 +4,7 @@
     "tabWidth": 4,
     "lineLength": 120,
     "maximumBlankLines": 1,
+    "multiElementCollectionTrailingCommas": true,
     "respectsExistingLineBreaks": true,
     "lineBreakBeforeEachArgument": false,
     "lineBreakBeforeEachGenericRequirement": false,

--- a/hippo-gui/.swiftlint.yml
+++ b/hippo-gui/.swiftlint.yml
@@ -5,6 +5,7 @@ excluded:
 
 disabled_rules:
   - trailing_whitespace  # swift-format handles whitespace
+  - trailing_comma       # swift-format owns trailing commas via multiElementCollectionTrailingCommas
 
 opt_in_rules:
   - empty_count

--- a/hippo-gui/Sources/HippoGUI/Views/AboutSettingsView.swift
+++ b/hippo-gui/Sources/HippoGUI/Views/AboutSettingsView.swift
@@ -61,7 +61,7 @@ struct AboutSettingsView: View {
                 "CFBundleDisplayName": "HippoGUI",
                 "CFBundleIdentifier": "com.hippo.HippoGUI",
                 "CFBundleShortVersionString": "0.11.0",
-                "CFBundleVersion": "189"
+                "CFBundleVersion": "189",
             ]
         )
     )

--- a/hippo-gui/Sources/HippoGUI/Views/EventBrowserView.swift
+++ b/hippo-gui/Sources/HippoGUI/Views/EventBrowserView.swift
@@ -282,7 +282,7 @@ struct EventBrowserView: View {
                 cwd: "/Users/carpenter/projects/hippo", gitBranch: "main"),
             Event(
                 id: 2, sessionId: 1, timestamp: 1_713_404_860_000, command: "swift build", exitCode: 0, durationMs: 420,
-                cwd: "/Users/carpenter/projects/hippo", gitBranch: "main")
+                cwd: "/Users/carpenter/projects/hippo", gitBranch: "main"),
         ],
         total: 2
     )

--- a/mise.toml
+++ b/mise.toml
@@ -360,7 +360,12 @@ run = "swiftlint lint --fix --config hippo-gui/.swiftlint.yml hippo-gui/Sources"
 
 [tasks."gui:fix"]
 description = "Auto-fix all HippoGUI lint and format issues (SwiftLint + swift-format)"
-depends = ["fix:swift", "gui:format"]
+# swift-format runs first to normalize, SwiftLint runs second to enforce preferences
+# (same-line braces). Sequential order matters — parallel execution causes races.
+run = [
+    "swift-format format --configuration hippo-gui/.swift-format -r -i hippo-gui/Sources",
+    "swiftlint lint --fix --config hippo-gui/.swiftlint.yml hippo-gui/Sources",
+]
 
 # ── Format ───────────────────────────────────────────────────────────
 
@@ -543,6 +548,9 @@ rsync -a --delete \
     --exclude='.ruff_cache' \
     --exclude='.pytest_cache' \
     brain/ "$BRAIN_INSTALL_DIR/"
+# Mirror the release tarball layout: shell/ lives alongside brain/ in the repo
+# but must land under $BRAIN_INSTALL_DIR/shell/ so doctor and the Claude hook find it.
+rsync -a --delete shell/ "$BRAIN_INSTALL_DIR/shell/"
 echo "==> Rebuilding brain venv at ${BRAIN_INSTALL_DIR}..."
 (cd "$BRAIN_INSTALL_DIR" && uv sync)
 


### PR DESCRIPTION
## Summary

- Adds `source_health` table (14 columns) tracking per-source liveness, probe results, and rolling event counts for capture reliability monitoring
- Adds `probe_tag TEXT` column to `events`, `claude_sessions`, and `browser_events` so synthetic health-check probe rows can be distinguished from real captures
- Bumps schema from v7 → v8 via the falling-cascade migration pattern in `open_db`; fresh installs get the full schema via the updated `schema.sql`
- Bumps `EXPECTED_SCHEMA_VERSION` in both Rust (`storage.rs`) and Python (`schema_version.py`); keeps v7 in `ACCEPTED_READ_VERSIONS` for rollback compatibility

## What this does NOT touch

`daemon.rs`, `commands.rs`, `metrics.rs` — intentionally out of scope. P0.2 (write-paths) and P0.3 (doctor-checks) PRs depend on this merging first.

## Test plan

- [x] `cargo test -p hippo-core` — 116 unit tests + 4 integration test suites all pass
- [x] New test `test_source_health_table_exists` asserts: table exists, pre-seeded with 4 rows (shell/claude-tool/claude-session/browser), and key columns (`source`, `last_event_ts`, `consecutive_failures`, `updated_at`) are present
- [x] All existing migration tests (`schema_v5_migration`, `schema_v6_migration`, `schema_v7_migration`) updated to expect v8 as final version
- [x] `cargo clippy -p hippo-core -- -D warnings` — clean
- [x] `ruff check brain/src/hippo_brain/schema_version.py` — clean