### PR TITLE
fix(gh-poll): close the silent opt-in gap + support `gh auth token` fallback

### DIFF
--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -118,6 +118,34 @@ strip_params = [
 # HIPPO_PROJECT_ROOTS env var to override at runtime.
 project_roots = []
 
+[github]
+# GitHub Actions CI-outcome ingest (opt-in).
+#
+# When enabled, a separate `com.hippo.gh-poll` LaunchAgent polls the GitHub
+# REST API every 5 minutes for workflow runs on `watched_repos`, pulls jobs +
+# annotations + failure log tails, and writes them to the `workflow_runs` /
+# `workflow_jobs` / `workflow_annotations` tables. The brain then enriches
+# them into knowledge nodes and eventually graduates recurring failures into
+# `lessons` (queryable via the `get_lessons` MCP tool).
+#
+# To enable CI ingest:
+#   1. Create a GitHub PAT with `repo` + `actions:read` scopes
+#   2. Export the token: `export HIPPO_GITHUB_TOKEN=ghp_...` (in ~/.zshrc or similar)
+#   3. Set enabled = true and populate watched_repos below
+#   4. Reinstall: `hippo daemon install --force` (writes the gh-poll plist)
+#   5. Load the agent: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.gh-poll.plist`
+#   6. Verify: `hippo doctor` and (after ~5 min) query via `get_ci_status` MCP tool
+#
+# Without these steps, CI ingest is entirely inactive — `workflow_runs` stays
+# empty and CI-failure lessons never graduate. `hippo doctor` will flag this.
+enabled = false
+watched_repos = []             # e.g., ["stevencarpenter/hippo"]
+# poll_interval_secs = 300       # Background cadence (5 min)
+# tight_poll_interval_secs = 45  # Post-push cadence for watched SHAs
+# watchlist_ttl_secs = 1200      # How long a pushed SHA stays in the tight-poll set (20 min)
+# log_excerpt_max_bytes = 51200  # 50 KB cap per failure log tail
+# token_env = "HIPPO_GITHUB_TOKEN"
+
 [telemetry]
 # OpenTelemetry observability: traces, metrics, and logs to Grafana/Tempo/Loki/Prometheus.
 #

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -129,12 +129,15 @@ project_roots = []
 # `lessons` (queryable via the `get_lessons` MCP tool).
 #
 # To enable CI ingest:
-#   1. Create a GitHub PAT with `repo` + `actions:read` scopes
-#   2. Export the token: `export HIPPO_GITHUB_TOKEN=ghp_...` (in ~/.zshrc or similar)
-#   3. Set enabled = true and populate watched_repos below
-#   4. Reinstall: `hippo daemon install --force` (writes the gh-poll plist)
-#   5. Load the agent: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.gh-poll.plist`
-#   6. Verify: `hippo doctor` and (after ~5 min) query via `get_ci_status` MCP tool
+#   1. Make sure a GitHub token is available. Two options:
+#        a. Run `gh auth login` (GitHub CLI) — the wrapper falls back to
+#           `gh auth token` automatically, no env var needed.
+#        b. Create a PAT with `repo` + `actions:read` scopes and export
+#           HIPPO_GITHUB_TOKEN=ghp_... (in ~/.zshrc or similar).
+#   2. Set enabled = true and populate watched_repos below
+#   3. Reinstall: `hippo daemon install --force` (writes the gh-poll plist)
+#   4. Load the agent: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.gh-poll.plist`
+#   5. Verify: `hippo doctor` and (after ~5 min) query via `get_ci_status` MCP tool
 #
 # Without these steps, CI ingest is entirely inactive — `workflow_runs` stays
 # empty and CI-failure lessons never graduate. `hippo doctor` will flag this.

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -629,6 +629,9 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
     // Check OpenTelemetry configuration
     fail_count += check_otel_status(config, &client).await;
 
+    // Check GitHub CI-ingest configuration
+    fail_count += check_github_source(config);
+
     // Check 1: Per-source staleness via source_health table (P0.1)
     // Check 8: Watchdog heartbeat
     if db_path.exists()
@@ -875,6 +878,83 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) -> u3
             0
         }
     }
+}
+
+/// Whether a launchd label is currently loaded. Local duplicate of
+/// `install::service_is_loaded` because `install` is a binary-only module
+/// (not reachable from this lib-side doctor check).
+fn launchctl_service_loaded(label: &str) -> bool {
+    std::process::Command::new("launchctl")
+        .args(["list", label])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Report on GitHub CI-ingest (`gh-poll`) configuration.
+///
+/// Three states:
+///   - enabled + plist loaded + token set  → OK
+///   - enabled but plist missing / token missing → warn (fixable config error)
+///   - disabled                             → info only, no fail increment
+///     (opt-in feature; most users don't want it — but make the opt-in
+///     discoverable since silent-missing-data is the #1 failure mode)
+fn check_github_source(config: &HippoConfig) -> u32 {
+    if !config.github.enabled {
+        println!(
+            "[--] GitHub CI ingest: disabled (set [github] enabled = true in {} to enable)",
+            config.storage.config_dir.join("config.toml").display()
+        );
+        return 0;
+    }
+
+    let mut fail = 0u32;
+
+    // Token must be readable at doctor time — same gate as install.
+    if std::env::var(&config.github.token_env).is_err() {
+        println!(
+            "[!!] GitHub CI ingest: enabled but {} is not set",
+            config.github.token_env
+        );
+        println!(
+            "     Create a PAT with repo + actions:read scopes and export {}",
+            config.github.token_env
+        );
+        fail += 1;
+    }
+
+    if config.github.watched_repos.is_empty() {
+        println!("[!!] GitHub CI ingest: enabled but [github] watched_repos is empty");
+        println!("     Add at least one repo, e.g.  watched_repos = [\"owner/name\"]");
+        fail += 1;
+    }
+
+    let plist_path = dirs::home_dir()
+        .map(|h| h.join("Library/LaunchAgents/com.hippo.gh-poll.plist"))
+        .unwrap_or_default();
+    if !plist_path.exists() {
+        println!(
+            "[!!] GitHub CI ingest: enabled but gh-poll plist not installed at {}",
+            plist_path.display()
+        );
+        println!("     Run: hippo daemon install --force");
+        fail += 1;
+    } else if !launchctl_service_loaded("com.hippo.gh-poll") {
+        println!("[!!] GitHub CI ingest: enabled and plist installed but agent not loaded");
+        println!(
+            "     Run: launchctl bootstrap gui/$(id -u) {}",
+            plist_path.display()
+        );
+        fail += 1;
+    }
+
+    if fail == 0 {
+        println!(
+            "[OK] GitHub CI ingest: enabled ({} repo(s) watched)",
+            config.github.watched_repos.len()
+        );
+    }
+    fail
 }
 
 /// Check 1: Per-source staleness via the `source_health` table (requires P0.1 migration).
@@ -2047,5 +2127,47 @@ replacement = "***"
 
         let fail2 = check_source_staleness(&conn, false);
         assert_eq!(fail2, 0, "fresh shell row should return fail_count=0");
+    }
+
+    #[test]
+    fn test_check_github_source_disabled_is_info_only() {
+        let config = HippoConfig::default();
+        assert!(!config.github.enabled, "default must be disabled");
+        // Disabled → opt-in feature, should not fail doctor.
+        assert_eq!(check_github_source(&config), 0);
+    }
+
+    #[test]
+    fn test_check_github_source_enabled_without_token_fails() {
+        // SAFETY: this test mutates process env. Other tests in this file
+        // don't touch HIPPO_GITHUB_TOKEN_DOES_NOT_EXIST_12345, so no race.
+        let mut config = HippoConfig::default();
+        config.github.enabled = true;
+        config.github.token_env = "HIPPO_GITHUB_TOKEN_DOES_NOT_EXIST_12345".to_string();
+        config.github.watched_repos = vec!["owner/repo".to_string()];
+        // Empty watched_repos would add another fail; we want to isolate token.
+        unsafe {
+            std::env::remove_var("HIPPO_GITHUB_TOKEN_DOES_NOT_EXIST_12345");
+        }
+        // Token missing AND (probably) plist missing in test env → at least 1.
+        assert!(check_github_source(&config) >= 1);
+    }
+
+    #[test]
+    fn test_check_github_source_enabled_empty_repos_fails() {
+        let mut config = HippoConfig::default();
+        config.github.enabled = true;
+        // Set a token so we isolate the empty-repos check.
+        unsafe {
+            std::env::set_var("HIPPO_GITHUB_TOKEN_TEST_REPOS", "dummy");
+        }
+        config.github.token_env = "HIPPO_GITHUB_TOKEN_TEST_REPOS".to_string();
+        // watched_repos stays empty.
+        let fail = check_github_source(&config);
+        unsafe {
+            std::env::remove_var("HIPPO_GITHUB_TOKEN_TEST_REPOS");
+        }
+        // At least the empty-repos fail (maybe also plist-not-installed in CI).
+        assert!(fail >= 1);
     }
 }

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -910,15 +910,19 @@ fn check_github_source(config: &HippoConfig) -> u32 {
 
     let mut fail = 0u32;
 
-    // Token must be readable at doctor time — same gate as install.
-    if std::env::var(&config.github.token_env).is_err() {
+    // Token must be resolvable at doctor time — same gate as install.
+    // Resolver tries env first, then `gh auth token` as a fallback.
+    if crate::gh_poll::resolve_github_token(&config.github.token_env).is_none() {
         println!(
-            "[!!] GitHub CI ingest: enabled but {} is not set",
+            "[!!] GitHub CI ingest: enabled but no token available (env {} unset and `gh auth token` failed)",
             config.github.token_env
         );
         println!(
-            "     Create a PAT with repo + actions:read scopes and export {}",
+            "     Either: export {} with a PAT (repo + actions:read scopes),",
             config.github.token_env
+        );
+        println!(
+            "     Or:     run `gh auth login` so the wrapper can fall back to `gh auth token`"
         );
         fail += 1;
     }

--- a/crates/hippo-daemon/src/gh_poll.rs
+++ b/crates/hippo-daemon/src/gh_poll.rs
@@ -16,6 +16,30 @@ pub struct PollConfig {
     pub redact_config_path: Option<PathBuf>,
 }
 
+/// Resolve a GitHub token the same way the gh-poll wrapper does: env first,
+/// then `gh auth token` as a fallback. Used by install-time validation, the
+/// `hippo doctor` check, and the gh-poll runtime — all three agree so the
+/// user doesn't hit surprises between one and the next.
+///
+/// Returns `None` only when the env var is unset *and* either `gh` is not
+/// installed or it returns an empty / non-zero response.
+pub fn resolve_github_token(token_env: &str) -> Option<String> {
+    if let Ok(v) = std::env::var(token_env)
+        && !v.is_empty()
+    {
+        return Some(v);
+    }
+    let output = std::process::Command::new("gh")
+        .args(["auth", "token"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!token.is_empty()).then_some(token)
+}
+
 fn parse_ts(s: Option<&str>) -> Option<i64> {
     s.and_then(|v| chrono::DateTime::parse_from_rfc3339(v).ok())
         .map(|dt| dt.timestamp_millis())
@@ -199,4 +223,43 @@ pub async fn run_once(api: &GhApi, db_path: &Path, cfg: &PollConfig) -> Result<(
     let _ = watchlist::cleanup_expired(&conn, now);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_prefers_env_over_gh() {
+        // SAFETY: process env mutation. Unique var name isolates from parallel tests.
+        let var = "HIPPO_GH_POLL_RESOLVER_TEST_ENV_WINS";
+        unsafe {
+            std::env::set_var(var, "env-value");
+        }
+        let got = resolve_github_token(var);
+        unsafe {
+            std::env::remove_var(var);
+        }
+        assert_eq!(got.as_deref(), Some("env-value"));
+    }
+
+    #[test]
+    fn resolve_treats_empty_env_as_unset() {
+        // If the env var is set but empty, the resolver must fall through to
+        // `gh auth token` rather than returning "". This ensures an empty
+        // export (e.g. `export HIPPO_GITHUB_TOKEN=` in a profile) doesn't
+        // block the fallback.
+        let var = "HIPPO_GH_POLL_RESOLVER_TEST_EMPTY_ENV";
+        unsafe {
+            std::env::set_var(var, "");
+        }
+        let got = resolve_github_token(var);
+        unsafe {
+            std::env::remove_var(var);
+        }
+        // Either None (no gh / not logged in in test env) or Some("...") if
+        // this is a dev machine with `gh auth login` — both prove the empty
+        // env was skipped, which is what we're verifying.
+        assert!(got.as_deref() != Some(""));
+    }
 }

--- a/crates/hippo-daemon/src/install.rs
+++ b/crates/hippo-daemon/src/install.rs
@@ -80,9 +80,17 @@ fn which(binary: &str) -> Option<PathBuf> {
 
 /// Write a wrapper script for gh-poll that sources the GitHub token at runtime.
 ///
-/// Reads the token from `$HIPPO_GITHUB_TOKEN` or, if unset, from the user's
-/// env file (`~/.config/zsh/.env`). This avoids embedding the plaintext token
-/// in the LaunchAgent plist.
+/// Token resolution chain (first hit wins):
+///   1. `$HIPPO_GITHUB_TOKEN` (or whatever `token_env` names) already in env
+///   2. `~/.config/zsh/.env` — for users who keep their secrets in a chezmoi-
+///      managed dotfile
+///   3. `gh auth token` — falls back to the GitHub CLI's OAuth token if the
+///      user has `gh auth login`'d. Zero new credential management for dev
+///      boxes that already use `gh`.
+///
+/// Keeps the plaintext token out of the plist. If nothing in the chain
+/// returns a token, `hippo gh-poll` will exit with an error which launchd
+/// logs to gh-poll.stderr.log.
 pub fn install_gh_poll_wrapper(
     hippo_bin: &Path,
     token_env: &str,
@@ -103,11 +111,21 @@ pub fn install_gh_poll_wrapper(
 # Sources the GitHub token at runtime to avoid embedding secrets in plists.
 set -euo pipefail
 
-# Try env var first; fall back to sourcing the encrypted-env-deployed file.
+# 1. env var already set (CI / explicit export): use as-is.
+# 2. else source chezmoi-deployed env file if present.
 if [ -z "${{{token_env}:-}}" ] && [ -f "$HOME/.config/zsh/.env" ]; then
     set -a
     source "$HOME/.config/zsh/.env"
     set +a
+fi
+
+# 3. else fall back to `gh auth token` — zero-config for dev boxes that are
+#    already `gh auth login`'d. `gh` stores its OAuth token in the macOS
+#    Keychain, which is readable under launchd's gui/UID context.
+if [ -z "${{{token_env}:-}}" ] && command -v gh >/dev/null 2>&1; then
+    if token=$(gh auth token 2>/dev/null) && [ -n "$token" ]; then
+        export {token_env}="$token"
+    fi
 fi
 
 exec {hippo_bin} gh-poll

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -287,11 +287,15 @@ async fn main() -> Result<()> {
 
                 // GitHub Actions poller plist — only written when github source is enabled.
                 let gh_poll_installed = if config.github.enabled {
-                    // Verify the token env var is set at install time so the user
-                    // gets an early error, but don't embed it in the plist.
-                    if std::env::var(&config.github.token_env).is_err() {
+                    // Verify a token is reachable at install time — either via the
+                    // env var or via `gh auth token` — so the user gets an early
+                    // error. The wrapper does the same resolution at runtime, so
+                    // we're just checking "will this work when launchd fires it?"
+                    if hippo_daemon::gh_poll::resolve_github_token(&config.github.token_env)
+                        .is_none()
+                    {
                         anyhow::bail!(
-                            "{} must be set to enable the github source",
+                            "No GitHub token available for gh-poll. Either export {} or run `gh auth login`.",
                             config.github.token_env
                         );
                     }
@@ -306,8 +310,11 @@ async fn main() -> Result<()> {
                 } else {
                     println!("  (github source disabled; skipping gh-poll plist)");
                     println!(
-                        "  To enable CI ingest: set [github] enabled = true in {}, export {},",
-                        config.storage.config_dir.join("config.toml").display(),
+                        "  To enable CI ingest: set [github] enabled = true in {},",
+                        config.storage.config_dir.join("config.toml").display()
+                    );
+                    println!(
+                        "    ensure a token is available (run `gh auth login` OR export {}),",
                         config.github.token_env
                     );
                     println!(

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -305,6 +305,14 @@ async fn main() -> Result<()> {
                     true
                 } else {
                     println!("  (github source disabled; skipping gh-poll plist)");
+                    println!(
+                        "  To enable CI ingest: set [github] enabled = true in {}, export {},",
+                        config.storage.config_dir.join("config.toml").display(),
+                        config.github.token_env
+                    );
+                    println!(
+                        "    populate watched_repos, then rerun: hippo daemon install --force"
+                    );
                     false
                 };
 


### PR DESCRIPTION
Closes the "CI ingest is a ghost feature on fresh installs" problem in two parts. Both landed on this branch.

## Part 1 — discovery gap (commit a715712)

gh-poll had been shipped and functional for a while, but the journey from fresh install to "CI data is flowing" had a silent hole:

- `config.default.toml` had no `[github]` section → users didn't know the feature existed.
- `hippo doctor` had no check for CI ingest → silently empty `workflow_runs` was invisible.
- `main.rs`'s install output said `(github source disabled; skipping gh-poll plist)` with **no** guidance on how to enable.

Fixes:

- **`config/config.default.toml`** — ships a commented `[github]` section with the full enable recipe (token options, which flags to set, which installer / launchctl commands to run).
- **`hippo doctor`** — new `check_github_source` with three states: disabled (info only), enabled-but-misconfigured (per-problem `[!!]` line with exact fix command), enabled-and-healthy (`[OK] ... (N repo(s) watched)`).
- **`main.rs` install output** — skip message now prints the enable steps inline.

## Part 2 — `gh auth token` fallback (commit 797c7fd)

The original design required a separate `HIPPO_GITHUB_TOKEN` env var even for users who already had `gh auth login` working. That's needless friction for dev boxes.

**Small clarification on motivation:** `gh` CLI uses OAuth (stored in macOS Keychain after `gh auth login`), not SSH — SSH is git-protocol-specific. But the UX ask stands: if you've already got `gh` authenticated, hippo should use it.

The gh-poll wrapper now resolves a token in three steps:

1. `$HIPPO_GITHUB_TOKEN` env var (existing — CI / explicit export)
2. `~/.config/zsh/.env` sourced file (existing — chezmoi users)
3. **`gh auth token` subprocess (new)** — zero-config for dev boxes already using `gh`

Same resolution logic moves into a shared `gh_poll::resolve_github_token` helper, so install-time validation, `hippo doctor`, and the wrapper all agree. Previously all three had drifted: wrapper already sourced the env file, but install and doctor only looked at `std::env::var` and would hard-fail even when the wrapper would have succeeded.

## Test plan

- [x] `cargo test -p hippo-core -p hippo-daemon` — 116 core + 89 daemon = 205 tests pass, including:
  - 3 new `commands::tests::test_check_github_source_*` (disabled / no-token / empty-repos)
  - 2 new `gh_poll::tests::resolve_*` (env-wins, empty-env-falls-through)
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Smoke-tested `./target/debug/hippo doctor` — new `[--] GitHub CI ingest: disabled ...` line visible.
- [ ] End-to-end (reviewer with `gh auth login` active): set `[github] enabled = true` + a repo in config, run `hippo daemon install --force`, confirm install succeeds without exporting `HIPPO_GITHUB_TOKEN`, launchctl-bootstrap, wait 5 min, confirm `workflow_runs` populates and `hippo doctor` reports `[OK] GitHub CI ingest: enabled (1 repo(s) watched)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)