### PR TITLE
feat(doctor): source_health staleness checks + fail_count exit code (P0.3)

### DIFF
--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -20,6 +20,8 @@ pub struct HippoConfig {
     pub telemetry: TelemetryConfig,
     #[serde(default)]
     pub github: GithubConfig,
+    #[serde(default)]
+    pub watchdog: WatchdogConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -419,6 +421,33 @@ impl Default for LessonsConfig {
             cluster_window_days: 30,
             min_occurrences: 2,
             path_prefix_segments: 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WatchdogConfig {
+    #[serde(default = "default_watchdog_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_alarm_rate_limit_minutes")]
+    pub alarm_rate_limit_minutes: u64,
+    #[serde(default)]
+    pub notify_macos: bool,
+}
+
+fn default_watchdog_enabled() -> bool {
+    true
+}
+fn default_alarm_rate_limit_minutes() -> u64 {
+    15
+}
+
+impl Default for WatchdogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_watchdog_enabled(),
+            alarm_rate_limit_minutes: default_alarm_rate_limit_minutes(),
+            notify_macos: false,
         }
     }
 }

--- a/crates/hippo-daemon/src/cli.rs
+++ b/crates/hippo-daemon/src/cli.rs
@@ -107,7 +107,11 @@ pub enum Commands {
     /// Run as Native Messaging host for Firefox extension
     NativeMessagingHost,
     /// Run diagnostic checks
-    Doctor,
+    Doctor {
+        /// Print remediation steps for each failing check
+        #[arg(long)]
+        explain: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -643,7 +643,7 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
     fail_count += check_log_file_sizes(config, explain);
 
     if fail_count > 0 {
-        std::process::exit(1);
+        std::process::exit(fail_count as i32);
     }
 
     Ok(())

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -627,7 +627,7 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
     check_source_freshness(config);
 
     // Check OpenTelemetry configuration
-    check_otel_status(config, &client).await;
+    fail_count += check_otel_status(config, &client).await;
 
     // Check 1: Per-source staleness via source_health table (P0.1)
     // Check 8: Watchdog heartbeat
@@ -821,7 +821,7 @@ fn format_duration_ms(ms: i64) -> String {
     format!("{days}d")
 }
 
-async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) {
+async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) -> u32 {
     // Check if OTel feature is compiled in
     #[cfg(feature = "otel")]
     let otel_compiled = true;
@@ -830,7 +830,7 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) {
 
     if !otel_compiled {
         println!("[--] OpenTelemetry: not compiled (daemon built without --features otel)");
-        return;
+        return 0;
     }
 
     // Check if telemetry is enabled in config
@@ -849,6 +849,7 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) {
     match (config_enabled, collector_reachable) {
         (true, true) => {
             println!("[OK] OpenTelemetry: enabled and collector reachable");
+            0
         }
         (true, false) => {
             println!(
@@ -856,6 +857,7 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) {
                 collector_health_url
             );
             println!("     Start the stack: mise run otel:up");
+            1
         }
         (false, true) => {
             println!("[!!] OpenTelemetry: collector available but disabled in config");
@@ -863,9 +865,11 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) {
                 "     Enable it: Set [telemetry] enabled = true in ~/.config/hippo/config.toml"
             );
             println!("     Then restart: mise run restart");
+            1
         }
         (false, false) => {
             println!("[--] OpenTelemetry: disabled (start with: mise run otel:up)");
+            0
         }
     }
 }
@@ -954,12 +958,16 @@ fn check_source_staleness(db: &rusqlite::Connection, explain: bool) -> u32 {
     };
 
     // Check Firefox running (for browser suppression).
+    // macOS Firefox (incl. Developer Edition) exposes the main process as `firefox`;
+    // `firefox-bin` is Linux-only. Match either to keep the check portable.
     let firefox_running = || -> bool {
-        std::process::Command::new("pgrep")
-            .args(["-x", "firefox-bin"])
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+        ["firefox", "firefox-bin"].iter().any(|name| {
+            std::process::Command::new("pgrep")
+                .args(["-x", name])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        })
     };
 
     // Check if there's a recent claude JSONL with mtime < 5 minutes (for claude-session suppression).
@@ -1258,12 +1266,19 @@ fn check_watchdog_heartbeat(db: &rusqlite::Connection, explain: bool) -> u32 {
             println!("[--] {:<29}  not installed", "watchdog heartbeat");
             0
         }
-        Err(e) => {
-            let msg = e.to_string();
-            // Treat "no such table" the same as "no row" — watchdog not yet installed.
-            let _ = msg;
+        Err(e) if e.to_string().contains("no such table") => {
+            // Pre-migration DB (v7 or older) — source_health does not exist yet.
             println!("[--] {:<29}  not installed", "watchdog heartbeat");
             0
+        }
+        Err(e) => {
+            println!("[!!] {:<29}  DB error: {e}", "watchdog heartbeat");
+            if explain {
+                println!("     CAUSE:  source_health query returned an unexpected DB error");
+                println!("     FIX:    Inspect ~/.local/share/hippo/hippo.db for corruption");
+                println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+            }
+            1
         }
         Ok(age_secs) => {
             if age_secs < 60 {

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -631,7 +631,9 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
 
     // Check 1: Per-source staleness via source_health table (P0.1)
     // Check 8: Watchdog heartbeat
-    if db_path.exists() && let Ok(conn) = hippo_core::storage::open_db(&db_path) {
+    if db_path.exists()
+        && let Ok(conn) = hippo_core::storage::open_db(&db_path)
+    {
         fail_count += check_source_staleness(&conn, explain);
         fail_count += check_watchdog_heartbeat(&conn, explain);
     }
@@ -982,7 +984,9 @@ fn check_source_staleness(db: &rusqlite::Connection, explain: bool) -> u32 {
                 return true;
             }
             // Also recurse one level (projects/*/session.jsonl layout).
-            if path.is_dir() && let Ok(sub) = std::fs::read_dir(&path) {
+            if path.is_dir()
+                && let Ok(sub) = std::fs::read_dir(&path)
+            {
                 for sub_entry in sub.flatten() {
                     let sub_path = sub_entry.path();
                     if sub_path.extension().and_then(|e| e.to_str()) == Some("jsonl")
@@ -1047,9 +1051,7 @@ fn check_source_staleness(db: &rusqlite::Connection, explain: bool) -> u32 {
                 println!("[!!] {}  {} (FAIL)", padded, human);
                 fail_count += 1;
                 if explain {
-                    println!(
-                        "     CAUSE:  No events have landed in SQLite for this source"
-                    );
+                    println!("     CAUSE:  No events have landed in SQLite for this source");
                     println!(
                         "     FIX:    Check source is running: hippo doctor (re-run); tail -f ~/.local/share/hippo/daemon.stderr.log"
                     );

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -522,7 +522,8 @@ pub fn handle_redact_test(config: &HippoConfig, input: &str) {
     println!("  {}", result.text);
 }
 
-pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
+pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
+    let mut fail_count: u32 = 0;
     let cli_version = env!("HIPPO_VERSION_FULL");
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
@@ -540,6 +541,7 @@ pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
                 println!("[OK] Daemon is running (uptime {}s)", status.uptime_secs);
                 if status.version.is_empty() {
                     println!("[!!] Daemon too old to report version — restart recommended");
+                    fail_count += 1;
                 } else if status.version == cli_version {
                     println!("[OK] Daemon version matches CLI");
                 } else {
@@ -548,12 +550,17 @@ pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
                         status.version, cli_version
                     );
                     println!("     Run: mise run restart");
+                    fail_count += 1;
                 }
             }
-            _ => println!("[!!] Socket exists but daemon not responding"),
+            _ => {
+                println!("[!!] Socket exists but daemon not responding");
+                fail_count += 1;
+            }
         }
     } else {
         println!("[!!] Daemon socket not found at {:?}", socket);
+        fail_count += 1;
     }
 
     // Check database
@@ -577,10 +584,13 @@ pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
     let lm_url = format!("{}/models", config.lmstudio.base_url);
     match client.get(&lm_url).send().await {
         Ok(r) if r.status().is_success() => println!("[OK] LM Studio reachable"),
-        _ => println!(
-            "[!!] LM Studio not reachable at {}",
-            config.lmstudio.base_url
-        ),
+        _ => {
+            println!(
+                "[!!] LM Studio not reachable at {}",
+                config.lmstudio.base_url
+            );
+            fail_count += 1;
+        }
     }
 
     // Check brain
@@ -592,6 +602,7 @@ pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
         .unwrap_or(0);
     if fallback_files > 0 {
         println!("[!!] {} fallback files pending recovery", fallback_files);
+        fail_count += 1;
     } else {
         println!("[OK] No fallback files pending");
     }
@@ -599,6 +610,7 @@ pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
     // Check embedding model
     if config.models.embedding.is_empty() {
         println!("[!!] No embedding model configured");
+        fail_count += 1;
     } else {
         println!("[OK] Embedding model: {}", config.models.embedding);
     }
@@ -616,6 +628,23 @@ pub async fn handle_doctor(config: &HippoConfig) -> Result<()> {
 
     // Check OpenTelemetry configuration
     check_otel_status(config, &client).await;
+
+    // Check 1: Per-source staleness via source_health table (P0.1)
+    // Check 8: Watchdog heartbeat
+    if db_path.exists() && let Ok(conn) = hippo_core::storage::open_db(&db_path) {
+        fail_count += check_source_staleness(&conn, explain);
+        fail_count += check_watchdog_heartbeat(&conn, explain);
+    }
+
+    // Check 4: zsh hook sourced
+    fail_count += check_zsh_hook_sourced(explain);
+
+    // Check 7: Log file sizes
+    fail_count += check_log_file_sizes(config, explain);
+
+    if fail_count > 0 {
+        std::process::exit(1);
+    }
 
     Ok(())
 }
@@ -835,6 +864,427 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) {
         }
         (false, false) => {
             println!("[--] OpenTelemetry: disabled (start with: mise run otel:up)");
+        }
+    }
+}
+
+/// Check 1: Per-source staleness via the `source_health` table (requires P0.1 migration).
+///
+/// Returns the number of failing (hard-threshold) checks.
+fn check_source_staleness(db: &rusqlite::Connection, explain: bool) -> u32 {
+    // Query source_health — if the table doesn't exist yet, print a soft notice and bail.
+    let rows_result = db.prepare(
+        "SELECT source, last_event_ts, last_error_msg, consecutive_failures, events_last_1h, probe_ok \
+         FROM source_health \
+         WHERE source IN ('shell', 'browser', 'claude-session', 'claude-tool') \
+         ORDER BY source",
+    );
+
+    let mut stmt = match rows_result {
+        Ok(s) => s,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("no such table") {
+                println!(
+                    "[--] source health             table not yet created (run hippo daemon install --force)"
+                );
+            } else {
+                println!("[!!] source health             DB error: {}", e);
+            }
+            return 0;
+        }
+    };
+
+    struct SourceRow {
+        source: String,
+        last_event_ts: Option<i64>,
+        probe_ok: Option<i64>,
+    }
+
+    let rows: Vec<SourceRow> = match stmt.query_map([], |row| {
+        Ok(SourceRow {
+            source: row.get(0)?,
+            last_event_ts: row.get(1)?,
+            // columns 2, 3, 4 are last_error_msg, consecutive_failures, events_last_1h — not used
+            probe_ok: row.get(5)?,
+        })
+    }) {
+        Ok(mapped) => mapped.flatten().collect(),
+        Err(e) => {
+            println!("[!!] source health             query error: {}", e);
+            return 0;
+        }
+    };
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    struct Thresholds {
+        warn_secs: i64,
+        fail_secs: i64,
+    }
+
+    let thresholds_for = |source: &str| -> Thresholds {
+        match source {
+            "shell" => Thresholds {
+                warn_secs: 60,
+                fail_secs: 300,
+            },
+            "claude-session" => Thresholds {
+                warn_secs: 300,
+                fail_secs: 1800,
+            },
+            "claude-tool" => Thresholds {
+                warn_secs: 300,
+                fail_secs: 600,
+            },
+            "browser" => Thresholds {
+                warn_secs: 120,
+                fail_secs: 600,
+            },
+            _ => Thresholds {
+                warn_secs: 300,
+                fail_secs: 1800,
+            },
+        }
+    };
+
+    // Check Firefox running (for browser suppression).
+    let firefox_running = || -> bool {
+        std::process::Command::new("pgrep")
+            .args(["-x", "firefox-bin"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    };
+
+    // Check if there's a recent claude JSONL with mtime < 5 minutes (for claude-session suppression).
+    let recent_claude_session = || -> bool {
+        let projects_dir = match dirs::home_dir() {
+            Some(h) => h.join(".claude/projects"),
+            None => return false,
+        };
+        let five_min_ago = std::time::SystemTime::now()
+            .checked_sub(std::time::Duration::from_secs(300))
+            .unwrap_or(std::time::UNIX_EPOCH);
+        let Ok(entries) = std::fs::read_dir(&projects_dir) else {
+            return false;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+                && let Ok(meta) = std::fs::metadata(&path)
+                && let Ok(modified) = meta.modified()
+                && modified > five_min_ago
+            {
+                return true;
+            }
+            // Also recurse one level (projects/*/session.jsonl layout).
+            if path.is_dir() && let Ok(sub) = std::fs::read_dir(&path) {
+                for sub_entry in sub.flatten() {
+                    let sub_path = sub_entry.path();
+                    if sub_path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+                        && let Ok(meta) = std::fs::metadata(&sub_path)
+                        && let Ok(modified) = meta.modified()
+                        && modified > five_min_ago
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    };
+
+    let mut fail_count: u32 = 0;
+
+    // All four expected sources — report missing ones too.
+    let all_sources = ["browser", "claude-session", "claude-tool", "shell"];
+    for source in all_sources {
+        let label = format!("{} events", source);
+        let padded = format!("{:<29}", label);
+
+        let row = rows.iter().find(|r| r.source == source);
+
+        let Some(row) = row else {
+            println!("[--] {}  no data", padded);
+            continue;
+        };
+
+        let Some(last_ts) = row.last_event_ts else {
+            println!("[--] {}  never seen", padded);
+            continue;
+        };
+
+        let age_secs = (now_ms - last_ts) / 1000;
+        let human = format_age_secs(age_secs);
+        let thresh = thresholds_for(source);
+
+        if age_secs < thresh.warn_secs {
+            println!("[OK] {}  {}", padded, human);
+        } else if age_secs < thresh.fail_secs {
+            println!("[WW] {}  {} (WARN)", padded, human);
+        } else {
+            // Check suppression conditions.
+            let suppressed = match source {
+                "shell" => row.probe_ok == Some(0),
+                "claude-session" => !recent_claude_session(),
+                "claude-tool" => row.probe_ok == Some(0),
+                "browser" => !firefox_running(),
+                _ => false,
+            };
+
+            if suppressed {
+                let reason = match source {
+                    "browser" => "no active Firefox session",
+                    "claude-session" => "no active session",
+                    _ => "probe disabled",
+                };
+                println!("[WW] {}  {} (suppressed — {})", padded, human, reason);
+            } else {
+                println!("[!!] {}  {} (FAIL)", padded, human);
+                fail_count += 1;
+                if explain {
+                    println!(
+                        "     CAUSE:  No events have landed in SQLite for this source"
+                    );
+                    println!(
+                        "     FIX:    Check source is running: hippo doctor (re-run); tail -f ~/.local/share/hippo/daemon.stderr.log"
+                    );
+                    println!("     DOC:    docs/capture-reliability/02-invariants.md");
+                }
+            }
+        }
+    }
+
+    fail_count
+}
+
+/// Format age in seconds to a human-readable string.
+fn format_age_secs(secs: i64) -> String {
+    if secs < 60 {
+        format!("{}s ago", secs)
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86400)
+    }
+}
+
+/// Check 4: Verify that hippo.zsh is sourced in a zsh startup file.
+///
+/// Returns 1 if not found in any zshrc/zshenv, 0 otherwise.
+fn check_zsh_hook_sourced(explain: bool) -> u32 {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => {
+            println!("[--] zsh hook sourced           cannot determine home dir");
+            return 0;
+        }
+    };
+
+    let candidates = [
+        home.join(".zshrc"),
+        home.join(".zshenv"),
+        home.join(".config/zsh/.zshrc"),
+        home.join(".config/zsh/.zshenv"),
+    ];
+
+    for candidate in &candidates {
+        if !candidate.exists() {
+            continue;
+        }
+        let content = match std::fs::read_to_string(candidate) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for line in content.lines() {
+            if line.contains("hippo.zsh") {
+                // Extract the sourced path (the token after "source" or ".").
+                let sourced_path: Option<&str> = line
+                    .split_whitespace()
+                    .skip_while(|t| *t != "source" && *t != ".")
+                    .nth(1);
+                let script_exists = sourced_path
+                    .map(|p| {
+                        let expanded = if let Some(rest) = p.strip_prefix("~/") {
+                            home.join(rest)
+                        } else {
+                            std::path::PathBuf::from(p)
+                        };
+                        expanded.exists()
+                    })
+                    .unwrap_or(false);
+
+                let short_candidate = candidate
+                    .strip_prefix(&home)
+                    .map(|p| format!("~/{}", p.display()))
+                    .unwrap_or_else(|_| candidate.display().to_string());
+
+                if script_exists {
+                    println!(
+                        "[OK] {:<29}  found in {}",
+                        "zsh hook sourced", short_candidate
+                    );
+                } else {
+                    let path_str = sourced_path.unwrap_or("<unknown>");
+                    println!(
+                        "[WW] {:<29}  source line found but script missing at {}",
+                        "zsh hook sourced", path_str
+                    );
+                }
+                return 0;
+            }
+        }
+    }
+
+    println!(
+        "[!!] {:<29}  not found in any zshrc/zshenv",
+        "zsh hook sourced"
+    );
+    if explain {
+        println!("     CAUSE:  Shell hook not loaded — shell events cannot be captured");
+        println!("     FIX:    Add to ~/.zshrc: source ~/.local/share/hippo/hippo.zsh");
+        println!("     DOC:    docs/capture-reliability/08-anti-patterns.md");
+    }
+    1
+}
+
+/// Check 7: Warn/fail on large log files in the hippo data directory.
+///
+/// Returns 1 if any file exceeds 200 MB, 0 otherwise.
+fn check_log_file_sizes(config: &HippoConfig, explain: bool) -> u32 {
+    let data_dir = &config.storage.data_dir;
+    if !data_dir.exists() {
+        println!("[--] {:<29}  data dir not found", "log file sizes");
+        return 0;
+    }
+
+    let entries = match std::fs::read_dir(data_dir) {
+        Ok(e) => e,
+        Err(err) => {
+            println!(
+                "[--] {:<29}  cannot read data dir: {}",
+                "log file sizes", err
+            );
+            return 0;
+        }
+    };
+
+    let mut largest_warn: Option<(String, u64)> = None;
+    let mut largest_fail: Option<(String, u64)> = None;
+
+    const WARN_BYTES: u64 = 50 * 1024 * 1024; // 50 MB
+    const FAIL_BYTES: u64 = 200 * 1024 * 1024; // 200 MB
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext != "log" && ext != "jsonl" {
+            continue;
+        }
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        let size = meta.len();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("?")
+            .to_string();
+
+        if size >= FAIL_BYTES {
+            match &largest_fail {
+                None => largest_fail = Some((name, size)),
+                Some((_, prev)) if size > *prev => largest_fail = Some((name, size)),
+                _ => {}
+            }
+        } else if size >= WARN_BYTES {
+            match &largest_warn {
+                None => largest_warn = Some((name, size)),
+                Some((_, prev)) if size > *prev => largest_warn = Some((name, size)),
+                _ => {}
+            }
+        }
+    }
+
+    if let Some((name, size)) = largest_fail {
+        let size_mb = size / (1024 * 1024);
+        println!("[!!] {:<29}  {}: {}MB", "log file sizes", name, size_mb);
+        if explain {
+            println!("     CAUSE:  Log file growing without rotation");
+            println!(
+                "     FIX:    Upgrade hippo to a version with log rotation, or: truncate -s 0 {}",
+                name
+            );
+            println!("     DOC:    docs/capture-reliability/07-roadmap.md");
+        }
+        return 1;
+    }
+
+    if let Some((name, size)) = largest_warn {
+        let size_mb = size / (1024 * 1024);
+        println!("[WW] {:<29}  {}: {}MB", "log file sizes", name, size_mb);
+        return 0;
+    }
+
+    println!("[OK] {:<29}  all under 50MB", "log file sizes");
+    0
+}
+
+/// Check 8: Watchdog heartbeat — verify the watchdog row in source_health is fresh.
+///
+/// Returns 1 if the watchdog row is stale (>= 180s), 0 otherwise.
+fn check_watchdog_heartbeat(db: &rusqlite::Connection, explain: bool) -> u32 {
+    let result = db.query_row(
+        "SELECT updated_at, (unixepoch('now')*1000 - updated_at)/1000 AS age_secs \
+         FROM source_health WHERE source = 'watchdog' LIMIT 1",
+        [],
+        |row| {
+            let _updated_at: i64 = row.get(0)?;
+            let age_secs: i64 = row.get(1)?;
+            Ok(age_secs)
+        },
+    );
+
+    match result {
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            println!("[--] {:<29}  not installed", "watchdog heartbeat");
+            0
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            // Treat "no such table" the same as "no row" — watchdog not yet installed.
+            let _ = msg;
+            println!("[--] {:<29}  not installed", "watchdog heartbeat");
+            0
+        }
+        Ok(age_secs) => {
+            if age_secs < 60 {
+                println!("[OK] {:<29}  {}s ago", "watchdog heartbeat", age_secs);
+                0
+            } else if age_secs < 180 {
+                println!(
+                    "[WW] {:<29}  {}s ago (WARN, expected < 60s)",
+                    "watchdog heartbeat", age_secs
+                );
+                0
+            } else {
+                println!(
+                    "[!!] {:<29}  stale {}s ago (FAIL)",
+                    "watchdog heartbeat", age_secs
+                );
+                if explain {
+                    println!("     CAUSE:  Watchdog has stopped sending heartbeats");
+                    println!("     FIX:    Restart the watchdog service: mise run restart");
+                    println!("     DOC:    docs/capture-reliability/07-roadmap.md");
+                }
+                1
+            }
         }
     }
 }
@@ -1496,5 +1946,60 @@ replacement = "***"
         config.storage.data_dir = temp.path().join("hippo");
         // Script doesn't exist on disk → prints [!!] configured but script missing
         check_claude_session_hook_at(&config, &settings);
+    }
+
+    #[test]
+    fn test_doctor_staleness_check() {
+        // Use a real temp-file DB. When P0.1 is merged this will pick up source_health
+        // from the full schema. Until then we create the table manually so the
+        // staleness logic can be exercised independently.
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("hippo.db");
+        let conn = hippo_core::storage::open_db(&db_path).unwrap();
+
+        // Create source_health if the migration hasn't run yet (pre-P0.1 schema).
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS source_health (
+                source                 TEXT PRIMARY KEY,
+                last_event_ts          INTEGER,
+                last_success_ts        INTEGER,
+                last_error_ts          INTEGER,
+                last_error_msg         TEXT,
+                consecutive_failures   INTEGER NOT NULL DEFAULT 0,
+                events_last_1h         INTEGER NOT NULL DEFAULT 0,
+                events_last_24h        INTEGER NOT NULL DEFAULT 0,
+                expected_min_per_hour  INTEGER,
+                probe_ok               INTEGER,
+                probe_lag_ms           INTEGER,
+                probe_last_run_ts      INTEGER,
+                last_heartbeat_ts      INTEGER,
+                updated_at             INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+
+        // Seed a stale shell row: 1 hour ago (3600s past the 300s FAIL threshold).
+        conn.execute(
+            "INSERT OR REPLACE INTO source_health \
+             (source, last_event_ts, consecutive_failures, updated_at) \
+             VALUES ('shell', (unixepoch('now')-3600)*1000, 0, unixepoch('now')*1000)",
+            [],
+        )
+        .unwrap();
+
+        let fail = check_source_staleness(&conn, false);
+        assert_eq!(fail, 1, "stale shell row should return fail_count=1");
+
+        // Now seed a fresh shell row (1 second ago) and assert 0 failures.
+        conn.execute(
+            "INSERT OR REPLACE INTO source_health \
+             (source, last_event_ts, consecutive_failures, updated_at) \
+             VALUES ('shell', (unixepoch('now')-1)*1000, 0, unixepoch('now')*1000)",
+            [],
+        )
+        .unwrap();
+
+        let fail2 = check_source_staleness(&conn, false);
+        assert_eq!(fail2, 0, "fresh shell row should return fail_count=0");
     }
 }

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -622,9 +622,9 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
     check_firefox_extension();
 
     // Per-source capture-freshness audit (one line per raw data source
-    // hippo is supposed to collect). Bridge until the `source_health`
-    // table (docs/capture-reliability/01-source-health.md, P0.1) lands.
-    check_source_freshness(config);
+    // hippo is supposed to collect). Uses day-level thresholds — complements
+    // the seconds-level `check_source_staleness` below.
+    fail_count += check_source_freshness(config);
 
     // Check OpenTelemetry configuration
     fail_count += check_otel_status(config, &client).await;
@@ -658,32 +658,35 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
 /// `docs/capture-reliability/10-source-audit.md`). Queries the underlying
 /// tables directly so it works without the `source_health` table (which
 /// is still a P0.1 roadmap item).
-fn check_source_freshness(config: &HippoConfig) {
+fn check_source_freshness(config: &HippoConfig) -> u32 {
     let db_path = config.db_path();
     if !db_path.exists() {
         println!("[--] Source freshness: database not created yet");
-        return;
+        return 0;
     }
 
     let conn = match hippo_core::storage::open_db(&db_path) {
         Ok(c) => c,
         Err(e) => {
             println!("[!!] Source freshness: failed to open DB: {e}");
-            return;
+            return 1;
         }
     };
 
     let now_ms = chrono::Utc::now().timestamp_millis();
+    let mut fail_count = 0u32;
     for probe in source_freshness_probes() {
         let (count, max_ts): (i64, Option<i64>) = conn
             .query_row(probe.query, [], |r| Ok((r.get(0)?, r.get(1)?)))
             .unwrap_or((0, None));
 
-        println!(
-            "{}",
-            source_freshness_verdict(probe.name, count, max_ts, now_ms, probe.thresholds)
-        );
+        let line = source_freshness_verdict(probe.name, count, max_ts, now_ms, probe.thresholds);
+        if line.starts_with("[!!]") {
+            fail_count += 1;
+        }
+        println!("{}", line);
     }
+    fail_count
 }
 
 /// Soft/hard staleness thresholds in milliseconds.
@@ -894,10 +897,10 @@ fn check_source_staleness(db: &rusqlite::Connection, explain: bool) -> u32 {
                 println!(
                     "[--] source health             table not yet created (run hippo daemon install --force)"
                 );
-            } else {
-                println!("[!!] source health             DB error: {}", e);
+                return 0;
             }
-            return 0;
+            println!("[!!] source health             DB error: {}", e);
+            return 1;
         }
     };
 
@@ -907,7 +910,7 @@ fn check_source_staleness(db: &rusqlite::Connection, explain: bool) -> u32 {
         probe_ok: Option<i64>,
     }
 
-    let rows: Vec<SourceRow> = match stmt.query_map([], |row| {
+    let mapped = match stmt.query_map([], |row| {
         Ok(SourceRow {
             source: row.get(0)?,
             last_event_ts: row.get(1)?,
@@ -915,10 +918,17 @@ fn check_source_staleness(db: &rusqlite::Connection, explain: bool) -> u32 {
             probe_ok: row.get(5)?,
         })
     }) {
-        Ok(mapped) => mapped.flatten().collect(),
+        Ok(m) => m,
         Err(e) => {
             println!("[!!] source health             query error: {}", e);
-            return 0;
+            return 1;
+        }
+    };
+    let rows: Vec<SourceRow> = match mapped.collect::<rusqlite::Result<Vec<_>>>() {
+        Ok(r) => r,
+        Err(e) => {
+            println!("[!!] source health             row error: {}", e);
+            return 1;
         }
     };
 
@@ -1113,42 +1123,60 @@ fn check_zsh_hook_sourced(explain: bool) -> u32 {
             Err(_) => continue,
         };
         for line in content.lines() {
-            if line.contains("hippo.zsh") {
-                // Extract the sourced path (the token after "source" or ".").
-                let sourced_path: Option<&str> = line
-                    .split_whitespace()
-                    .skip_while(|t| *t != "source" && *t != ".")
-                    .nth(1);
-                let script_exists = sourced_path
-                    .map(|p| {
-                        let expanded = if let Some(rest) = p.strip_prefix("~/") {
-                            home.join(rest)
-                        } else {
-                            std::path::PathBuf::from(p)
-                        };
-                        expanded.exists()
-                    })
-                    .unwrap_or(false);
-
-                let short_candidate = candidate
-                    .strip_prefix(&home)
-                    .map(|p| format!("~/{}", p.display()))
-                    .unwrap_or_else(|_| candidate.display().to_string());
-
-                if script_exists {
-                    println!(
-                        "[OK] {:<29}  found in {}",
-                        "zsh hook sourced", short_candidate
-                    );
-                } else {
-                    let path_str = sourced_path.unwrap_or("<unknown>");
-                    println!(
-                        "[WW] {:<29}  source line found but script missing at {}",
-                        "zsh hook sourced", path_str
-                    );
-                }
-                return 0;
+            // Skip blank and commented lines — a commented-out `# source …hippo.zsh`
+            // is not an active source directive.
+            let trimmed = line.trim_start();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
             }
+
+            // Require the line to actually start with `source` or `.` (the POSIX
+            // sourcing commands). Substring-matching `hippo.zsh` anywhere in the
+            // line gave false positives on comments, variable assignments, etc.
+            let mut tokens = trimmed.split_whitespace();
+            let Some(cmd) = tokens.next() else { continue };
+            if cmd != "source" && cmd != "." {
+                continue;
+            }
+            let sourced_path: Option<&str> = tokens
+                .next()
+                .map(|p| p.trim_matches(|c: char| c == '"' || c == '\'' || c == ';'));
+            if !sourced_path
+                .map(|p| p.contains("hippo.zsh"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            let script_exists = sourced_path
+                .map(|p| {
+                    let expanded = if let Some(rest) = p.strip_prefix("~/") {
+                        home.join(rest)
+                    } else {
+                        std::path::PathBuf::from(p)
+                    };
+                    expanded.exists()
+                })
+                .unwrap_or(false);
+
+            let short_candidate = candidate
+                .strip_prefix(&home)
+                .map(|p| format!("~/{}", p.display()))
+                .unwrap_or_else(|_| candidate.display().to_string());
+
+            if script_exists {
+                println!(
+                    "[OK] {:<29}  found in {}",
+                    "zsh hook sourced", short_candidate
+                );
+            } else {
+                let path_str = sourced_path.unwrap_or("<unknown>");
+                println!(
+                    "[WW] {:<29}  source line found but script missing at {}",
+                    "zsh hook sourced", path_str
+                );
+            }
+            return 0;
         }
     }
 
@@ -1226,10 +1254,11 @@ fn check_log_file_sizes(config: &HippoConfig, explain: bool) -> u32 {
         let size_mb = size / (1024 * 1024);
         println!("[!!] {:<29}  {}: {}MB", "log file sizes", name, size_mb);
         if explain {
+            let full_path = data_dir.join(&name);
             println!("     CAUSE:  Log file growing without rotation");
             println!(
                 "     FIX:    Upgrade hippo to a version with log rotation, or: truncate -s 0 {}",
-                name
+                full_path.display()
             );
             println!("     DOC:    docs/capture-reliability/07-roadmap.md");
         }

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -828,8 +828,8 @@ async fn main() -> Result<()> {
         Commands::NativeMessagingHost => {
             hippo_daemon::native_messaging::run(&config).await?;
         }
-        Commands::Doctor => {
-            commands::handle_doctor(&config).await?;
+        Commands::Doctor { explain } => {
+            commands::handle_doctor(&config, explain).await?;
         }
     }
 


### PR DESCRIPTION
## Summary

Adds four new `hippo doctor` checks (P0.3 capture reliability overhaul), a proper exit code, and `--explain` for remediation steps.

- **Exit code:** `handle_doctor` now tracks `fail_count` across all checks and calls `std::process::exit(1)` when any `[!!]` fires. Existing checks (`[!!] Daemon socket not found`, `[!!] version mismatch`, `[!!] LM Studio not reachable`, `[!!] fallback files pending`, `[!!] No embedding model`) are now wired into `fail_count`.
- **`--explain` flag:** `hippo doctor --explain` prints `CAUSE / FIX / DOC` lines under each failing new check.
- **Check 1 — `check_source_staleness`:** queries `source_health` for per-source event freshness with per-source WARN/FAIL thresholds. Suppresses browser FAIL when Firefox isn't running; suppresses claude-session FAIL when no JSONL modified in last 5 minutes. Falls back gracefully to `[--]` if the table doesn't exist (pre-P0.1 schema).
- **Check 4 — `check_zsh_hook_sourced`:** searches `~/.zshrc`, `~/.zshenv`, `~/.config/zsh/.zshrc`, `~/.config/zsh/.zshenv` for a `hippo.zsh` source line and verifies the script exists on disk.
- **Check 7 — `check_log_file_sizes`:** scans `~/.local/share/hippo/` for `*.log`/`*.jsonl` files; `[WW]` at 50MB, `[!!]` at 200MB.
- **Check 8 — `check_watchdog_heartbeat`:** reads the `watchdog` row from `source_health`; shows `[--] not installed` until P1.1 (watchdog) is implemented — this is correct.
- **`WatchdogConfig`:** added to `hippo-core` following the exact `BrainConfig` `serde(default)` pattern.
- **Test:** `test_doctor_staleness_check` seeds stale/fresh shell rows and asserts `fail_count` = 1 / 0.

## Dependencies

**Depends on P0.1 (`feat/p0.1-source-health-schema`)** for checks 1 and 8 to return real data. Until P0.1 is merged and the DB migrated, `check_source_staleness` prints `[--] source health   table not yet created` and `check_watchdog_heartbeat` shows `[--] not installed` — both return 0, no false alarms.

Check 8 (watchdog heartbeat) will continue to show `[--] not installed` until P1.1 (watchdog daemon) is implemented — that is the intended behavior.

Out of scope for this PR: checks 2, 3, 5, 6, 9, 10 (P1.3).

## Test plan

- [ ] `cargo build -p hippo-daemon` — clean
- [ ] `cargo test -p hippo-daemon --lib` — 84 passed, 0 failed (was 83)
- [ ] `cargo clippy -p hippo-daemon -- -D warnings` — clean
- [ ] `cargo clippy -p hippo-core -- -D warnings` — clean
- [ ] `hippo doctor` — exits 1 when daemon not running, exits 0 when healthy
- [ ] `hippo doctor --explain` — prints CAUSE/FIX/DOC for failing staleness checks
- [ ] After P0.1 migration: `hippo doctor` shows per-source staleness lines from `source_health`