### PR TITLE
feat(otel): in-process process.* metrics for daemon + brain (#30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tracing",
@@ -1152,6 +1153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1193,25 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1940,6 +1969,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2604,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +2657,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2600,6 +2697,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -2662,6 +2769,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/brain/src/hippo_brain/telemetry.py
+++ b/brain/src/hippo_brain/telemetry.py
@@ -160,7 +160,9 @@ def _register_process_metrics() -> None:
     def _safe_observations(get_value) -> list[Observation]:
         try:
             return [Observation(get_value(), {})]
-        except psutil.NoSuchProcess, psutil.AccessDenied:
+        except psutil.Error:
+            # Covers NoSuchProcess / AccessDenied / ZombieProcess / TimeoutExpired —
+            # all surface only transient failures we want to soft-ignore.
             return []
 
     def cpu_cb(_options: CallbackOptions) -> list[Observation]:

--- a/brain/src/hippo_brain/telemetry.py
+++ b/brain/src/hippo_brain/telemetry.py
@@ -78,6 +78,8 @@ def init_telemetry(
     meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
     otel_metrics.set_meter_provider(meter_provider)
 
+    _register_process_metrics()
+
     logger.info(
         "OpenTelemetry initialized: endpoint=%s, service=%s",
         endpoint,
@@ -131,3 +133,88 @@ def hist(histogram, value, **attrs):
     """Record an OTel histogram value if it exists (no-op when ``None``)."""
     if histogram:
         histogram.record(value, attrs)
+
+
+def _register_process_metrics() -> None:
+    """Register OTel process.* semantic-convention metrics via psutil.
+
+    Uses observable gauges/counters so sampling happens lazily, on the OTel
+    export tick, without a separate background task. Safe to call exactly once
+    after ``set_meter_provider``; subsequent calls would register duplicate
+    instruments and emit SDK warnings.
+    """
+    try:
+        from opentelemetry import metrics as otel_metrics
+        from opentelemetry.metrics import CallbackOptions, Observation
+
+        import psutil
+    except ImportError as e:
+        logger.warning("process metrics unavailable: %s", e)
+        return
+
+    proc = psutil.Process()
+    # First cpu_percent() call returns 0.0 and seeds the delta baseline.
+    # Subsequent calls report utilization over the interval since the last call.
+    proc.cpu_percent(interval=None)
+
+    def _safe_observations(get_value) -> list[Observation]:
+        try:
+            return [Observation(get_value(), {})]
+        except psutil.NoSuchProcess, psutil.AccessDenied:
+            return []
+
+    def cpu_cb(_options: CallbackOptions) -> list[Observation]:
+        # psutil returns process CPU as percent of a single CPU (100 = one full
+        # core). OTel process.cpu.utilization is "fraction of one CPU" per
+        # semconv — dividing by 100 matches.
+        return _safe_observations(lambda: proc.cpu_percent(interval=None) / 100.0)
+
+    def rss_cb(_options: CallbackOptions) -> list[Observation]:
+        return _safe_observations(lambda: proc.memory_info().rss)
+
+    def vms_cb(_options: CallbackOptions) -> list[Observation]:
+        return _safe_observations(lambda: proc.memory_info().vms)
+
+    def threads_cb(_options: CallbackOptions) -> list[Observation]:
+        return _safe_observations(proc.num_threads)
+
+    def cpu_time_cb(_options: CallbackOptions) -> list[Observation]:
+        def _total_ms() -> int:
+            times = proc.cpu_times()
+            return int((times.user + times.system) * 1000)
+
+        return _safe_observations(_total_ms)
+
+    meter = otel_metrics.get_meter("hippo-brain.process")
+    meter.create_observable_gauge(
+        "process.cpu.utilization",
+        callbacks=[cpu_cb],
+        unit="1",
+        description=(
+            "Difference in process.cpu.time since last observation, "
+            "divided by interval time (1.0 = one full CPU)."
+        ),
+    )
+    meter.create_observable_gauge(
+        "process.memory.usage",
+        callbacks=[rss_cb],
+        unit="By",
+        description="Resident set size of the process.",
+    )
+    meter.create_observable_gauge(
+        "process.memory.virtual",
+        callbacks=[vms_cb],
+        unit="By",
+        description="Virtual memory size of the process.",
+    )
+    meter.create_observable_gauge(
+        "process.threads",
+        callbacks=[threads_cb],
+        description="Number of OS threads in the process.",
+    )
+    meter.create_observable_counter(
+        "process.cpu.time",
+        callbacks=[cpu_time_cb],
+        unit="ms",
+        description="Total CPU time consumed by the process.",
+    )

--- a/brain/tests/test_telemetry.py
+++ b/brain/tests/test_telemetry.py
@@ -73,3 +73,37 @@ def test_get_meter_returns_none_when_disabled():
         os.environ.pop("HIPPO_OTEL_ENABLED", None)
         result = get_meter()
         assert result is None
+
+
+def test_process_metrics_registered_when_enabled():
+    """init_telemetry should register process.* observable instruments without error."""
+    with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
+        from hippo_brain.telemetry import init_telemetry
+
+        shutdown = init_telemetry("test-service", endpoint="http://localhost:4318")
+        assert shutdown is not None
+        try:
+            # Registration happens inside init_telemetry; if it raised we wouldn't
+            # get here. Exercise the callbacks via a forced collect to make sure
+            # none of them blow up on this interpreter.
+            from opentelemetry import metrics as otel_metrics
+
+            provider = otel_metrics.get_meter_provider()
+            force_flush = getattr(provider, "force_flush", None)
+            if callable(force_flush):
+                force_flush(timeout_millis=500)
+        finally:
+            shutdown()
+
+
+def test_process_metrics_missing_psutil_is_soft_failure(monkeypatch):
+    """If psutil import fails, _register_process_metrics logs and returns; does not raise."""
+    import sys
+
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    if "hippo_brain.telemetry" in sys.modules:
+        del sys.modules["hippo_brain.telemetry"]
+    from hippo_brain.telemetry import _register_process_metrics
+
+    # Should not raise even with psutil masked out.
+    _register_process_metrics()

--- a/crates/hippo-daemon/Cargo.toml
+++ b/crates/hippo-daemon/Cargo.toml
@@ -34,6 +34,7 @@ opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry-appender-tracing = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
+sysinfo = { version = "0.38", optional = true, default-features = false, features = ["system"] }
 which = "8.0.2"
 
 [features]
@@ -44,6 +45,7 @@ otel = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-appender-tracing",
     "dep:tracing-opentelemetry",
+    "dep:sysinfo",
 ]
 
 [dev-dependencies]

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -479,6 +479,8 @@ pub async fn run(config: HippoConfig) -> Result<()> {
         use opentelemetry::global;
         let meter = global::meter("hippo-daemon");
 
+        crate::process_metrics::register();
+
         let state_ref = Arc::clone(&state);
         let _ = meter
             .u64_observable_gauge("hippo.daemon.buffer.size")

--- a/crates/hippo-daemon/src/lib.rs
+++ b/crates/hippo-daemon/src/lib.rs
@@ -8,6 +8,8 @@ pub mod git_repo;
 #[cfg(feature = "otel")]
 pub mod metrics;
 pub mod native_messaging;
+#[cfg(feature = "otel")]
+pub mod process_metrics;
 pub mod schema_handshake;
 #[cfg(feature = "otel")]
 pub mod telemetry;

--- a/crates/hippo-daemon/src/process_metrics.rs
+++ b/crates/hippo-daemon/src/process_metrics.rs
@@ -1,0 +1,158 @@
+//! OpenTelemetry process.* semantic-convention metrics for hippo-daemon.
+//!
+//! Samples the current process's CPU utilization, RSS/VSZ memory, thread count,
+//! and cumulative CPU time at a fixed interval via `sysinfo`, then exposes them
+//! as OTel observable gauges and a counter. Only compiled with `--features otel`.
+//!
+//! Implementation note: a background tokio task refreshes `sysinfo` state on a
+//! timer and stores the latest values in atomics. Observable callbacks read the
+//! atomics without touching `sysinfo` themselves — this decouples sampling
+//! cadence from exporter cadence and keeps the callbacks lock-free.
+
+use opentelemetry::global;
+use std::process;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+use tokio::time::{self, Duration};
+
+/// How often the background task refreshes sysinfo and updates atomics.
+/// 10s lines up with a typical 10–15s OTel export interval without
+/// oversampling. CPU% is computed by sysinfo across the refresh delta.
+const REFRESH_INTERVAL_SECS: u64 = 10;
+
+/// Shared sampling state. Atomics so observable callbacks are lock-free and
+/// can run concurrently with the refresh task.
+struct Samples {
+    /// CPU utilization × 10_000. Divided back to f64 in the 0.0–N.0 range
+    /// (where N is the CPU count) when exported. Integer storage keeps the
+    /// struct Send + Sync without a Mutex.
+    cpu_ratio_x10k: AtomicU64,
+    rss_bytes: AtomicU64,
+    vms_bytes: AtomicU64,
+    accumulated_cpu_ms: AtomicU64,
+}
+
+impl Samples {
+    const fn new() -> Self {
+        Self {
+            cpu_ratio_x10k: AtomicU64::new(0),
+            rss_bytes: AtomicU64::new(0),
+            vms_bytes: AtomicU64::new(0),
+            accumulated_cpu_ms: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Register process.* observable gauges + spawn the refresh task. Call once,
+/// from `daemon::run` after telemetry init, under `cfg(feature = "otel")`.
+///
+/// Gauges stay alive because the SDK retains them via the registered callback;
+/// we drop the builder return values to avoid holding handles we don't need.
+pub fn register() {
+    let samples = Arc::new(Samples::new());
+    spawn_refresh_task(Arc::clone(&samples));
+
+    let meter = global::meter("hippo-daemon");
+
+    let s_cpu = Arc::clone(&samples);
+    let _ = meter
+        .f64_observable_gauge("process.cpu.utilization")
+        .with_description("Difference in process.cpu.time since last observation, divided by interval time (1.0 = one full CPU).")
+        .with_unit("1")
+        .with_callback(move |g| {
+            let raw = s_cpu.cpu_ratio_x10k.load(Ordering::Relaxed);
+            g.observe(raw as f64 / 10_000.0, &[]);
+        })
+        .build();
+
+    let s_rss = Arc::clone(&samples);
+    let _ = meter
+        .u64_observable_gauge("process.memory.usage")
+        .with_description("Resident set size of the process.")
+        .with_unit("By")
+        .with_callback(move |g| {
+            g.observe(s_rss.rss_bytes.load(Ordering::Relaxed), &[]);
+        })
+        .build();
+
+    let s_vms = Arc::clone(&samples);
+    let _ = meter
+        .u64_observable_gauge("process.memory.virtual")
+        .with_description("Virtual memory size of the process.")
+        .with_unit("By")
+        .with_callback(move |g| {
+            g.observe(s_vms.vms_bytes.load(Ordering::Relaxed), &[]);
+        })
+        .build();
+
+    let s_cpu_time = Arc::clone(&samples);
+    let _ = meter
+        .u64_observable_counter("process.cpu.time")
+        .with_description("Total CPU time consumed by the process.")
+        .with_unit("ms")
+        .with_callback(move |c| {
+            c.observe(s_cpu_time.accumulated_cpu_ms.load(Ordering::Relaxed), &[]);
+        })
+        .build();
+}
+
+fn spawn_refresh_task(samples: Arc<Samples>) {
+    tokio::spawn(async move {
+        let self_pid = Pid::from_u32(process::id());
+        let mut sys = System::new();
+        let mut interval = time::interval(Duration::from_secs(REFRESH_INTERVAL_SECS));
+        // First tick returns immediately; second tick is REFRESH_INTERVAL_SECS
+        // away. The first refresh seeds the CPU delta baseline (cpu_usage()
+        // returns 0.0 on first call), so the first meaningful CPU sample lands
+        // at t = 2 * REFRESH_INTERVAL_SECS after startup.
+        loop {
+            interval.tick().await;
+            sys.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[self_pid]),
+                true,
+                ProcessRefreshKind::nothing().with_cpu().with_memory(),
+            );
+            if let Some(proc) = sys.process(self_pid) {
+                // cpu_usage() returns percent-of-one-core (0..100*N on N cores).
+                // OTel process.cpu.utilization is "fraction of one CPU" per
+                // semconv, matching this semantics. Store ×10_000 for 4-decimal
+                // precision without floats in atomics.
+                let cpu_x10k = (proc.cpu_usage() * 100.0) as u64;
+                samples.cpu_ratio_x10k.store(cpu_x10k, Ordering::Relaxed);
+                samples.rss_bytes.store(proc.memory(), Ordering::Relaxed);
+                samples
+                    .vms_bytes
+                    .store(proc.virtual_memory(), Ordering::Relaxed);
+                samples
+                    .accumulated_cpu_ms
+                    .store(proc.accumulated_cpu_time(), Ordering::Relaxed);
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn samples_default_zero() {
+        let s = Samples::new();
+        assert_eq!(s.cpu_ratio_x10k.load(Ordering::Relaxed), 0);
+        assert_eq!(s.rss_bytes.load(Ordering::Relaxed), 0);
+        assert_eq!(s.vms_bytes.load(Ordering::Relaxed), 0);
+        assert_eq!(s.accumulated_cpu_ms.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn refresh_task_populates_memory_sample() {
+        let samples = Arc::new(Samples::new());
+        spawn_refresh_task(Arc::clone(&samples));
+        // First tick is immediate; wait briefly for it to complete.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        // Memory is available on the first refresh (no delta required).
+        assert!(samples.rss_bytes.load(Ordering::Relaxed) > 0);
+        assert!(samples.vms_bytes.load(Ordering::Relaxed) > 0);
+    }
+}

--- a/otel/README.md
+++ b/otel/README.md
@@ -83,6 +83,20 @@ HIPPO_OTEL_RESET_CONFIRM=delete mise run otel:reset  # Backup, then stop + delet
 mise run otel:status                                 # Show container status
 ```
 
+## Process Metrics
+
+Daemon and brain emit OTel [`process.*` semantic-convention](https://opentelemetry.io/docs/specs/semconv/resource/process/) metrics from inside each process — no host-side exporter needed, so Docker-on-macOS host-visibility limits don't apply.
+
+| Metric | Kind | Unit | Source | Notes |
+|---|---|---|---|---|
+| `process.cpu.utilization` | Gauge | `1` (fraction of one core) | daemon, brain | Sampled at 10–15s |
+| `process.memory.usage` | Gauge | bytes (RSS) | daemon, brain | |
+| `process.memory.virtual` | Gauge | bytes (VSZ) | daemon, brain | |
+| `process.threads` | Gauge | count | brain only | Daemon omitted — sysinfo has no cross-platform thread count |
+| `process.cpu.time` | Counter | ms | daemon, brain | Cumulative user + system time |
+
+Series are labelled by `service_name` (`hippo-daemon` / `hippo-brain`) once the otel-collector translates them to Prometheus. See the **Hippo Processes** dashboard in Grafana.
+
 ## Storage and Retention
 
 - **Persistent data path:** `~/.local/share/hippo/otel/`

--- a/otel/grafana/dashboards/hippo-processes.json
+++ b/otel/grafana/dashboards/hippo-processes.json
@@ -1,0 +1,174 @@
+{
+  "uid": "hippo-processes",
+  "title": "Hippo Processes",
+  "tags": ["hippo", "observability", "process"],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU Utilization (fraction of one core)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "process_cpu_utilization_ratio",
+          "legendFormat": "{{service_name}}",
+          "editorMode": "code"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Resident Memory (RSS)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "process_memory_usage_bytes",
+          "legendFormat": "{{service_name}}",
+          "editorMode": "code"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Virtual Memory (VSZ)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "process_memory_virtual_bytes",
+          "legendFormat": "{{service_name}}",
+          "editorMode": "code"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Threads (brain only — daemon unsupported cross-platform)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "process_threads",
+          "legendFormat": "{{service_name}}",
+          "editorMode": "code"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "stepAfter",
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Cumulative CPU Time (rate/sec)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(process_cpu_time_milliseconds_total[5m]) / 1000",
+          "legendFormat": "{{service_name}}",
+          "editorMode": "code"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #30 (Path A from [discussion](https://github.com/stevencarpenter/hippo/issues/30#issuecomment-4312031226)).

## Summary

Adds per-process CPU / memory / thread / CPU-time metrics for `hippo-daemon` and `hippo-brain` using the [OTel `process.*` semantic conventions](https://opentelemetry.io/docs/specs/semconv/resource/process/). Metrics are emitted from **inside each process** through the existing OTel pipeline — no new Docker services, no node-exporter/process-exporter, and no macOS/Docker-VM host-visibility problem.

| Metric | Kind | Unit | Daemon | Brain |
|---|---|---|:-:|:-:|
| `process.cpu.utilization` | Gauge | `1` (fraction of one core) | ✅ | ✅ |
| `process.memory.usage` | Gauge | `By` (RSS) | ✅ | ✅ |
| `process.memory.virtual` | Gauge | `By` (VSZ) | ✅ | ✅ |
| `process.threads` | Gauge | count | ❌¹ | ✅ |
| `process.cpu.time` | Counter | `ms` | ✅ | ✅ |

¹ sysinfo doesn't expose a cross-platform thread count; skipped for the daemon and documented. Can follow up with a macOS-specific path if needed.

Series are labelled by `service_name` (`hippo-daemon` / `hippo-brain`) once the otel-collector translates to Prometheus.

## Implementation notes

**Daemon (Rust)** — `crates/hippo-daemon/src/process_metrics.rs`. A 10s tokio task refreshes `sysinfo` and stores values in atomics. Observable callbacks read atomics lock-free, decoupling sampling cadence from the exporter cadence. `sysinfo` is gated on the existing `otel` feature so the non-OTel build stays lean.

**Brain (Python)** — extends `brain/src/hippo_brain/telemetry.py`. Uses OTel observable callbacks directly against `psutil.Process()` (already a dep) — no background task needed because the Python SDK pulls on collection. First `cpu_percent(interval=None)` call seeds the delta baseline.

**Dashboard** — `otel/grafana/dashboards/hippo-processes.json`: CPU%, RSS, VSZ, threads, and cumulative CPU rate, all grouped by `service_name`.

## What this doesn't do

- **Disk I/O per process** — omitted for MVP. Possible follow-up via `psutil.Process.io_counters()` / macOS `proc_pidinfo`.
- **Network per process** — not feasible cross-platform without kernel-level hooks; out of scope.
- **HippoGUI** — omitted per earlier issue discussion; it's user-launched and transient, so continuous resource metrics are near-useless.

## Test plan

- [x] `cargo test -p hippo-daemon` — 86 passed (2 new: `process_metrics::tests::samples_default_zero`, `process_metrics::tests::refresh_task_populates_memory_sample`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `uv run --project brain pytest brain/tests` — 709 passed (2 new in `test_telemetry.py`)
- [x] `uv run --project brain ruff check brain/` — clean
- [x] `uv run --project brain ruff format --check brain/` — clean
- [x] `hippo-processes.json` validates as JSON
- [ ] Manual smoke test: start OTel stack, run daemon + brain, confirm all five series appear in Prometheus and the new dashboard renders. *Deferred to reviewer / follow-up run — the user lacks a running OTel stack right now per the issue discussion.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)