### PR TITLE
fix(source-health): restore write paths lost in PR #68 rebase + M2 gate bugs

### DIFF
--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -456,7 +456,7 @@ pub struct WatchdogConfig {
 }
 
 fn default_watchdog_enabled() -> bool {
-    false
+    true
 }
 fn default_alarm_rate_limit_minutes() -> u64 {
     60

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -436,7 +436,7 @@ impl Default for LessonsConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WatchdogConfig {
-    /// Feature flag — off by default; flip to `true` in T-2 after launchd plist ships.
+    /// Feature flag — enabled by default (flipped on in T-2 when the launchd plist shipped).
     #[serde(default = "default_watchdog_enabled")]
     pub enabled: bool,
     /// Sliding-window rate limit (minutes) before the same invariant can raise a new alarm.

--- a/crates/hippo-core/src/schema.sql
+++ b/crates/hippo-core/src/schema.sql
@@ -218,6 +218,7 @@ CREATE INDEX IF NOT EXISTS idx_queue_pending ON enrichment_queue (status, priori
 WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS idx_claude_sessions_cwd ON claude_sessions (cwd);
 CREATE INDEX IF NOT EXISTS idx_claude_sessions_session ON claude_sessions (session_id);
+CREATE INDEX IF NOT EXISTS idx_claude_sessions_start_time ON claude_sessions (start_time DESC);
 CREATE INDEX IF NOT EXISTS idx_claude_queue_pending ON claude_enrichment_queue (status, priority)
 WHERE status = 'pending';
 

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -415,6 +415,8 @@ pub fn open_db(path: &Path) -> Result<Connection> {
              CREATE INDEX IF NOT EXISTS idx_capture_alarms_invariant_active
                  ON capture_alarms (invariant_id, acked_at)
                  WHERE acked_at IS NULL;
+             CREATE INDEX IF NOT EXISTS idx_claude_sessions_start_time
+                 ON claude_sessions (start_time DESC);
              PRAGMA user_version = 9;",
         )?;
     } else if version != 0 && version != EXPECTED_VERSION {

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -527,6 +527,16 @@ pub fn insert_event(
     )
 }
 
+/// Derive the `source_kind` string for a shell event — same logic used by `insert_event_at`.
+/// Exposed so callers that need the kind for bookkeeping don't duplicate the derivation.
+pub fn source_kind_of(event: &ShellEvent) -> &'static str {
+    if event.tool_name.is_some() {
+        "claude-tool"
+    } else {
+        "shell"
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn insert_event_at(
     conn: &Connection,
@@ -557,15 +567,7 @@ pub fn insert_event_at(
         None => (None, None),
     };
 
-    // Derive source_kind from tool_name presence. A populated tool_name
-    // means the event was synthesized from a Claude Code tool use; a
-    // missing one means it came from a native shell hook. Future sources
-    // (cursor, codex, ...) will need their own discriminator on ShellEvent.
-    let source_kind = if event.tool_name.is_some() {
-        "claude-tool"
-    } else {
-        "shell"
-    };
+    let source_kind = source_kind_of(event);
 
     let tx = conn.unchecked_transaction()?;
 

--- a/crates/hippo-daemon/src/claude_session.rs
+++ b/crates/hippo-daemon/src/claude_session.rs
@@ -856,7 +856,7 @@ fn insert_segments(conn: &Connection, segments: &[SessionSegment]) -> Result<(us
             serde_json::to_string(&seg.user_prompts).unwrap_or_else(|_| "[]".into());
         let is_subagent_int: i64 = if seg.is_subagent { 1 } else { 0 };
 
-        let res = conn.execute(
+        match conn.execute(
             "INSERT OR IGNORE INTO claude_sessions
                 (session_id, project_dir, cwd, git_branch, segment_index,
                  start_time, end_time, summary_text, tool_calls_json,
@@ -881,24 +881,45 @@ fn insert_segments(conn: &Connection, segments: &[SessionSegment]) -> Result<(us
                 seg.parent_session_id,
                 now_ms,
             ],
-        )?;
+        )? {
+            0 => {
+                // UNIQUE (session_id, segment_index) collided — already ingested.
+                skipped += 1;
+                continue;
+            }
+            _ => {
+                let claude_session_id = conn.last_insert_rowid();
+                // Enqueue for enrichment. OR IGNORE so a replay doesn't trip the
+                // UNIQUE (claude_session_id) constraint — belt-and-suspenders since
+                // the parent INSERT was also OR IGNORE.
+                conn.execute(
+                    "INSERT OR IGNORE INTO claude_enrichment_queue (claude_session_id, created_at)
+                     VALUES (?1, ?2)",
+                    params![claude_session_id, now_ms],
+                )?;
 
-        if res == 0 {
-            // UNIQUE (session_id, segment_index) collided — already ingested.
-            skipped += 1;
-            continue;
+                // Update source_health for claude-session on success.
+                let seg_ts = seg.end_time;
+                match conn.execute(
+                    "UPDATE source_health
+                     SET last_event_ts        = MAX(COALESCE(last_event_ts, 0), ?1),
+                         last_success_ts      = ?2,
+                         events_last_1h       = events_last_1h + 1,
+                         events_last_24h      = events_last_24h + 1,
+                         consecutive_failures = 0,
+                         updated_at           = ?2
+                     WHERE source = 'claude-session'",
+                    rusqlite::params![seg_ts, now_ms],
+                ) {
+                    Err(e) if !crate::is_missing_source_health_table_error(&e) => {
+                        warn!("source_health session update failed: {e}");
+                    }
+                    _ => {}
+                }
+
+                inserted += 1;
+            }
         }
-
-        let claude_session_id = conn.last_insert_rowid();
-        // Enqueue for enrichment. OR IGNORE so a replay doesn't trip the
-        // UNIQUE (claude_session_id) constraint — belt-and-suspenders since
-        // the parent INSERT was also OR IGNORE.
-        conn.execute(
-            "INSERT OR IGNORE INTO claude_enrichment_queue (claude_session_id, created_at)
-             VALUES (?1, ?2)",
-            params![claude_session_id, now_ms],
-        )?;
-        inserted += 1;
     }
 
     Ok((inserted, skipped))

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -8,6 +8,7 @@ use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Mutex;
 use tokio::sync::watch;
@@ -256,6 +257,11 @@ pub async fn flush_events(state: &Arc<DaemonState>) -> usize {
     #[cfg(feature = "otel")]
     let flush_start = OtelInstant::now();
 
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
     let events: Vec<EventEnvelope> = {
         let mut buffer = state.event_buffer.lock().await;
         let n = buffer.len().min(state.config.daemon.flush_batch_size);
@@ -265,12 +271,30 @@ pub async fn flush_events(state: &Arc<DaemonState>) -> usize {
     tracing::Span::current().record("event_count", count);
 
     if events.is_empty() {
+        // Idle tick: stamp last_success_ts so the watchdog sees liveness
+        // even when no events are flowing.
+        let db = state.write_db.lock().await;
+        match db.execute(
+            "UPDATE source_health
+             SET last_success_ts = ?1, updated_at = ?1
+             WHERE source IN ('shell', 'claude-tool', 'browser')",
+            rusqlite::params![now_ms],
+        ) {
+            Err(e) if !crate::is_missing_source_health_table_error(&e) => {
+                warn!("source_health idle-tick update failed: {e}");
+            }
+            _ => {}
+        }
         return 0;
     }
 
     let username = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
     let db = state.write_db.lock().await;
     let mut session_map = state.session_map.lock().await;
+
+    let mut source_latest_ts: HashMap<&'static str, i64> = HashMap::new();
+    let mut source_counts: HashMap<&'static str, i64> = HashMap::new();
+    let mut source_errors: HashMap<&'static str, String> = HashMap::new();
 
     for envelope in &events {
         match &envelope.payload {
@@ -332,59 +356,144 @@ pub async fn flush_events(state: &Arc<DaemonState>) -> usize {
                         },
                     );
 
+                let event_ts = envelope.timestamp.timestamp_millis();
+                let source: &'static str = storage::source_kind_of(&redacted_event);
                 let eid = envelope.envelope_id.to_string();
-                if let Err(e) = storage::insert_event_at(
+                match storage::insert_event_at(
                     &db,
                     session_id,
                     &redacted_event,
-                    envelope.timestamp.timestamp_millis(),
+                    event_ts,
                     redacted_event.redaction_count,
                     env_snapshot_id,
                     Some(&eid),
                     envelope.probe_tag.as_deref(),
                 ) {
-                    warn!("event insert failed, falling back: {}", e);
-                    let redacted_envelope = EventEnvelope {
-                        envelope_id: envelope.envelope_id,
-                        producer_version: envelope.producer_version,
-                        timestamp: envelope.timestamp,
-                        payload: EventPayload::Shell(redacted_event.clone()),
-                        probe_tag: envelope.probe_tag.clone(),
-                    };
-                    if let Err(fe) = storage::write_fallback_jsonl(
-                        &state.config.fallback_dir(),
-                        &redacted_envelope,
-                    ) {
-                        error!("fallback write failed: {}", fe);
+                    Ok(id) if id >= 0 => {
+                        let entry = source_latest_ts.entry(source).or_insert(0);
+                        if event_ts > *entry {
+                            *entry = event_ts;
+                        }
+                        *source_counts.entry(source).or_insert(0) += 1;
                     }
-                    #[cfg(feature = "otel")]
-                    metrics::FALLBACK_WRITES.add(1, &[]);
-                    state.drop_count.fetch_add(1, Ordering::Relaxed);
+                    Ok(_) => {} // duplicate envelope_id, already stored
+                    Err(e) => {
+                        warn!("event insert failed, falling back: {}", e);
+                        source_errors
+                            .entry(source)
+                            .or_insert_with(|| e.to_string().chars().take(512).collect());
+                        let redacted_envelope = EventEnvelope {
+                            envelope_id: envelope.envelope_id,
+                            producer_version: envelope.producer_version,
+                            timestamp: envelope.timestamp,
+                            payload: EventPayload::Shell(redacted_event.clone()),
+                            probe_tag: envelope.probe_tag.clone(),
+                        };
+                        if let Err(fe) = storage::write_fallback_jsonl(
+                            &state.config.fallback_dir(),
+                            &redacted_envelope,
+                        ) {
+                            error!("fallback write failed: {}", fe);
+                        }
+                        #[cfg(feature = "otel")]
+                        metrics::FALLBACK_WRITES.add(1, &[]);
+                        state.drop_count.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
             }
             EventPayload::Browser(browser_event) => {
+                let event_ts = envelope.timestamp.timestamp_millis();
                 let eid = envelope.envelope_id.to_string();
-                if let Err(e) = storage::insert_browser_event(
+                match storage::insert_browser_event(
                     &db,
                     browser_event,
-                    envelope.timestamp.timestamp_millis(),
+                    event_ts,
                     Some(&eid),
                     envelope.probe_tag.as_deref(),
                 ) {
-                    warn!("browser event insert failed, falling back: {}", e);
-                    if let Err(fe) =
-                        storage::write_fallback_jsonl(&state.config.fallback_dir(), envelope)
-                    {
-                        error!("fallback write failed: {}", fe);
+                    Ok(id) if id >= 0 => {
+                        let entry = source_latest_ts.entry("browser").or_insert(0);
+                        if event_ts > *entry {
+                            *entry = event_ts;
+                        }
+                        *source_counts.entry("browser").or_insert(0) += 1;
                     }
-                    #[cfg(feature = "otel")]
-                    metrics::FALLBACK_WRITES.add(1, &[]);
-                    state.drop_count.fetch_add(1, Ordering::Relaxed);
+                    Ok(_) => {} // duplicate envelope_id
+                    Err(e) => {
+                        warn!("browser event insert failed, falling back: {}", e);
+                        source_errors
+                            .entry("browser")
+                            .or_insert_with(|| e.to_string().chars().take(512).collect());
+                        if let Err(fe) =
+                            storage::write_fallback_jsonl(&state.config.fallback_dir(), envelope)
+                        {
+                            error!("fallback write failed: {}", fe);
+                        }
+                        #[cfg(feature = "otel")]
+                        metrics::FALLBACK_WRITES.add(1, &[]);
+                        state.drop_count.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
             }
             _ => {
                 tracing::warn!("unknown event payload type, skipping");
             }
+        }
+    }
+
+    // Batch-upsert source_health SUCCESS paths (skip sources that also errored).
+    for (source, latest_ts) in &source_latest_ts {
+        if source_errors.contains_key(source) {
+            continue;
+        }
+        let count_val = source_counts.get(source).copied().unwrap_or(0);
+        match db.execute(
+            "UPDATE source_health
+             SET last_event_ts        = MAX(COALESCE(last_event_ts, 0), ?1),
+                 last_success_ts      = ?2,
+                 events_last_1h       = events_last_1h  + ?3,
+                 events_last_24h      = events_last_24h + ?3,
+                 consecutive_failures = 0,
+                 updated_at           = ?2
+             WHERE source = ?4",
+            rusqlite::params![latest_ts, now_ms, count_val, source],
+        ) {
+            Err(e) if !crate::is_missing_source_health_table_error(&e) => {
+                warn!("source_health success update failed for {source}: {e}");
+            }
+            _ => {}
+        }
+    }
+    // Batch-upsert source_health ERROR paths.
+    for (source, err_msg) in &source_errors {
+        match db.execute(
+            "UPDATE source_health
+             SET last_error_ts        = ?1,
+                 last_error_msg       = ?2,
+                 consecutive_failures = consecutive_failures + 1,
+                 updated_at           = ?1
+             WHERE source = ?3",
+            rusqlite::params![now_ms, err_msg, source],
+        ) {
+            Err(e) if !crate::is_missing_source_health_table_error(&e) => {
+                warn!("source_health error update failed for {source}: {e}");
+            }
+            _ => {}
+        }
+    }
+    // Liveness stamp for all sources (even those with no events this tick).
+    for source in ["shell", "claude-tool", "browser"] {
+        if source_errors.contains_key(source) {
+            continue;
+        }
+        match db.execute(
+            "UPDATE source_health SET last_success_ts = ?1, updated_at = ?1 WHERE source = ?2",
+            rusqlite::params![now_ms, source],
+        ) {
+            Err(e) if !crate::is_missing_source_health_table_error(&e) => {
+                warn!("source_health liveness update failed for {source}: {e}");
+            }
+            _ => {}
         }
     }
 
@@ -413,6 +522,82 @@ pub async fn flush_events(state: &Arc<DaemonState>) -> usize {
     }
 
     count
+}
+
+struct RollingCounts {
+    shell_1h: i64,
+    shell_24h: i64,
+    tool_1h: i64,
+    tool_24h: i64,
+    session_1h: i64,
+    session_24h: i64,
+    browser_1h: i64,
+    browser_24h: i64,
+}
+
+async fn recompute_rolling_counts(state: Arc<DaemonState>) {
+    let mut interval = tokio::time::interval(Duration::from_secs(300));
+    interval.tick().await; // discard first immediate tick so we start ~5 min after daemon start
+    loop {
+        interval.tick().await;
+        let counts = {
+            let db = state.read_db.lock().await;
+            let read = |sql: &str| -> rusqlite::Result<i64> { db.query_row(sql, [], |r| r.get(0)) };
+            let result: rusqlite::Result<RollingCounts> = (|| {
+                Ok(RollingCounts {
+                    shell_1h: read(
+                        "SELECT COUNT(*) FROM events WHERE source_kind='shell' AND timestamp>(unixepoch('now')-3600)*1000",
+                    )?,
+                    shell_24h: read(
+                        "SELECT COUNT(*) FROM events WHERE source_kind='shell' AND timestamp>(unixepoch('now')-86400)*1000",
+                    )?,
+                    tool_1h: read(
+                        "SELECT COUNT(*) FROM events WHERE source_kind='claude-tool' AND timestamp>(unixepoch('now')-3600)*1000",
+                    )?,
+                    tool_24h: read(
+                        "SELECT COUNT(*) FROM events WHERE source_kind='claude-tool' AND timestamp>(unixepoch('now')-86400)*1000",
+                    )?,
+                    session_1h: read(
+                        "SELECT COUNT(*) FROM claude_sessions WHERE start_time>(unixepoch('now')-3600)*1000",
+                    )?,
+                    session_24h: read(
+                        "SELECT COUNT(*) FROM claude_sessions WHERE start_time>(unixepoch('now')-86400)*1000",
+                    )?,
+                    browser_1h: read(
+                        "SELECT COUNT(*) FROM browser_events WHERE timestamp>(unixepoch('now')-3600)*1000",
+                    )?,
+                    browser_24h: read(
+                        "SELECT COUNT(*) FROM browser_events WHERE timestamp>(unixepoch('now')-86400)*1000",
+                    )?,
+                })
+            })();
+            match result {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::debug!("recompute_rolling_counts read failed, skipping: {e}");
+                    continue;
+                }
+            }
+        };
+        let db = state.write_db.lock().await;
+        for (source, c1h, c24h) in [
+            ("shell", counts.shell_1h, counts.shell_24h),
+            ("claude-tool", counts.tool_1h, counts.tool_24h),
+            ("claude-session", counts.session_1h, counts.session_24h),
+            ("browser", counts.browser_1h, counts.browser_24h),
+        ] {
+            match db.execute(
+                "UPDATE source_health SET events_last_1h=?1, events_last_24h=?2, \
+                 updated_at=unixepoch('now')*1000 WHERE source=?3",
+                rusqlite::params![c1h, c24h, source],
+            ) {
+                Err(e) if !crate::is_missing_source_health_table_error(&e) => {
+                    warn!("source_health rolling-count update failed for {source}: {e}");
+                }
+                _ => {}
+            }
+        }
+    }
 }
 
 pub async fn run(config: HippoConfig) -> Result<()> {
@@ -582,6 +767,8 @@ pub async fn run(config: HippoConfig) -> Result<()> {
         }
     });
 
+    let recompute_task = tokio::spawn(recompute_rolling_counts(Arc::clone(&state)));
+
     // Bind listener
     let listener = UnixListener::bind(&socket_path)?;
     info!("daemon listening on {:?}", socket_path);
@@ -622,6 +809,9 @@ pub async fn run(config: HippoConfig) -> Result<()> {
     if let Err(e) = flush_task.await {
         warn!("flush task join error: {}", e);
     }
+
+    recompute_task.abort();
+    let _ = recompute_task.await; // JoinError::Cancelled is expected
 
     // Final drain for events buffered by connections that finished after the
     // flush task exited. No race: flush task is already joined above.

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -441,11 +441,12 @@ pub async fn flush_events(state: &Arc<DaemonState>) -> usize {
         }
     }
 
-    // Batch-upsert source_health SUCCESS paths (skip sources that also errored).
+    // Batch-upsert source_health SUCCESS paths for any source with persisted events.
+    // Run independently of the error path so that mixed-outcome batches (some inserts
+    // succeeded, one failed) still advance last_event_ts and rolling counters.  The error
+    // path runs afterwards and increments consecutive_failures, netting to 1 for a partial
+    // failure rather than zero.
     for (source, latest_ts) in &source_latest_ts {
-        if source_errors.contains_key(source) {
-            continue;
-        }
         let count_val = source_counts.get(source).copied().unwrap_or(0);
         match db.execute(
             "UPDATE source_health

--- a/crates/hippo-daemon/src/lib.rs
+++ b/crates/hippo-daemon/src/lib.rs
@@ -49,6 +49,10 @@ pub fn load_redaction_engine(config: &hippo_core::config::HippoConfig) -> Redact
     }
 }
 
+pub(crate) fn is_missing_source_health_table_error(err: &rusqlite::Error) -> bool {
+    err.to_string().contains("no such table: source_health")
+}
+
 /// Redact a shell event: scrub the command, filter env to allowlist, redact env values.
 /// Returns the redacted event plus the per-rule hit breakdown from the command
 /// redaction pass, so callers can emit per-rule observability (see #52). The

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -240,6 +240,7 @@ async fn main() -> Result<()> {
                 let daemon_was_loaded = install::service_is_loaded("com.hippo.daemon");
                 let brain_was_loaded = install::service_is_loaded("com.hippo.brain");
                 let watchdog_was_loaded = install::service_is_loaded("com.hippo.watchdog");
+                let probe_was_loaded = install::service_is_loaded("com.hippo.probe");
 
                 if brain_was_loaded {
                     print!("  Draining brain (waiting for in-flight requests)");
@@ -269,6 +270,10 @@ async fn main() -> Result<()> {
                         &launch_agents.join("com.hippo.watchdog.plist"),
                     );
                     println!("  Stopped watchdog");
+                }
+                if probe_was_loaded {
+                    install::service_bootout(&domain, &launch_agents.join("com.hippo.probe.plist"));
+                    println!("  Stopped probe");
                 }
 
                 let daemon_template = include_str!("../../../launchd/com.hippo.daemon.plist");
@@ -363,7 +368,8 @@ async fn main() -> Result<()> {
                 }
 
                 // Reload services that were running before the upgrade.
-                if daemon_was_loaded || brain_was_loaded || watchdog_was_loaded {
+                if daemon_was_loaded || brain_was_loaded || watchdog_was_loaded || probe_was_loaded
+                {
                     println!();
                     println!("Restarting services...");
                     if daemon_was_loaded {
@@ -387,12 +393,20 @@ async fn main() -> Result<()> {
                         )?;
                         println!("  Started watchdog");
                     }
+                    if probe_was_loaded {
+                        install::service_bootstrap(
+                            &domain,
+                            &launch_agents.join("com.hippo.probe.plist"),
+                        )?;
+                        println!("  Started probe");
+                    }
                 }
 
                 // Only print "Load with:" for services that weren't already cycled.
                 let needs_manual_start = !daemon_was_loaded
                     || !brain_was_loaded
                     || !watchdog_was_loaded
+                    || !probe_was_loaded
                     || gh_poll_installed;
                 if needs_manual_start {
                     println!();
@@ -410,6 +424,11 @@ async fn main() -> Result<()> {
                     if !watchdog_was_loaded {
                         println!(
                             "  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.watchdog.plist"
+                        );
+                    }
+                    if !probe_was_loaded {
+                        println!(
+                            "  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.probe.plist"
                         );
                     }
                     if gh_poll_installed {

--- a/docs/capture-reliability/07-roadmap.md
+++ b/docs/capture-reliability/07-roadmap.md
@@ -30,8 +30,6 @@ Violating any invariant below breaks autonomous execution:
 
 **Milestone M1** ✅ — doctor reports per-source staleness; outage diagnosable via `SELECT * FROM source_health` in a single query.
 
-**Known transitional issue:** Check 8 (watchdog heartbeat) ships on v0.16.0 but always returns `[--] no data` until T-1 (watchdog) lands. Flag this in v0.17 release notes.
-
 ---
 
 # Task Queue (Execute In Order)
@@ -71,7 +69,7 @@ Violating any invariant below breaks autonomous execution:
 
 ## T-2 · P1.1b — Watchdog launchd install + `hippo alarms` CLI
 
-- **Status:** review
+- **Status:** done
 - **Phase:** P1
 - **Depends on:** T-1 (done)
 - **Branch:** `feat/p1.1b-watchdog-install`


### PR DESCRIPTION
This pull request introduces significant improvements to the event health tracking and service management logic in the Hippo daemon. The main changes focus on more robust and granular updating of the `source_health` table for all event sources, improved error handling, and the addition of a background task to periodically recompute rolling event counts. Additionally, the upgrade process now properly handles the `probe` service alongside other core services.

**Event health tracking and error handling:**

* The daemon now updates the `source_health` table in real time for each event source, recording success, error, and liveness information for `shell`, `claude-tool`, `browser`, and `claude-session` sources. This includes tracking the latest event timestamps, rolling counts, and consecutive failures, with improved error handling for missing tables. [[1]](diffhunk://#diff-ee4bda1b9e34059b4bf4f440d76e387b0bb7a319029a89450d735965a4017a57R274-R298) [[2]](diffhunk://#diff-ee4bda1b9e34059b4bf4f440d76e387b0bb7a319029a89450d735965a4017a57R359-R384) [[3]](diffhunk://#diff-ee4bda1b9e34059b4bf4f440d76e387b0bb7a319029a89450d735965a4017a57R403-R426) [[4]](diffhunk://#diff-ee4bda1b9e34059b4bf4f440d76e387b0bb7a319029a89450d735965a4017a57R437-R499) [[5]](diffhunk://#diff-a2d97b37d78fefbfe0d4af1e61bc49ababa2ff88deb3c1637de9c530a449ecd3R52-R55)
* A new helper function, `source_kind_of`, centralizes logic for determining the `source_kind` string for shell events, reducing code duplication. [[1]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26R530-R539) [[2]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26L560-R570)

**Rolling event counts:**

* A background task (`recompute_rolling_counts`) is introduced to periodically (every 5 minutes) recalculate and update rolling 1-hour and 24-hour event counts for all sources in the `source_health` table, ensuring these metrics remain accurate even if events are missed or delayed. [[1]](diffhunk://#diff-ee4bda1b9e34059b4bf4f440d76e387b0bb7a319029a89450d735965a4017a57R527-R602) [[2]](diffhunk://#diff-ee4bda1b9e34059b4bf4f440d76e387b0bb7a319029a89450d735965a4017a57R770-R771) [[3]](diffhunk://#diff-ee4bda1b9e34059b4bf4f440d76e387b0bb7a319029a89450d735965a4017a57R813-R815)

**Session and segment handling:**

* When inserting session segments, the daemon now updates the `source_health` table for `claude-session` events, ensuring session activity is reflected in health metrics. [[1]](diffhunk://#diff-31379fbaf1d6e2adaf9a8b3046959f8e72f4e4b094c3f8d53b7bee2827a643bfL859-R859) [[2]](diffhunk://#diff-31379fbaf1d6e2adaf9a8b3046959f8e72f4e4b094c3f8d53b7bee2827a643bfL884-R890) [[3]](diffhunk://#diff-31379fbaf1d6e2adaf9a8b3046959f8e72f4e4b094c3f8d53b7bee2827a643bfR900-R923)

**Service management improvements:**

* The upgrade and reload process now detects, stops, and restarts the `probe` service alongside the daemon, brain, and watchdog services, ensuring consistent service state after upgrades. [[1]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dR243) [[2]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dR274-R277) [[3]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dL366-R372) [[4]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dR396-R409)

**Configuration default:**

* The default for `watchdog_enabled` is now set to `true`, enabling the watchdog by default for improved reliability.