### PR TITLE
feat(daemon): daily rolling log rotation via tracing-appender (7-day retention)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +300,15 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -654,6 +678,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
@@ -1136,6 +1161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1404,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1866,6 +1903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +2000,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2175,6 +2249,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/hippo-daemon/Cargo.toml
+++ b/crates/hippo-daemon/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-appender = { workspace = true }
 uuid.workspace = true
 chrono.workspace = true
 dirs = "6"

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -42,8 +42,12 @@ async fn main() -> Result<()> {
     // The launchd StandardErrorPath still captures pre-main panics and OS-level
     // launch output; runtime application logs go here exclusively.
     let data_dir = config.storage.data_dir.clone();
-    std::fs::create_dir_all(&data_dir)
-        .unwrap_or_else(|e| eprintln!("Warning: could not create data dir {}: {e}", data_dir.display()));
+    std::fs::create_dir_all(&data_dir).unwrap_or_else(|e| {
+        eprintln!(
+            "Warning: could not create data dir {}: {e}",
+            data_dir.display()
+        )
+    });
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
         .filename_prefix("daemon")

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -38,14 +38,31 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Set up rolling file appender for runtime logs (7-day retention).
+    // The launchd StandardErrorPath still captures pre-main panics and OS-level
+    // launch output; runtime application logs go here exclusively.
+    let data_dir = config.storage.data_dir.clone();
+    std::fs::create_dir_all(&data_dir)
+        .unwrap_or_else(|e| eprintln!("Warning: could not create data dir {}: {e}", data_dir.display()));
+    let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .filename_prefix("daemon")
+        .filename_suffix("log")
+        .max_log_files(7)
+        .build(&data_dir)
+        .expect("failed to initialize log appender");
+    let (non_blocking, _log_guard) = tracing_appender::non_blocking(file_appender);
+
     // Initialize telemetry — OTel if feature-enabled and config says so, else plain fmt
     #[cfg(feature = "otel")]
     let _otel_guard = if config.telemetry.enabled {
-        match hippo_daemon::telemetry::init("hippo-daemon", &config.telemetry.endpoint) {
+        // Clone so the fallback path below can reuse the same writer if OTel init fails.
+        let writer = non_blocking.clone();
+        match hippo_daemon::telemetry::init("hippo-daemon", &config.telemetry.endpoint, writer) {
             Ok(guard) => Some(guard),
             Err(e) => {
                 tracing_subscriber::fmt()
-                    .with_writer(std::io::stderr)
+                    .with_writer(non_blocking)
                     .with_env_filter(
                         EnvFilter::try_from_default_env()
                             .unwrap_or_else(|_| EnvFilter::new("info")),
@@ -57,7 +74,7 @@ async fn main() -> Result<()> {
         }
     } else {
         tracing_subscriber::fmt()
-            .with_writer(std::io::stderr)
+            .with_writer(non_blocking)
             .with_env_filter(
                 EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
             )
@@ -67,7 +84,7 @@ async fn main() -> Result<()> {
 
     #[cfg(not(feature = "otel"))]
     tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
+        .with_writer(non_blocking)
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )

--- a/crates/hippo-daemon/src/telemetry.rs
+++ b/crates/hippo-daemon/src/telemetry.rs
@@ -44,7 +44,13 @@ impl TelemetryGuard {
 /// Initialize OTel tracing subscriber with OTLP exporters.
 /// Replaces the default `tracing_subscriber::fmt` when OTel is enabled.
 /// Returns a guard that must be held for the lifetime of the program.
-pub fn init(service_name: &str, endpoint: &str) -> Result<TelemetryGuard> {
+///
+/// `writer` is the log destination for the fmt layer (typically a
+/// `tracing_appender::non_blocking::NonBlocking` file writer).
+pub fn init<W>(service_name: &str, endpoint: &str, writer: W) -> Result<TelemetryGuard>
+where
+    W: for<'a> tracing_subscriber::fmt::MakeWriter<'a> + Send + Sync + 'static,
+{
     let res = resource(service_name);
 
     // Traces
@@ -94,7 +100,7 @@ pub fn init(service_name: &str, endpoint: &str) -> Result<TelemetryGuard> {
         EnvFilter::new("info,opentelemetry_sdk=off,opentelemetry_otlp=off,opentelemetry_http=off")
     });
 
-    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(writer);
 
     let otel_trace_layer = OpenTelemetryLayer::new(tracer);
 

--- a/crates/hippo-daemon/tests/telemetry_test.rs
+++ b/crates/hippo-daemon/tests/telemetry_test.rs
@@ -13,7 +13,7 @@ mod otel_tests {
     /// background tasks that need a reactor.
     #[tokio::test]
     async fn test_telemetry_init_shutdown() {
-        let guard = telemetry::init("test-service", "http://localhost:19999")
+        let guard = telemetry::init("test-service", "http://localhost:19999", std::io::stderr)
             .expect("telemetry init should succeed even without a collector");
         guard.shutdown();
     }

--- a/launchd/com.hippo.daemon.plist
+++ b/launchd/com.hippo.daemon.plist
@@ -27,6 +27,8 @@
     <true/>
     <key>StandardOutPath</key>
     <string>__DATA_DIR__/daemon.stdout.log</string>
+    <!-- Runtime logs: __DATA_DIR__/daemon.YYYY-MM-DD.log (rolling 7 days via tracing-appender) -->
+    <!-- Pre-main crash output only: -->
     <key>StandardErrorPath</key>
     <string>__DATA_DIR__/daemon.stderr.log</string>
     <key>WorkingDirectory</key>


### PR DESCRIPTION
## Summary

- Replace `std::io::stderr` writer with a rolling file appender in all three logging initialization paths: non-OTel (`#[cfg(not(feature = "otel"))]`), OTel-disabled fallback, and OTel-init-failed fallback
- Update `telemetry::init()` to accept a generic `MakeWriter` parameter so the OTel fmt layer also writes to the file appender instead of stderr
- Add XML comment to `com.hippo.daemon.plist` clarifying the split: runtime logs go to the rolling file, `StandardErrorPath` (`daemon.stderr.log`) captures only pre-main crashes and OS-level launch output

**Log file location:** `~/.local/share/hippo/daemon.YYYY-MM-DD.log`
**Retention:** 7 days via `max_log_files(7)`
**tracing-appender version:** 0.2.5 — `RollingFileAppender::builder()` and `max_log_files` are both available

**Guard lifetime:** `_log_guard` (the `NonBlocking` flush guard) is bound in `main`'s outermost scope at the point of creation, before any `match` or `#[cfg]` branching, so it is dropped only when `main` returns. No logs are lost on shutdown.

**OTel path:** `NonBlocking` is `Clone` (Arc-backed); a clone is passed to `telemetry::init()` when OTel is enabled, and the original is retained in `main` for the fallback path. The OTel fmt layer now writes to the file appender alongside the OTLP exporter layers.

**Brain logs:** Brain only writes to stderr via `logging.StreamHandler(sys.stderr)`, captured by the brain launchd plist. No file rotation needed there.

## Test plan

- [x] `cargo build -p hippo-daemon` — passes
- [x] `cargo build -p hippo-daemon --no-default-features` — passes
- [x] `cargo clippy -p hippo-daemon -- -D warnings` — passes
- [ ] After `hippo daemon run`, confirm `~/.local/share/hippo/daemon.YYYY-MM-DD.log` is created and receiving log output
- [ ] Confirm `daemon.stderr.log` is empty (or only has pre-main output) during normal operation