### PR TITLE
fix: address unresolved review comments from #75 and #73

### DIFF
--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -129,11 +129,16 @@ project_roots = []
 # `lessons` (queryable via the `get_lessons` MCP tool).
 #
 # To enable CI ingest:
-#   1. Make sure a GitHub token is available. Two options:
-#        a. Run `gh auth login` (GitHub CLI) — the wrapper falls back to
-#           `gh auth token` automatically, no env var needed.
-#        b. Create a PAT with `repo` + `actions:read` scopes and export
-#           HIPPO_GITHUB_TOKEN=ghp_... (in ~/.zshrc or similar).
+#   1. Make sure a GitHub token is available. The launchd wrapper checks, in order:
+#        a. HIPPO_GITHUB_TOKEN in the process env.
+#        b. `~/.config/zsh/.env` (sourced at runtime — add `export HIPPO_GITHUB_TOKEN=ghp_...`
+#           here so the env var is present under launchd; shell rc files are NOT read by
+#           LaunchAgents).
+#        c. `gh auth token` (zero-config — run `gh auth login` once with the GitHub CLI
+#           and the wrapper picks up the OAuth token from the macOS keychain).
+#      For a manual token, create one with:
+#        - classic PAT: `repo` + `workflow` scopes
+#        - fine-grained PAT: repository Actions (read) + Metadata (read) + Contents (read)
 #   2. Set enabled = true and populate watched_repos below
 #   3. Reinstall: `hippo daemon install --force` (writes the gh-poll plist)
 #   4. Load the agent: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.gh-poll.plist`

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -900,6 +900,18 @@ fn launchctl_service_loaded(label: &str) -> bool {
 ///     (opt-in feature; most users don't want it — but make the opt-in
 ///     discoverable since silent-missing-data is the #1 failure mode)
 fn check_github_source(config: &HippoConfig) -> u32 {
+    check_github_source_with(config, || {
+        crate::gh_poll::resolve_github_token(&config.github.token_env).is_some()
+    })
+}
+
+/// Testable core of `check_github_source`. `token_present` is a closure so
+/// tests can inject token-presence without mutating the process environment
+/// (which is `unsafe` on Rust 1.82+ and races with any concurrent env reader).
+fn check_github_source_with<F>(config: &HippoConfig, token_present: F) -> u32
+where
+    F: FnOnce() -> bool,
+{
     if !config.github.enabled {
         println!(
             "[--] GitHub CI ingest: disabled (set [github] enabled = true in {} to enable)",
@@ -911,15 +923,18 @@ fn check_github_source(config: &HippoConfig) -> u32 {
     let mut fail = 0u32;
 
     // Token must be resolvable at doctor time — same gate as install.
-    // Resolver tries env first, then `gh auth token` as a fallback.
-    if crate::gh_poll::resolve_github_token(&config.github.token_env).is_none() {
+    // Resolver tries env first, then `~/.config/zsh/.env`, then `gh auth token`.
+    if !token_present() {
         println!(
-            "[!!] GitHub CI ingest: enabled but no token available (env {} unset and `gh auth token` failed)",
+            "[!!] GitHub CI ingest: enabled but no token available (env {} unset, ~/.config/zsh/.env lacks it, and `gh auth token` failed)",
             config.github.token_env
         );
         println!(
-            "     Either: export {} with a PAT (repo + actions:read scopes),",
+            "     Either: export {} with a token",
             config.github.token_env
+        );
+        println!(
+            "             (classic PAT: `repo` + `workflow` scopes; fine-grained PAT: Actions + Metadata + Contents read)"
         );
         println!(
             "     Or:     run `gh auth login` so the wrapper can fall back to `gh auth token`"
@@ -933,9 +948,13 @@ fn check_github_source(config: &HippoConfig) -> u32 {
         fail += 1;
     }
 
-    let plist_path = dirs::home_dir()
-        .map(|h| h.join("Library/LaunchAgents/com.hippo.gh-poll.plist"))
-        .unwrap_or_default();
+    let Some(home_dir) = dirs::home_dir() else {
+        println!(
+            "[!!] GitHub CI ingest: cannot locate home directory; skipping plist verification"
+        );
+        return fail + 1;
+    };
+    let plist_path = home_dir.join("Library/LaunchAgents/com.hippo.gh-poll.plist");
     if !plist_path.exists() {
         println!(
             "[!!] GitHub CI ingest: enabled but gh-poll plist not installed at {}",
@@ -2138,39 +2157,27 @@ replacement = "***"
         let config = HippoConfig::default();
         assert!(!config.github.enabled, "default must be disabled");
         // Disabled → opt-in feature, should not fail doctor.
-        assert_eq!(check_github_source(&config), 0);
+        // Resolver is never called when disabled — pass a trivial stub.
+        assert_eq!(check_github_source_with(&config, || false), 0);
     }
 
     #[test]
     fn test_check_github_source_enabled_without_token_fails() {
-        // SAFETY: this test mutates process env. Other tests in this file
-        // don't touch HIPPO_GITHUB_TOKEN_DOES_NOT_EXIST_12345, so no race.
         let mut config = HippoConfig::default();
         config.github.enabled = true;
-        config.github.token_env = "HIPPO_GITHUB_TOKEN_DOES_NOT_EXIST_12345".to_string();
         config.github.watched_repos = vec!["owner/repo".to_string()];
-        // Empty watched_repos would add another fail; we want to isolate token.
-        unsafe {
-            std::env::remove_var("HIPPO_GITHUB_TOKEN_DOES_NOT_EXIST_12345");
-        }
+        // Inject "token missing" without touching process env.
         // Token missing AND (probably) plist missing in test env → at least 1.
-        assert!(check_github_source(&config) >= 1);
+        assert!(check_github_source_with(&config, || false) >= 1);
     }
 
     #[test]
     fn test_check_github_source_enabled_empty_repos_fails() {
         let mut config = HippoConfig::default();
         config.github.enabled = true;
-        // Set a token so we isolate the empty-repos check.
-        unsafe {
-            std::env::set_var("HIPPO_GITHUB_TOKEN_TEST_REPOS", "dummy");
-        }
-        config.github.token_env = "HIPPO_GITHUB_TOKEN_TEST_REPOS".to_string();
+        // Inject "token present" so we isolate the empty-repos check.
         // watched_repos stays empty.
-        let fail = check_github_source(&config);
-        unsafe {
-            std::env::remove_var("HIPPO_GITHUB_TOKEN_TEST_REPOS");
-        }
+        let fail = check_github_source_with(&config, || true);
         // At least the empty-repos fail (maybe also plist-not-installed in CI).
         assert!(fail >= 1);
     }

--- a/crates/hippo-daemon/src/gh_poll.rs
+++ b/crates/hippo-daemon/src/gh_poll.rs
@@ -16,18 +16,25 @@ pub struct PollConfig {
     pub redact_config_path: Option<PathBuf>,
 }
 
-/// Resolve a GitHub token the same way the gh-poll wrapper does: env first,
-/// then `gh auth token` as a fallback. Used by install-time validation, the
-/// `hippo doctor` check, and the gh-poll runtime — all three agree so the
-/// user doesn't hit surprises between one and the next.
+/// Resolve a GitHub token the same way the gh-poll launchd wrapper does:
+/// process env first, then `~/.config/zsh/.env` (chezmoi-deployed), then
+/// `gh auth token`. Used by install-time validation, the `hippo doctor`
+/// check, and the gh-poll runtime — all three agree so the user doesn't hit
+/// "doctor reports missing but launchd finds it" divergences.
 ///
-/// Returns `None` only when the env var is unset *and* either `gh` is not
-/// installed or it returns an empty / non-zero response.
+/// Returns `None` only when none of those three sources yields a non-empty
+/// token.
 pub fn resolve_github_token(token_env: &str) -> Option<String> {
     if let Ok(v) = std::env::var(token_env)
         && !v.is_empty()
     {
         return Some(v);
+    }
+    if let Some(home) = dirs::home_dir() {
+        let env_file = home.join(".config/zsh/.env");
+        if let Some(v) = read_var_from_env_file(&env_file, token_env) {
+            return Some(v);
+        }
     }
     let output = std::process::Command::new("gh")
         .args(["auth", "token"])
@@ -38,6 +45,42 @@ pub fn resolve_github_token(token_env: &str) -> Option<String> {
     }
     let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
     (!token.is_empty()).then_some(token)
+}
+
+/// Minimal parser for the subset of bash assignment syntax that the wrapper
+/// would resolve via `set -a; source FILE; set +a`. Handles:
+///   - `KEY=value` and `export KEY=value`
+///   - blank lines and `# comments`
+///   - optional single or double quotes around the value
+///
+/// Does not expand `$VAR` references or handle heredocs — if the user's env
+/// file uses those for their token, they can set the variable in the process
+/// env directly, which is the first resolver path.
+fn read_var_from_env_file(path: &Path, var_name: &str) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let assignment = trimmed.strip_prefix("export ").unwrap_or(trimmed);
+        let Some((key, value)) = assignment.split_once('=') else {
+            continue;
+        };
+        if key.trim() != var_name {
+            continue;
+        }
+        let value = value.trim();
+        let unquoted = match (value.chars().next(), value.chars().last()) {
+            (Some('"'), Some('"')) if value.len() >= 2 => &value[1..value.len() - 1],
+            (Some('\''), Some('\'')) if value.len() >= 2 => &value[1..value.len() - 1],
+            _ => value,
+        };
+        if !unquoted.is_empty() {
+            return Some(unquoted.to_string());
+        }
+    }
+    None
 }
 
 fn parse_ts(s: Option<&str>) -> Option<i64> {
@@ -261,5 +304,54 @@ mod tests {
         // this is a dev machine with `gh auth login` — both prove the empty
         // env was skipped, which is what we're verifying.
         assert!(got.as_deref() != Some(""));
+    }
+
+    #[test]
+    fn env_file_parses_bare_assignment() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".env");
+        std::fs::write(&path, "FOO=bar\nBAZ=qux\n").unwrap();
+        assert_eq!(read_var_from_env_file(&path, "FOO").as_deref(), Some("bar"));
+        assert_eq!(read_var_from_env_file(&path, "BAZ").as_deref(), Some("qux"));
+        assert_eq!(read_var_from_env_file(&path, "MISSING"), None);
+    }
+
+    #[test]
+    fn env_file_parses_export_and_quotes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".env");
+        std::fs::write(
+            &path,
+            "# a comment\n\nexport DQ=\"double quoted\"\nexport SQ='single quoted'\nPLAIN=plain\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_var_from_env_file(&path, "DQ").as_deref(),
+            Some("double quoted")
+        );
+        assert_eq!(
+            read_var_from_env_file(&path, "SQ").as_deref(),
+            Some("single quoted")
+        );
+        assert_eq!(
+            read_var_from_env_file(&path, "PLAIN").as_deref(),
+            Some("plain")
+        );
+    }
+
+    #[test]
+    fn env_file_skips_empty_values_and_missing_file() {
+        // Missing file → None (not an error path; file is optional).
+        assert_eq!(
+            read_var_from_env_file(Path::new("/nonexistent/path/.env"), "X"),
+            None
+        );
+
+        // Empty assignment is treated as unset so we fall through to the next
+        // resolver source, matching `if [ -z "$VAR" ]` in the wrapper.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".env");
+        std::fs::write(&path, "EMPTY=\n").unwrap();
+        assert_eq!(read_var_from_env_file(&path, "EMPTY"), None);
     }
 }

--- a/crates/hippo-daemon/src/process_metrics.rs
+++ b/crates/hippo-daemon/src/process_metrics.rs
@@ -1,7 +1,7 @@
 //! OpenTelemetry process.* semantic-convention metrics for hippo-daemon.
 //!
-//! Samples the current process's CPU utilization, RSS/VSZ memory, thread count,
-//! and cumulative CPU time at a fixed interval via `sysinfo`, then exposes them
+//! Samples the current process's CPU utilization, RSS/VSZ memory, and
+//! cumulative CPU time at a fixed interval via `sysinfo`, then exposes them
 //! as OTel observable gauges and a counter. Only compiled with `--features otel`.
 //!
 //! Implementation note: a background tokio task refreshes `sysinfo` state on a


### PR DESCRIPTION
Follow-up to #75 (gh-poll silent opt-in fix) and #73 (daemon process.* metrics) that sweeps up the unresolved automated-review comments left behind on those PRs. Bundled as one follow-up since they're all small and cohesive around gh-poll config/docs plus one docstring fix.

## Summary

### #73 — process metrics

- **`process_metrics.rs`** — drop the stale `thread count` line from the daemon module doc. The daemon only exposes `cpu.utilization`, `memory.usage`, `memory.virtual`, and `cpu.time`; the thread-count claim was inherited from the brain-side metric where it does apply. (Copilot, line 4.)

### #75 — gh-poll / doctor

- **`gh_poll.rs`** — teach `resolve_github_token` about `~/.config/zsh/.env` so the resolver order matches the launchd wrapper exactly (env → env file → `gh auth token`). Before this, `hippo doctor` could report "no token available" for a working chezmoi-deployed setup because it never consulted the env file the wrapper sources at runtime. Ships with a minimal bash-assignment parser (`KEY=value` / `export KEY=value`, comments, single/double quotes) and 3 unit tests exercising tempfile inputs — no process-env mutation needed. (codex P1.)

- **`commands.rs`** — split `check_github_source` into a thin public wrapper plus a `check_github_source_with` that takes a `FnOnce() -> bool` token-presence closure. Doctor tests now inject the closure instead of mutating process env, removing both `unsafe { std::env::set_var }` blocks. On Rust 1.82+, env mutation is UB across threads even for distinct var names because libc can reallocate the `environ` array. (Copilot, lines 2157 & 2173.)

- **`commands.rs`** — handle `dirs::home_dir()` returning `None` explicitly. `unwrap_or_default()` previously produced an empty `PathBuf` that `exists()` can treat as CWD, risking a bogus "plist not installed" message with an empty path. (Copilot, line 952.)

- **`commands.rs` + `config.default.toml`** — correct the PAT scope guidance. Classic PATs use `repo` + `workflow` (there is no `actions:read` scope); fine-grained tokens use per-repo Actions + Metadata + Contents read permissions. (Copilot, 3 locations.)

- **`config.default.toml`** — rewrite the enablement recipe so it reflects the wrapper's actual search order. `~/.zshrc` isn't read by launchd — the previous doc sent users down a path where all install steps could succeed but the agent would still ingest zero runs. (codex P2.)

## What this doesn't do (pushback)

- **`main.rs` trailing-comma note** (PR #75 Copilot) — the commas are prose continuation across three consecutive `println!` calls, not a typo. The reviewer also suggested adding a `launchctl bootstrap ...` hint inline, but that's premature: the plist isn't installed yet at that point, so the user must `hippo daemon install --force` first, after which the normal install flow already surfaces the bootstrap line. Leaving as-is.

- **Existing `resolve_github_token` tests** still use `unsafe std::env::set_var` with unique var names. Pre-existing, not flagged in review, and refactoring the public resolver signature to take an injected env source would be a heavier change than this PR's scope. Can follow up separately if the soundness concern on those tests specifically becomes load-bearing.

## Test plan

- [x] `cargo test -p hippo-core -p hippo-daemon` — 116 core + 94 daemon, plus 3 new `gh_poll::tests::env_file_*` cases
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build -p hippo-daemon --no-default-features` — clean (non-otel path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)