### PR TITLE
feat(doctor): checks 2, 5, 6, 9, 10 — NM manifest, session DB, hook log, fallback age, schema version

### DIFF
--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -5,6 +5,7 @@ use hippo_core::events::{CapturedOutput, EventEnvelope, EventPayload, GitState, 
 use hippo_core::protocol::{DaemonRequest, DaemonResponse};
 use hippo_core::redaction::RedactionEngine;
 use hippo_core::storage;
+use rusqlite::OptionalExtension as _;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::net::UnixStream;
@@ -129,7 +130,14 @@ fn format_optional_brain_field(label: &str, value: Option<&str>) -> Option<Strin
         .map(|s| format!("[OK] Brain {}: {}", label, s))
 }
 
-async fn print_brain_health_details(config: &HippoConfig, client: &reqwest::Client) {
+/// Fetch and print brain /health details.
+///
+/// Returns the raw JSON on success so callers can reuse it (e.g. Check 10 for
+/// schema-version comparison) without issuing a second HTTP request.
+async fn print_brain_health_details(
+    config: &HippoConfig,
+    client: &reqwest::Client,
+) -> Option<serde_json::Value> {
     let brain_url = format!("http://localhost:{}/health", config.brain.port);
     match client.get(&brain_url).send().await {
         Ok(resp) if resp.status().is_success() => {
@@ -223,19 +231,24 @@ async fn print_brain_health_details(config: &HippoConfig, client: &reqwest::Clie
                     {
                         println!("{}", line);
                     }
+                    Some(json)
                 }
                 Err(err) => {
                     println!(
                         "[!!] Brain server reachable but returned unreadable health JSON: {}",
                         err
                     );
+                    None
                 }
             }
         }
-        _ => println!(
-            "[!!] Brain server not reachable on port {}",
-            config.brain.port
-        ),
+        _ => {
+            println!(
+                "[!!] Brain server not reachable on port {}",
+                config.brain.port
+            );
+            None
+        }
     }
 }
 
@@ -536,9 +549,12 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
 
     // Check daemon socket and version
     let socket = config.socket_path();
+    // Track whether the daemon socket responded — used by Check 9 (fallback age).
+    let mut daemon_socket_ok = false;
     if socket.exists() {
         match send_request(&socket, &DaemonRequest::GetStatus).await {
             Ok(DaemonResponse::Status(status)) => {
+                daemon_socket_ok = true;
                 println!("[OK] Daemon is running (uptime {}s)", status.uptime_secs);
                 if status.version.is_empty() {
                     println!("[!!] Daemon too old to report version — restart recommended");
@@ -594,19 +610,11 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
         }
     }
 
-    // Check brain
-    print_brain_health_details(config, &client).await;
+    // Check brain — store JSON for reuse in Check 10 (schema version).
+    let brain_json = print_brain_health_details(config, &client).await;
 
-    // Check fallback files
-    let fallback_files = storage::list_fallback_files(&config.fallback_dir())
-        .map(|f| f.len())
-        .unwrap_or(0);
-    if fallback_files > 0 {
-        println!("[!!] {} fallback files pending recovery", fallback_files);
-        fail_count += 1;
-    } else {
-        println!("[OK] No fallback files pending");
-    }
+    // Check 9: Fallback file age (extends the old plain-count check).
+    fail_count += check_fallback_age(&config.fallback_dir(), daemon_socket_ok, explain);
 
     // Check embedding model
     if config.models.embedding.is_empty() {
@@ -635,11 +643,28 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
 
     // Check 1: Per-source staleness via source_health table (P0.1)
     // Check 8: Watchdog heartbeat
+    // Check 5: Live-session vs DB reconciliation
+    // Check 6: Session-hook log vs DB
+    // Check 10: Schema version
     if db_path.exists()
         && let Ok(conn) = hippo_core::storage::open_db(&db_path)
     {
         fail_count += check_source_staleness(&conn, explain);
         fail_count += check_watchdog_heartbeat(&conn, explain);
+
+        // Check 5: active JSONL sessions vs claude_sessions table
+        if let Some(home) = dirs::home_dir() {
+            fail_count += check_claude_session_db(&home.join(".claude/projects"), &conn, explain);
+        } else {
+            println!("[--] {:<29}  no home dir", "claude-session DB");
+        }
+
+        // Check 6: session-hook debug log vs claude_sessions rows (last 1h)
+        let hook_log = config.storage.data_dir.join("session-hook-debug.log");
+        fail_count += check_session_hook_log(&hook_log, &conn, explain);
+
+        // Check 10: daemon PRAGMA user_version vs brain expected_schema_version
+        fail_count += check_schema_version(&conn, brain_json.as_ref(), explain);
     }
 
     // Check 4: zsh hook sourced
@@ -647,6 +672,15 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
 
     // Check 7: Log file sizes
     fail_count += check_log_file_sizes(config, explain);
+
+    // Check 2: Native Messaging manifest (detailed — existence + JSON + path executable + extension ID)
+    if let Some(home) = dirs::home_dir() {
+        let nm_manifest =
+            home.join("Library/Application Support/Mozilla/NativeMessagingHosts/hippo_daemon.json");
+        fail_count += check_nm_manifest(&nm_manifest, explain);
+    } else {
+        println!("[--] {:<29}  no home dir", "native-msg manifest");
+    }
 
     if fail_count > 0 {
         std::process::exit(fail_count as i32);
@@ -1438,6 +1472,483 @@ fn check_watchdog_heartbeat(db: &rusqlite::Connection, explain: bool) -> u32 {
         }
     }
 }
+
+// ─── Check 2: Native Messaging manifest health ──────────────────────────────
+
+/// Check 2: Native Messaging manifest health.
+///
+/// Verifies the manifest file exists, is valid JSON, the `path` field points
+/// to an executable binary, and `allowed_extensions` contains
+/// `"hippo-browser@local"`.
+///
+/// `nm_manifest_path` is the full path to `hippo_daemon.json`; injectable for
+/// tests (pass a tempdir path instead of `~/Library/…`).
+pub fn check_nm_manifest(nm_manifest_path: &std::path::Path, explain: bool) -> u32 {
+    const LABEL: &str = "native-msg manifest";
+
+    if !nm_manifest_path.exists() {
+        println!("[!!] {:<29}  not found", LABEL);
+        if explain {
+            println!(
+                "     CAUSE:  Native Messaging manifest not installed — Firefox cannot launch the host"
+            );
+            println!("     FIX:    hippo daemon install --force");
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        return 1;
+    }
+
+    let content = match std::fs::read_to_string(nm_manifest_path) {
+        Ok(c) => c,
+        Err(e) => {
+            println!("[!!] {:<29}  cannot read: {}", LABEL, e);
+            if explain {
+                println!("     CAUSE:  Manifest file exists but is not readable");
+                println!("     FIX:    hippo daemon install --force");
+                println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+            }
+            return 1;
+        }
+    };
+
+    let json: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("[!!] {:<29}  invalid JSON: {}", LABEL, e);
+            if explain {
+                println!("     CAUSE:  Manifest file is not valid JSON");
+                println!("     FIX:    hippo daemon install --force");
+                println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+            }
+            return 1;
+        }
+    };
+
+    // Check `path` field exists and is an executable file.
+    let Some(path_str) = json.get("path").and_then(|v| v.as_str()) else {
+        println!("[!!] {:<29}  missing `path` field", LABEL);
+        if explain {
+            println!("     CAUSE:  Manifest is malformed — no `path` key");
+            println!("     FIX:    hippo daemon install --force");
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        return 1;
+    };
+
+    let binary = std::path::Path::new(path_str);
+    if !binary.exists() {
+        println!("[!!] {:<29}  `path` not found: {}", LABEL, path_str);
+        if explain {
+            println!("     CAUSE:  Manifest `path` points to a non-existent binary");
+            println!("     FIX:    hippo daemon install --force");
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        return 1;
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+    let executable = std::fs::metadata(binary)
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false);
+    if !executable {
+        println!("[!!] {:<29}  `path` not executable: {}", LABEL, path_str);
+        if explain {
+            println!("     CAUSE:  Manifest `path` binary lacks execute permission");
+            println!("     FIX:    chmod +x {}", path_str);
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        return 1;
+    }
+
+    // Check allowed_extensions contains the hippo extension ID.
+    let has_ext = json
+        .get("allowed_extensions")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .any(|e| e.as_str() == Some("hippo-browser@local"))
+        })
+        .unwrap_or(false);
+    if !has_ext {
+        println!(
+            "[!!] {:<29}  `allowed_extensions` missing `hippo-browser@local`",
+            LABEL
+        );
+        if explain {
+            println!(
+                "     CAUSE:  Extension ID absent from manifest — Firefox refuses to launch the host"
+            );
+            println!("     FIX:    hippo daemon install --force");
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        return 1;
+    }
+
+    println!(
+        "[OK] {:<29}  path={}, extension ID matches",
+        LABEL, path_str
+    );
+    0
+}
+
+// ─── Check 5: Live-session vs DB reconciliation ──────────────────────────────
+
+/// Check 5: Glob active Claude session JSONL files and verify each has a
+/// matching row in `claude_sessions`.
+///
+/// `projects_dir` is `~/.claude/projects` (injectable for tests).
+/// A session file is "active" if its mtime is < 5 minutes old.
+/// Returns fail_count capped at 3.
+pub fn check_claude_session_db(
+    projects_dir: &std::path::Path,
+    db: &rusqlite::Connection,
+    explain: bool,
+) -> u32 {
+    const LABEL: &str = "claude-session DB";
+
+    let five_min_ago = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(300))
+        .unwrap_or(std::time::UNIX_EPOCH);
+
+    // Collect active JSONL paths (mtime within last 5 minutes).
+    let mut active: Vec<std::path::PathBuf> = Vec::new();
+
+    let Ok(proj_entries) = std::fs::read_dir(projects_dir) else {
+        println!("[--] {:<29}  projects dir not found", LABEL);
+        return 0;
+    };
+
+    for proj_entry in proj_entries.flatten() {
+        let proj_path = proj_entry.path();
+        if !proj_path.is_dir() {
+            continue;
+        }
+        let Ok(sub_entries) = std::fs::read_dir(&proj_path) else {
+            continue;
+        };
+        for sub_entry in sub_entries.flatten() {
+            let sub_path = sub_entry.path();
+            if sub_path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+                && let Ok(meta) = std::fs::metadata(&sub_path)
+                && let Ok(modified) = meta.modified()
+                && modified > five_min_ago
+            {
+                active.push(sub_path);
+            }
+        }
+    }
+
+    if active.is_empty() {
+        println!("[--] {:<29}  no active sessions", LABEL);
+        return 0;
+    }
+
+    // session_id is the file stem (the JSONL filename without extension).
+    // This matches how hippo_core::claude_session::SessionFile::from_path derives it.
+    let mut missing: u32 = 0;
+    for path in &active {
+        let Some(session_id) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+
+        let exists = db
+            .query_row(
+                "SELECT 1 FROM claude_sessions WHERE session_id = ? LIMIT 1",
+                rusqlite::params![session_id],
+                |_| Ok(()),
+            )
+            .optional()
+            .unwrap_or(None)
+            .is_some();
+
+        if !exists {
+            let short = &session_id[..session_id.len().min(8)];
+            let fname = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+            println!(
+                "[!!] {:<29}  session {}… not in DB (FAIL, active JSONL {})",
+                LABEL, short, fname
+            );
+            if explain && missing == 0 {
+                println!(
+                    "     CAUSE:  Session hook fired but row never reached SQLite (tmux crash?)"
+                );
+                println!(
+                    "     FIX:    tail -f ~/.local/share/hippo/session-hook-debug.log; check tmux ls"
+                );
+                println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+            }
+            missing += 1;
+            if missing >= 3 {
+                break;
+            }
+        }
+    }
+
+    if missing == 0 {
+        println!(
+            "[OK] {:<29}  {} active session(s) in DB",
+            LABEL,
+            active.len()
+        );
+    }
+
+    missing.min(3)
+}
+
+// ─── Check 6: Session-hook log vs DB ────────────────────────────────────────
+
+/// Count "hook invoked" log entries within the past hour.
+///
+/// Reads up to the last 10 000 lines of the log. Each line's first
+/// whitespace-delimited token must be a valid RFC 3339 timestamp.
+fn count_hook_invocations_in_last_1h(log_path: &std::path::Path) -> i64 {
+    use std::io::{BufRead, BufReader};
+
+    let Ok(file) = std::fs::File::open(log_path) else {
+        return 0;
+    };
+
+    let reader = BufReader::new(file);
+    let lines: Vec<String> = reader.lines().map_while(Result::ok).collect();
+
+    let tail_start = lines.len().saturating_sub(10_000);
+    let tail = &lines[tail_start..];
+
+    let one_hour_ago = chrono::Utc::now() - chrono::TimeDelta::hours(1);
+    let mut count: i64 = 0;
+
+    for line in tail {
+        if !line.contains("hook invoked") {
+            continue;
+        }
+        if let Some(ts_str) = line.split_whitespace().next()
+            && let Ok(ts) = chrono::DateTime::parse_from_rfc3339(ts_str)
+            && ts.with_timezone(&chrono::Utc) > one_hour_ago
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Check 6: Session-hook debug log vs DB reconciliation.
+///
+/// Counts `"hook invoked"` entries in the last hour (capped at 10 000 log
+/// lines) and compares to `claude_sessions.created_at` rows in the same
+/// window.
+///
+/// `log_path` = `$DATA_DIR/session-hook-debug.log` (injectable for tests).
+pub fn check_session_hook_log(
+    log_path: &std::path::Path,
+    db: &rusqlite::Connection,
+    explain: bool,
+) -> u32 {
+    const LABEL: &str = "session-hook log";
+
+    let invocations = count_hook_invocations_in_last_1h(log_path);
+
+    let one_hour_ago_ms = chrono::Utc::now().timestamp_millis() - 3_600_000i64;
+    let db_rows: i64 = db
+        .query_row(
+            "SELECT COUNT(*) FROM claude_sessions WHERE created_at >= ?",
+            rusqlite::params![one_hour_ago_ms],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    if invocations == 0 && db_rows == 0 {
+        println!("[--] {:<29}  no hook activity", LABEL);
+        return 0;
+    }
+
+    if invocations > 0 && db_rows > 0 {
+        println!(
+            "[OK] {:<29}  {} invocations, {} DB rows (last 1h)",
+            LABEL, invocations, db_rows
+        );
+        return 0;
+    }
+
+    if invocations > 0 && db_rows == 0 && invocations < 3 {
+        println!(
+            "[WW] {:<29}  {} invocations, 0 DB rows — too fresh",
+            LABEL, invocations
+        );
+        return 0;
+    }
+
+    if invocations >= 3 && db_rows == 0 {
+        println!(
+            "[!!] {:<29}  {} invocations, 0 DB rows (last 1h)",
+            LABEL, invocations
+        );
+        if explain {
+            println!("     CAUSE:  Hook fires repeatedly but sessions never reach SQLite");
+            println!(
+                "     FIX:    Check tmux: tmux ls; tail -f ~/.local/share/hippo/session-hook-debug.log"
+            );
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        return 1;
+    }
+
+    // invocations == 0 && db_rows > 0 — sessions in DB but hook not logging recently.
+    // Not an error; could be sessions from earlier this hour.
+    println!(
+        "[OK] {:<29}  0 invocations, {} DB rows (last 1h)",
+        LABEL, db_rows
+    );
+    0
+}
+
+// ─── Check 9: Fallback file age ──────────────────────────────────────────────
+
+/// Check 9: Fallback JSONL file age.
+///
+/// Extends the old "count fallback files" check with an mtime predicate:
+/// - No files → `[OK]`
+/// - Files all < 24 h old → `[WW]` (daemon may still be down / recovering)
+/// - Any file > 24 h old AND daemon is responding → `[!!]` (drain is broken)
+///
+/// `daemon_reachable`: true if the daemon socket returned a valid Status
+/// response earlier in `handle_doctor`; injectable for tests.
+pub fn check_fallback_age(
+    fallback_dir: &std::path::Path,
+    daemon_reachable: bool,
+    explain: bool,
+) -> u32 {
+    const LABEL: &str = "fallback files";
+    const FAIL_AGE: std::time::Duration = std::time::Duration::from_secs(24 * 3600);
+
+    let files = match hippo_core::storage::list_fallback_files(fallback_dir) {
+        Ok(f) => f,
+        Err(_) => {
+            println!("[--] {:<29}  cannot read fallback dir", LABEL);
+            return 0;
+        }
+    };
+
+    if files.is_empty() {
+        println!("[OK] {:<29}  none pending", LABEL);
+        return 0;
+    }
+
+    let now = std::time::SystemTime::now();
+    let mut oldest_secs: u64 = 0;
+    let mut has_stale = false;
+
+    for path in &files {
+        if let Ok(meta) = std::fs::metadata(path)
+            && let Ok(modified) = meta.modified()
+        {
+            let age = now.duration_since(modified).unwrap_or_default();
+            if age.as_secs() > oldest_secs {
+                oldest_secs = age.as_secs();
+            }
+            if age > FAIL_AGE {
+                has_stale = true;
+            }
+        }
+    }
+
+    if has_stale && daemon_reachable {
+        println!(
+            "[!!] {:<29}  {} pending, oldest {}h (daemon up — drain broken?)",
+            LABEL,
+            files.len(),
+            oldest_secs / 3600
+        );
+        if explain {
+            println!(
+                "     CAUSE:  Fallback files > 24h old while daemon is running — drain path broken"
+            );
+            println!("     FIX:    Restart daemon: mise run restart");
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        return 1;
+    }
+
+    if has_stale {
+        println!(
+            "[WW] {:<29}  {} pending, oldest {}h (daemon down — drain pending)",
+            LABEL,
+            files.len(),
+            oldest_secs / 3600
+        );
+    } else {
+        println!(
+            "[WW] {:<29}  {} pending (all < 24h old)",
+            LABEL,
+            files.len()
+        );
+    }
+    0
+}
+
+// ─── Check 10: Schema version ────────────────────────────────────────────────
+
+/// Check 10: Daemon DB schema version vs brain's `expected_schema_version`.
+///
+/// Reuses the `brain_json` already fetched by `print_brain_health_details` —
+/// no extra HTTP round-trip.
+pub fn check_schema_version(
+    db: &rusqlite::Connection,
+    brain_json: Option<&serde_json::Value>,
+    explain: bool,
+) -> u32 {
+    const LABEL: &str = "schema version";
+
+    let db_version: i64 = match db.query_row("PRAGMA user_version", [], |row| row.get(0)) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("[!!] {:<29}  DB error: {}", LABEL, e);
+            return 1;
+        }
+    };
+
+    let Some(json) = brain_json else {
+        println!(
+            "[--] {:<29}  v{} (brain unreachable — cannot compare)",
+            LABEL, db_version
+        );
+        return 0;
+    };
+
+    let Some(expected) = json.get("expected_schema_version").and_then(|v| v.as_i64()) else {
+        println!(
+            "[--] {:<29}  v{} (brain /health missing `expected_schema_version`)",
+            LABEL, db_version
+        );
+        return 0;
+    };
+
+    // A daemon version listed in accepted_read_versions is rollback-compatible.
+    let accepted: Vec<i64> = json
+        .get("accepted_read_versions")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|e| e.as_i64()).collect())
+        .unwrap_or_default();
+
+    if db_version == expected || accepted.contains(&db_version) {
+        println!("[OK] {:<29}  v{}", LABEL, db_version);
+        0
+    } else {
+        println!(
+            "[!!] {:<29}  daemon v{}, brain expects v{}",
+            LABEL, db_version, expected
+        );
+        if explain {
+            println!(
+                "     CAUSE:  Daemon and brain schema versions diverged — enrichment silently crashes"
+            );
+            println!("     FIX:    mise run restart  (or rebuild both components after updating)");
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        1
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 fn check_claude_session_hook(config: &HippoConfig) {
     let settings_path = dirs::home_dir()

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -1547,10 +1547,25 @@ pub fn check_nm_manifest(nm_manifest_path: &std::path::Path, explain: bool) -> u
     }
 
     use std::os::unix::fs::PermissionsExt;
-    let executable = std::fs::metadata(binary)
+    let meta = std::fs::metadata(binary).ok();
+    if !meta.as_ref().map(|m| m.is_file()).unwrap_or(false) {
+        println!(
+            "[!!] {:<29}  `path` is not a regular file: {}",
+            LABEL, path_str
+        );
+        if explain {
+            println!(
+                "     CAUSE:  Manifest `path` points to a directory or special file, not an executable binary"
+            );
+            println!("     FIX:    hippo daemon install --force");
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+        }
+        return 1;
+    }
+    if !meta
         .map(|m| m.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false);
-    if !executable {
+        .unwrap_or(false)
+    {
         println!("[!!] {:<29}  `path` not executable: {}", LABEL, path_str);
         if explain {
             println!("     CAUSE:  Manifest `path` binary lacks execute permission");
@@ -1593,11 +1608,37 @@ pub fn check_nm_manifest(nm_manifest_path: &std::path::Path, explain: bool) -> u
 
 // ─── Check 5: Live-session vs DB reconciliation ──────────────────────────────
 
-/// Check 5: Glob active Claude session JSONL files and verify each has a
-/// matching row in `claude_sessions`.
+/// Recursively collect JSONL files under `dir` whose mtime is newer than
+/// `cutoff`.  Handles the Claude Code layout where subagent transcripts live
+/// at `<project>/<parent-uuid>/subagents/<id>.jsonl`.
+fn collect_active_jsonls(
+    dir: &std::path::Path,
+    cutoff: std::time::SystemTime,
+    result: &mut Vec<std::path::PathBuf>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_active_jsonls(&path, cutoff, result);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+            && let Ok(meta) = std::fs::metadata(&path)
+            && let Ok(modified) = meta.modified()
+            && modified > cutoff
+        {
+            result.push(path);
+        }
+    }
+}
+
+/// Check 5: Recursively find active Claude session JSONL files under
+/// `projects_dir` and verify each has a matching row in `claude_sessions`.
 ///
 /// `projects_dir` is `~/.claude/projects` (injectable for tests).
 /// A session file is "active" if its mtime is < 5 minutes old.
+/// Recursion handles subagent transcripts at `<proj>/<parent>/subagents/*.jsonl`.
 /// Returns fail_count capped at 3.
 pub fn check_claude_session_db(
     projects_dir: &std::path::Path,
@@ -1606,37 +1647,18 @@ pub fn check_claude_session_db(
 ) -> u32 {
     const LABEL: &str = "claude-session DB";
 
+    if !projects_dir.is_dir() {
+        println!("[--] {:<29}  projects dir not found", LABEL);
+        return 0;
+    }
+
     let five_min_ago = std::time::SystemTime::now()
         .checked_sub(std::time::Duration::from_secs(300))
         .unwrap_or(std::time::UNIX_EPOCH);
 
-    // Collect active JSONL paths (mtime within last 5 minutes).
+    // Collect active JSONL paths (mtime within last 5 minutes) recursively.
     let mut active: Vec<std::path::PathBuf> = Vec::new();
-
-    let Ok(proj_entries) = std::fs::read_dir(projects_dir) else {
-        println!("[--] {:<29}  projects dir not found", LABEL);
-        return 0;
-    };
-
-    for proj_entry in proj_entries.flatten() {
-        let proj_path = proj_entry.path();
-        if !proj_path.is_dir() {
-            continue;
-        }
-        let Ok(sub_entries) = std::fs::read_dir(&proj_path) else {
-            continue;
-        };
-        for sub_entry in sub_entries.flatten() {
-            let sub_path = sub_entry.path();
-            if sub_path.extension().and_then(|e| e.to_str()) == Some("jsonl")
-                && let Ok(meta) = std::fs::metadata(&sub_path)
-                && let Ok(modified) = meta.modified()
-                && modified > five_min_ago
-            {
-                active.push(sub_path);
-            }
-        }
-    }
+    collect_active_jsonls(projects_dir, five_min_ago, &mut active);
 
     if active.is_empty() {
         println!("[--] {:<29}  no active sessions", LABEL);
@@ -1644,7 +1666,7 @@ pub fn check_claude_session_db(
     }
 
     // session_id is the file stem (the JSONL filename without extension).
-    // This matches how hippo_core::claude_session::SessionFile::from_path derives it.
+    // This matches how hippo_daemon::claude_session::SessionFile::from_path derives it.
     let mut missing: u32 = 0;
     for path in &active {
         let Some(session_id) = path.file_stem().and_then(|s| s.to_str()) else {
@@ -1699,25 +1721,32 @@ pub fn check_claude_session_db(
 
 /// Count "hook invoked" log entries within the past hour.
 ///
-/// Reads up to the last 10 000 lines of the log. Each line's first
+/// Streams the log through a ring buffer capped at 10 000 lines so memory
+/// usage is bounded even for large files. Each line's first
 /// whitespace-delimited token must be a valid RFC 3339 timestamp.
 fn count_hook_invocations_in_last_1h(log_path: &std::path::Path) -> i64 {
+    use std::collections::VecDeque;
     use std::io::{BufRead, BufReader};
+
+    const MAX_LINES: usize = 10_000;
 
     let Ok(file) = std::fs::File::open(log_path) else {
         return 0;
     };
 
-    let reader = BufReader::new(file);
-    let lines: Vec<String> = reader.lines().map_while(Result::ok).collect();
-
-    let tail_start = lines.len().saturating_sub(10_000);
-    let tail = &lines[tail_start..];
+    // Stream into a ring buffer — avoids loading the whole file into memory.
+    let mut ring: VecDeque<String> = VecDeque::with_capacity(MAX_LINES + 1);
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        if ring.len() == MAX_LINES {
+            ring.pop_front();
+        }
+        ring.push_back(line);
+    }
 
     let one_hour_ago = chrono::Utc::now() - chrono::TimeDelta::hours(1);
     let mut count: i64 = 0;
 
-    for line in tail {
+    for line in &ring {
         if !line.contains("hook invoked") {
             continue;
         }

--- a/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
+++ b/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
@@ -25,8 +25,8 @@ mod doctor {
 
         // ── helpers ────────────────────────────────────────────────────────
 
-        /// Open a fresh in-memory SQLite DB with the full hippo schema applied
-        /// (migrations run via `open_db`).
+        /// Open a fresh file-backed SQLite DB at `dir/hippo.db` with the full
+        /// hippo schema applied (migrations run via `open_db`).
         fn open_test_db(dir: &std::path::Path) -> rusqlite::Connection {
             let db_path = dir.join("hippo.db");
             hippo_core::storage::open_db(&db_path).expect("open_db")
@@ -154,6 +154,27 @@ mod doctor {
             let _ = check_nm_manifest(&manifest, true);
         }
 
+        #[test]
+        fn check_2_directory_path_fails() {
+            // A manifest `path` pointing at a directory (mode 0755) must fail
+            // even though directories have execute bits set.
+            let tmp = tempdir().unwrap();
+            let dir_path = tmp.path().join("some-dir");
+            fs::create_dir_all(&dir_path).unwrap();
+
+            let manifest = tmp.path().join("hippo_daemon.json");
+            let json = serde_json::json!({
+                "name": "hippo_daemon",
+                "path": dir_path.to_string_lossy(),
+                "type": "stdio",
+                "allowed_extensions": ["hippo-browser@local"],
+            });
+            fs::write(&manifest, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+            let fail = check_nm_manifest(&manifest, false);
+            assert_eq!(fail, 1, "directory as `path` must fail");
+        }
+
         // ── Check 5: live-session vs DB ────────────────────────────────────
 
         #[test]
@@ -234,6 +255,46 @@ mod doctor {
 
             let fail = check_claude_session_db(&tmp.path().join("no-such-dir"), &conn, false);
             assert_eq!(fail, 0, "non-existent projects dir → [--], not a failure");
+        }
+
+        #[test]
+        fn check_5_subagent_jsonl_detected_recursively() {
+            // Regression test for the P1 bug: subagent transcripts at
+            // `<proj>/<parent-uuid>/subagents/<id>.jsonl` must be found by the
+            // recursive walk and reconciled against claude_sessions.
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            // Nested subagent path matching the Claude Code layout.
+            let subagent_dir = tmp
+                .path()
+                .join("projects/encoded-proj/parent-uuid/subagents");
+            fs::create_dir_all(&subagent_dir).unwrap();
+            let session_id = "subagent-session-abc";
+            let jsonl = subagent_dir.join(format!("{session_id}.jsonl"));
+            fs::write(&jsonl, "{}\n").unwrap();
+            // File is fresh — NOT in the DB.
+
+            let fail = check_claude_session_db(&tmp.path().join("projects"), &conn, false);
+            assert_eq!(fail, 1, "nested subagent JSONL absent from DB must fail");
+        }
+
+        #[test]
+        fn check_5_subagent_jsonl_in_db_passes() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let subagent_dir = tmp
+                .path()
+                .join("projects/encoded-proj/parent-uuid/subagents");
+            fs::create_dir_all(&subagent_dir).unwrap();
+            let session_id = "subagent-session-xyz";
+            let jsonl = subagent_dir.join(format!("{session_id}.jsonl"));
+            fs::write(&jsonl, "{}\n").unwrap();
+            insert_session_row(&conn, session_id);
+
+            let fail = check_claude_session_db(&tmp.path().join("projects"), &conn, false);
+            assert_eq!(fail, 0, "nested subagent JSONL present in DB must pass");
         }
 
         // ── Check 6: session-hook log vs DB ───────────────────────────────

--- a/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
+++ b/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
@@ -1,0 +1,543 @@
+//! Integration tests for doctor checks 2, 5, 6, 9, 10.
+//!
+//! All tests live inside `doctor::checks_2_5_6_9_10` so the cargo test
+//! filter works:
+//!
+//!   cargo test -p hippo-daemon -- doctor::checks_2_5_6_9_10
+//!
+//! Each check has at least one negative test seeded with a failing fixture.
+//! The `doctor_perf_budget` test asserts the combined wall-clock of all five
+//! checks is under 2 seconds.
+
+mod doctor {
+    mod checks_2_5_6_9_10 {
+        use std::fs;
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::{Duration, SystemTime};
+
+        use hippo_core::config::HippoConfig;
+        use hippo_daemon::commands::{
+            check_claude_session_db, check_fallback_age, check_nm_manifest, check_schema_version,
+            check_session_hook_log,
+        };
+        use tempfile::tempdir;
+
+        // ── helpers ────────────────────────────────────────────────────────
+
+        /// Open a fresh in-memory SQLite DB with the full hippo schema applied
+        /// (migrations run via `open_db`).
+        fn open_test_db(dir: &std::path::Path) -> rusqlite::Connection {
+            let db_path = dir.join("hippo.db");
+            hippo_core::storage::open_db(&db_path).expect("open_db")
+        }
+
+        /// Write a valid NM manifest + executable wrapper into `nm_dir` and
+        /// return the manifest path.
+        fn write_valid_manifest(nm_dir: &std::path::Path) -> std::path::PathBuf {
+            fs::create_dir_all(nm_dir).unwrap();
+            let wrapper = nm_dir.join("hippo-native-messaging");
+            fs::write(&wrapper, "#!/bin/bash\nexec hippo native-messaging-host\n").unwrap();
+            fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755)).unwrap();
+
+            let manifest = nm_dir.join("hippo_daemon.json");
+            let json = serde_json::json!({
+                "name": "hippo_daemon",
+                "description": "Hippo knowledge capture daemon",
+                "path": wrapper.to_string_lossy(),
+                "type": "stdio",
+                "allowed_extensions": ["hippo-browser@local"],
+            });
+            fs::write(&manifest, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+            manifest
+        }
+
+        /// Back-date a file's mtime using `std::fs::FileTimes`.
+        fn back_date_file(path: &std::path::Path, age: Duration) {
+            let past = SystemTime::now().checked_sub(age).unwrap();
+            let times = fs::FileTimes::new().set_modified(past);
+            let file = fs::OpenOptions::new()
+                .write(true)
+                .open(path)
+                .expect("open for back-dating");
+            file.set_times(times).expect("set_times");
+        }
+
+        /// Insert a `claude_sessions` row for the given session_id.
+        fn insert_session_row(conn: &rusqlite::Connection, session_id: &str) {
+            conn.execute(
+                "INSERT OR IGNORE INTO claude_sessions \
+                 (session_id, project_dir, cwd, segment_index, start_time, end_time, \
+                  summary_text, message_count, source_file, is_subagent, created_at) \
+                 VALUES (?, '', '/', 0, unixepoch('now')*1000, unixepoch('now')*1000, \
+                         '', 0, '', 0, unixepoch('now')*1000)",
+                rusqlite::params![session_id],
+            )
+            .unwrap();
+        }
+
+        // ── Check 2: NM manifest ───────────────────────────────────────────
+
+        #[test]
+        fn check_2_missing_manifest_fails() {
+            let tmp = tempdir().unwrap();
+            let manifest = tmp.path().join("hippo_daemon.json");
+            // Intentionally do NOT write the manifest.
+            let fail = check_nm_manifest(&manifest, false);
+            assert_eq!(fail, 1, "missing manifest must fail");
+        }
+
+        #[test]
+        fn check_2_valid_manifest_passes() {
+            let tmp = tempdir().unwrap();
+            let manifest = write_valid_manifest(tmp.path());
+            let fail = check_nm_manifest(&manifest, false);
+            assert_eq!(fail, 0, "valid manifest must pass");
+        }
+
+        #[test]
+        fn check_2_invalid_json_fails() {
+            let tmp = tempdir().unwrap();
+            let manifest = tmp.path().join("hippo_daemon.json");
+            fs::write(&manifest, "not valid json{{").unwrap();
+            let fail = check_nm_manifest(&manifest, false);
+            assert_eq!(fail, 1, "invalid JSON must fail");
+        }
+
+        #[test]
+        fn check_2_non_executable_path_fails() {
+            let tmp = tempdir().unwrap();
+            let wrapper = tmp.path().join("hippo-nm");
+            fs::write(&wrapper, "#!/bin/bash\n").unwrap();
+            // Deliberately NOT setting the execute bit.
+            fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o644)).unwrap();
+
+            let manifest = tmp.path().join("hippo_daemon.json");
+            let json = serde_json::json!({
+                "name": "hippo_daemon",
+                "path": wrapper.to_string_lossy(),
+                "type": "stdio",
+                "allowed_extensions": ["hippo-browser@local"],
+            });
+            fs::write(&manifest, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+            let fail = check_nm_manifest(&manifest, false);
+            assert_eq!(fail, 1, "non-executable wrapper must fail");
+        }
+
+        #[test]
+        fn check_2_missing_extension_id_fails() {
+            let tmp = tempdir().unwrap();
+            let wrapper = tmp.path().join("hippo-nm");
+            fs::write(&wrapper, "#!/bin/bash\n").unwrap();
+            fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755)).unwrap();
+
+            let manifest = tmp.path().join("hippo_daemon.json");
+            // allowed_extensions is empty — hippo-browser@local absent.
+            let json = serde_json::json!({
+                "name": "hippo_daemon",
+                "path": wrapper.to_string_lossy(),
+                "type": "stdio",
+                "allowed_extensions": [],
+            });
+            fs::write(&manifest, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+            let fail = check_nm_manifest(&manifest, false);
+            assert_eq!(fail, 1, "empty allowed_extensions must fail");
+        }
+
+        #[test]
+        fn check_2_explain_output_does_not_panic() {
+            let tmp = tempdir().unwrap();
+            let manifest = tmp.path().join("hippo_daemon.json");
+            // explain=true on missing manifest must not panic.
+            let _ = check_nm_manifest(&manifest, true);
+        }
+
+        // ── Check 5: live-session vs DB ────────────────────────────────────
+
+        #[test]
+        fn check_5_active_session_missing_from_db_fails() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            // Fake projects dir with one fresh JSONL file.
+            let projects = tmp.path().join("projects/abc");
+            fs::create_dir_all(&projects).unwrap();
+            let jsonl = projects.join("session-uuid-1234.jsonl");
+            fs::write(&jsonl, "{}\n").unwrap();
+            // File is fresh (just written) — mtime < 5min by default.
+
+            // Do NOT insert any row into claude_sessions — session is "missing".
+            let fail = check_claude_session_db(&tmp.path().join("projects"), &conn, false);
+            assert_eq!(fail, 1, "active session absent from DB must yield fail=1");
+        }
+
+        #[test]
+        fn check_5_active_session_present_in_db_passes() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let projects = tmp.path().join("projects/abc");
+            fs::create_dir_all(&projects).unwrap();
+            let session_id = "session-uuid-5678";
+            let jsonl = projects.join(format!("{session_id}.jsonl"));
+            fs::write(&jsonl, "{}\n").unwrap();
+
+            insert_session_row(&conn, session_id);
+
+            let fail = check_claude_session_db(&tmp.path().join("projects"), &conn, false);
+            assert_eq!(fail, 0, "active session in DB must pass");
+        }
+
+        #[test]
+        fn check_5_no_active_sessions_is_not_data() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            // Projects dir exists but the one JSONL is old (> 5 min).
+            let projects = tmp.path().join("projects/abc");
+            fs::create_dir_all(&projects).unwrap();
+            let jsonl = projects.join("old-session.jsonl");
+            fs::write(&jsonl, "{}\n").unwrap();
+            back_date_file(&jsonl, Duration::from_secs(600)); // 10 minutes old
+
+            let fail = check_claude_session_db(&tmp.path().join("projects"), &conn, false);
+            assert_eq!(fail, 0, "no active sessions → [--], not a failure");
+        }
+
+        #[test]
+        fn check_5_missing_sessions_capped_at_3() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let projects = tmp.path().join("projects/abc");
+            fs::create_dir_all(&projects).unwrap();
+
+            // Create 5 fresh JSONL files, none in the DB.
+            for i in 0..5u32 {
+                let jsonl = projects.join(format!("session-{i}.jsonl"));
+                fs::write(&jsonl, "{}\n").unwrap();
+            }
+
+            let fail = check_claude_session_db(&tmp.path().join("projects"), &conn, false);
+            assert_eq!(
+                fail, 3,
+                "fail_count must be capped at 3 regardless of missing count"
+            );
+        }
+
+        #[test]
+        fn check_5_nonexistent_projects_dir_is_not_data() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let fail = check_claude_session_db(&tmp.path().join("no-such-dir"), &conn, false);
+            assert_eq!(fail, 0, "non-existent projects dir → [--], not a failure");
+        }
+
+        // ── Check 6: session-hook log vs DB ───────────────────────────────
+
+        /// Write timestamped "hook invoked" lines into a log file.
+        /// `age_secs_list`: each entry is how many seconds ago to back-date the line.
+        fn write_hook_log(log_path: &std::path::Path, age_secs_list: &[u64]) {
+            let mut f = fs::File::create(log_path).unwrap();
+            for &age_secs in age_secs_list {
+                let ts = chrono::Utc::now() - chrono::TimeDelta::seconds(age_secs as i64);
+                writeln!(
+                    f,
+                    "{} hook invoked, input={{}}",
+                    ts.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+                )
+                .unwrap();
+            }
+        }
+
+        #[test]
+        fn check_6_three_invocations_no_db_rows_fails() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let log = tmp.path().join("session-hook-debug.log");
+            // 3 recent hook invocations, none older than 1h.
+            write_hook_log(&log, &[10, 60, 120]);
+
+            // No claude_sessions rows → 0 DB rows in last 1h.
+            let fail = check_session_hook_log(&log, &conn, false);
+            assert_eq!(fail, 1, "≥3 invocations with 0 DB rows must fail");
+        }
+
+        #[test]
+        fn check_6_two_invocations_no_db_rows_warns_not_fails() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let log = tmp.path().join("session-hook-debug.log");
+            write_hook_log(&log, &[10, 60]); // only 2 invocations
+
+            let fail = check_session_hook_log(&log, &conn, false);
+            assert_eq!(fail, 0, "< 3 invocations with 0 DB rows is [WW], not [!!]");
+        }
+
+        #[test]
+        fn check_6_no_log_file_is_no_data() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let log = tmp.path().join("session-hook-debug.log");
+            // File does not exist.
+            let fail = check_session_hook_log(&log, &conn, false);
+            assert_eq!(
+                fail, 0,
+                "missing log file → [--] no activity, not a failure"
+            );
+        }
+
+        #[test]
+        fn check_6_invocations_with_db_rows_passes() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let log = tmp.path().join("session-hook-debug.log");
+            write_hook_log(&log, &[30, 90, 150]);
+
+            insert_session_row(&conn, "recent-session-abc");
+
+            let fail = check_session_hook_log(&log, &conn, false);
+            assert_eq!(fail, 0, "invocations + DB rows → [OK]");
+        }
+
+        #[test]
+        fn check_6_old_log_lines_outside_1h_not_counted() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let log = tmp.path().join("session-hook-debug.log");
+            // 5 lines but all older than 1h.
+            write_hook_log(&log, &[3700, 4000, 5000, 6000, 7200]);
+
+            let fail = check_session_hook_log(&log, &conn, false);
+            assert_eq!(fail, 0, "invocations outside 1h window should not count");
+        }
+
+        // ── Check 9: fallback file age ─────────────────────────────────────
+
+        #[test]
+        fn check_9_no_fallback_files_passes() {
+            let tmp = tempdir().unwrap();
+            let fallback = tmp.path().join("fallback");
+            fs::create_dir_all(&fallback).unwrap();
+
+            let fail = check_fallback_age(&fallback, true, false);
+            assert_eq!(fail, 0, "no fallback files → [OK]");
+        }
+
+        #[test]
+        fn check_9_stale_file_daemon_up_fails() {
+            let tmp = tempdir().unwrap();
+            let fallback = tmp.path().join("fallback");
+            fs::create_dir_all(&fallback).unwrap();
+
+            let old_file = fallback.join("2026-04-01.jsonl");
+            fs::write(&old_file, "{}\n").unwrap();
+            back_date_file(&old_file, Duration::from_secs(25 * 3600)); // 25 hours
+
+            let fail = check_fallback_age(&fallback, /*daemon_reachable=*/ true, false);
+            assert_eq!(fail, 1, "stale file with daemon up must fail");
+        }
+
+        #[test]
+        fn check_9_stale_file_daemon_down_warns_not_fails() {
+            let tmp = tempdir().unwrap();
+            let fallback = tmp.path().join("fallback");
+            fs::create_dir_all(&fallback).unwrap();
+
+            let old_file = fallback.join("2026-04-01.jsonl");
+            fs::write(&old_file, "{}\n").unwrap();
+            back_date_file(&old_file, Duration::from_secs(25 * 3600));
+
+            // daemon is down — drain cannot run, so stale files are expected.
+            let fail = check_fallback_age(&fallback, /*daemon_reachable=*/ false, false);
+            assert_eq!(fail, 0, "stale file with daemon down → [WW], not [!!]");
+        }
+
+        #[test]
+        fn check_9_fresh_file_warns_not_fails() {
+            let tmp = tempdir().unwrap();
+            let fallback = tmp.path().join("fallback");
+            fs::create_dir_all(&fallback).unwrap();
+
+            let fresh = fallback.join("today.jsonl");
+            fs::write(&fresh, "{}\n").unwrap();
+            // File is < 24h old (just written), daemon is up.
+
+            let fail = check_fallback_age(&fallback, true, false);
+            assert_eq!(fail, 0, "fresh file → [WW] not [!!]");
+        }
+
+        #[test]
+        fn check_9_explain_on_stale_does_not_panic() {
+            let tmp = tempdir().unwrap();
+            let fallback = tmp.path().join("fallback");
+            fs::create_dir_all(&fallback).unwrap();
+
+            let old = fallback.join("old.jsonl");
+            fs::write(&old, "{}\n").unwrap();
+            back_date_file(&old, Duration::from_secs(25 * 3600));
+
+            let _ = check_fallback_age(&fallback, true, /*explain=*/ true);
+        }
+
+        // ── Check 10: schema version ───────────────────────────────────────
+
+        #[test]
+        fn check_10_version_match_passes() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let current_version: i64 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+
+            let brain_json = serde_json::json!({
+                "expected_schema_version": current_version,
+                "accepted_read_versions": [],
+            });
+
+            let fail = check_schema_version(&conn, Some(&brain_json), false);
+            assert_eq!(fail, 0, "matching versions must pass");
+        }
+
+        #[test]
+        fn check_10_version_mismatch_fails() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            // Brain expects a future version the daemon DB doesn't have yet.
+            let brain_json = serde_json::json!({
+                "expected_schema_version": 9999,
+                "accepted_read_versions": [],
+            });
+
+            let fail = check_schema_version(&conn, Some(&brain_json), false);
+            assert_eq!(fail, 1, "version mismatch must fail");
+        }
+
+        #[test]
+        fn check_10_db_version_in_accepted_read_versions_passes() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let current_version: i64 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+
+            // Brain has moved forward but still accepts the daemon's version.
+            let brain_json = serde_json::json!({
+                "expected_schema_version": current_version + 1,
+                "accepted_read_versions": [current_version],
+            });
+
+            let fail = check_schema_version(&conn, Some(&brain_json), false);
+            assert_eq!(fail, 0, "version in accepted_read_versions must pass");
+        }
+
+        #[test]
+        fn check_10_brain_unreachable_is_not_data() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let fail = check_schema_version(&conn, None, false);
+            assert_eq!(fail, 0, "brain unreachable → [--], not a failure");
+        }
+
+        #[test]
+        fn check_10_brain_json_missing_field_is_not_data() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            // Brain JSON present but old (no expected_schema_version field).
+            let brain_json = serde_json::json!({ "status": "ok" });
+            let fail = check_schema_version(&conn, Some(&brain_json), false);
+            assert_eq!(fail, 0, "missing field → [--], not a failure");
+        }
+
+        // ── Performance budget ─────────────────────────────────────────────
+
+        /// Assert the combined wall-clock of all five checks is < 2 seconds.
+        ///
+        /// Uses a tempdir DB with representative data so I/O is included.
+        #[test]
+        fn doctor_perf_budget() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            // Seed some data to make the checks non-trivial.
+            for i in 0..10u32 {
+                insert_session_row(&conn, &format!("perf-session-{i}"));
+            }
+
+            // Manifest fixture.
+            let nm_dir = tmp.path().join("nm_hosts");
+            let manifest = write_valid_manifest(&nm_dir);
+
+            // Projects dir with one fresh session.
+            let projects = tmp.path().join("projects/proj1");
+            fs::create_dir_all(&projects).unwrap();
+            let session_id = "perf-session-0";
+            fs::write(projects.join(format!("{session_id}.jsonl")), "{}\n").unwrap();
+
+            // Hook log with a few recent lines.
+            let log = tmp.path().join("session-hook-debug.log");
+            {
+                let mut f = fs::File::create(&log).unwrap();
+                let ts = chrono::Utc::now();
+                writeln!(
+                    f,
+                    "{} hook invoked, input={{}}",
+                    ts.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+                )
+                .unwrap();
+            }
+
+            // Fallback dir with one fresh file.
+            let fallback = tmp.path().join("fallback");
+            fs::create_dir_all(&fallback).unwrap();
+            fs::write(fallback.join("today.jsonl"), "{}\n").unwrap();
+
+            // Brain JSON for Check 10.
+            let db_ver: i64 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+            let brain_json = serde_json::json!({
+                "expected_schema_version": db_ver,
+                "accepted_read_versions": [],
+            });
+
+            let start = std::time::Instant::now();
+
+            let _ = check_nm_manifest(&manifest, false);
+            let _ = check_claude_session_db(&tmp.path().join("projects"), &conn, false);
+            let _ = check_session_hook_log(&log, &conn, false);
+            let _ = check_fallback_age(&fallback, true, false);
+            let _ = check_schema_version(&conn, Some(&brain_json), false);
+
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed < Duration::from_secs(2),
+                "all five checks combined took {:?}, must be < 2s",
+                elapsed
+            );
+        }
+
+        // ── Config struct used by perf test ───────────────────────────────
+
+        #[allow(dead_code)]
+        fn _make_config(dir: &std::path::Path) -> HippoConfig {
+            let mut cfg = HippoConfig::default();
+            cfg.storage.data_dir = dir.join("data");
+            cfg.storage.config_dir = dir.join("config");
+            cfg
+        }
+    }
+}

--- a/docs/capture-reliability/07-roadmap.md
+++ b/docs/capture-reliability/07-roadmap.md
@@ -134,7 +134,7 @@ Violating any invariant below breaks autonomous execution:
 
 ## T-4 · P1.3 — Doctor checks 2, 5, 6, 9, 10
 
-- **Status:** open
+- **Status:** review
 - **Phase:** P1
 - **Depends on:** (P0 — all done). Note: Check 3 (browser ext dist/) already shipped via #54; Check 8 already shipped via #70 but is dark until T-1 lands.
 - **Branch:** `feat/p1.3-doctor-checks-2`


### PR DESCRIPTION
## Summary

Implements **T-4 (P1.3)** from `docs/capture-reliability/07-roadmap.md`. Adds five new public check functions to `handle_doctor` and a 27-test integration test file.

### New doctor checks

| # | Label | What it catches |
|---|---|---|
| 2 | `native-msg manifest` | Missing/malformed NM manifest, non-executable `path`, `allowed_extensions` lacking `hippo-browser@local` |
| 5 | `claude-session DB` | Active JSONL files (mtime < 5min) whose session IDs are absent from `claude_sessions` — cap +3 fail_count |
| 6 | `session-hook log` | ≥3 "hook invoked" lines in last 1h with 0 `claude_sessions.created_at` rows in same window |
| 9 | `fallback files` | Replaces old plain-count check: `[!!]` only if file > 24h old **and** daemon is responding (drain-broken signal) |
| 10 | `schema version` | `PRAGMA user_version` vs brain `/health` `expected_schema_version` — reuses cached brain JSON, zero extra HTTP calls |

### Refactor
- `print_brain_health_details` now returns `Option<serde_json::Value>` so Check 10 reuses the already-fetched brain JSON.

### DoD checklist

- [x] Check 2 (NM manifest healthy): stat + JSON + path executable + `allowed_extensions`
- [x] Check 5 (live-session vs DB): glob + SQL, fail capped at +3
- [x] Check 6 (session-hook log vs DB): tail 10 000 lines, 1h window comparison
- [x] Check 9 (fallback file age): stat, `[!!]` only with daemon up
- [x] Check 10 (schema version): PRAGMA + cached JSON, zero extra network
- [x] Each check has a negative test with seeded failing fixture
- [x] Total doctor wall-clock < 2s asserted in `doctor_perf_budget` integration test
- [x] `--explain` output includes CAUSE/FIX/DOC for each new `[!!]`

## Test plan

- [x] `cargo test -p hippo-daemon -- doctor::checks_2_5_6_9_10` — 27/27 pass
- [x] `cargo test -p hippo-daemon -- doctor_perf_budget` — pass (20ms wall-clock)
- [x] `cargo clippy -p hippo-daemon --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p hippo-daemon` — full suite pass (no regressions)
- [x] `cargo test -p hippo-core` — 135 tests pass
- [x] `semgrep --config auto crates/hippo-daemon/src/commands.rs` — 0 findings

Status flipped from `open` to `review` in `docs/capture-reliability/07-roadmap.md`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)