### PR TITLE
feat(watcher): T-5 — Claude session FS watcher + schema v10 (P2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,10 +697,12 @@ dependencies = [
  "hippo-core",
  "hostname",
  "libc",
+ "notify",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "proptest",
  "reqwest",
  "rusqlite",
  "serde",
@@ -990,6 +1022,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1088,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1131,6 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1150,6 +1223,33 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1201,7 +1301,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1232,7 +1332,7 @@ version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1469,6 +1569,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1609,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1542,12 +1667,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1662,7 +1796,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1677,7 +1811,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1724,10 +1858,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1750,7 +1905,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1988,7 +2143,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2259,7 +2414,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2386,6 +2541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +2612,25 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2568,7 +2748,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2618,6 +2798,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2743,7 +2932,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2761,14 +2959,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2787,10 +3002,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2799,10 +3026,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2811,10 +3050,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2823,10 +3074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2921,7 +3184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "walkdir",
  "which",
  "wiremock",
 ]

--- a/brain/src/hippo_brain/schema_version.py
+++ b/brain/src/hippo_brain/schema_version.py
@@ -12,13 +12,13 @@ migration, bump both together.
 
 from __future__ import annotations
 
-EXPECTED_SCHEMA_VERSION: int = 9
+EXPECTED_SCHEMA_VERSION: int = 10
 
 # Versions brain can read without erroring, so the daemon can migrate
 # forward and brain can still serve queries during the window where the
 # new rows are settling in. Brain requires v5 as the minimum because the
 # knowledge_nodes table and FTS5 index were added in that migration; v1–v4
-# DBs must be migrated by the daemon before brain starts. Keep 8 for
-# rollback compatibility during the v8→v9 window (capture_alarms table is
-# additive and does not affect brain read paths).
-ACCEPTED_READ_VERSIONS: frozenset[int] = frozenset({EXPECTED_SCHEMA_VERSION, 8, 7, 6, 5})
+# DBs must be migrated by the daemon before brain starts. Keep 9 for
+# rollback compatibility during the v9→v10 window (new tables are additive
+# and do not affect brain read paths).
+ACCEPTED_READ_VERSIONS: frozenset[int] = frozenset({EXPECTED_SCHEMA_VERSION, 9, 8, 7, 6, 5})

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -154,6 +154,20 @@ watched_repos = []             # e.g., ["stevencarpenter/hippo"]
 # log_excerpt_max_bytes = 51200  # 50 KB cap per failure log tail
 # token_env = "HIPPO_GITHUB_TOKEN"
 
+[capture]
+# Controls how Claude session JSONL files are ingested.
+#
+# "tmux-tailer" (default): the SessionStart hook spawns one tmux window per
+#   session that tails the JSONL until Claude exits.
+#
+# "watcher": a persistent FSEvents daemon (com.hippo.claude-session-watcher)
+#   watches ~/.claude/projects/**/*.jsonl continuously. No tmux windows.
+#   Flip to this default in T-7 after 48 h of parity validation.
+#
+# "both": runs the tmux tailer AND the watcher concurrently. INSERT OR IGNORE
+#   deduplicates at the DB layer. Use during M3 parity gate.
+claude_session_mode = "tmux-tailer"
+
 [watchdog]
 # Capture-reliability watchdog — enabled by default since T-2 (launchd plist ships).
 #

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -22,6 +22,8 @@ pub struct HippoConfig {
     pub github: GithubConfig,
     #[serde(default)]
     pub watchdog: WatchdogConfig,
+    #[serde(default)]
+    pub capture: CaptureConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -530,6 +532,35 @@ pub fn socket_path(data_dir: &Path) -> PathBuf {
         std::env::temp_dir().join("hippo-daemon.sock")
     } else {
         candidate
+    }
+}
+
+// --- Capture config ---
+
+/// Controls how Claude session JSONL files are ingested.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClaudeSessionMode {
+    /// Legacy tmux-based tailer (one window per session). Default until T-7.
+    #[default]
+    TmuxTailer,
+    /// FSEvents watcher process watches all JSONL files continuously.
+    Watcher,
+    /// Both: tailer + watcher run concurrently for parity validation (M3 gate).
+    Both,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureConfig {
+    #[serde(default)]
+    pub claude_session_mode: ClaudeSessionMode,
+}
+
+impl Default for CaptureConfig {
+    fn default() -> Self {
+        Self {
+            claude_session_mode: ClaudeSessionMode::TmuxTailer,
+        }
     }
 }
 

--- a/crates/hippo-core/src/schema.sql
+++ b/crates/hippo-core/src/schema.sql
@@ -494,4 +494,29 @@ CREATE INDEX IF NOT EXISTS idx_capture_alarms_invariant_active
     ON capture_alarms (invariant_id, acked_at)
     WHERE acked_at IS NULL;
 
-PRAGMA user_version = 9;
+-- Watcher offset tracking: resume-after-restart for the FS watcher (T-5).
+CREATE TABLE IF NOT EXISTS claude_session_offsets (
+    path              TEXT    PRIMARY KEY,
+    session_id        TEXT,
+    byte_offset       INTEGER NOT NULL DEFAULT 0,
+    inode             INTEGER,
+    device            INTEGER,
+    size_at_last_read INTEGER NOT NULL DEFAULT 0,
+    updated_at        INTEGER NOT NULL
+) STRICT;
+
+-- Hourly parity snapshots comparing tailer vs. watcher counts (M3 gate).
+CREATE TABLE IF NOT EXISTS claude_session_parity (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    path           TEXT    NOT NULL,
+    tailer_count   INTEGER NOT NULL DEFAULT 0,
+    watcher_count  INTEGER NOT NULL DEFAULT 0,
+    mismatch_count INTEGER NOT NULL DEFAULT 0,
+    window_start   INTEGER NOT NULL,
+    window_end     INTEGER NOT NULL
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_claude_session_parity_path_window
+    ON claude_session_parity (path, window_start);
+
+PRAGMA user_version = 10;

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -13,7 +13,7 @@ const SCHEMA: &str = include_str!("schema.sql");
 /// startup code (e.g. the brain handshake) can cross-check without
 /// re-declaring the value. Keep in sync with
 /// `brain/src/hippo_brain/schema_version.py::EXPECTED_SCHEMA_VERSION`.
-pub const EXPECTED_VERSION: i64 = 9;
+pub const EXPECTED_VERSION: i64 = 10;
 
 pub fn open_db(path: &Path) -> Result<Connection> {
     if let Some(parent) = path.parent() {
@@ -418,6 +418,33 @@ pub fn open_db(path: &Path) -> Result<Connection> {
              CREATE INDEX IF NOT EXISTS idx_claude_sessions_start_time
                  ON claude_sessions (start_time DESC);
              PRAGMA user_version = 9;",
+        )?;
+    }
+
+    // Migrate from v9 → v10: add watcher offset tracking and parity tables (T-5).
+    if (1..=9).contains(&version) {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS claude_session_offsets (
+                path              TEXT    PRIMARY KEY,
+                session_id        TEXT,
+                byte_offset       INTEGER NOT NULL DEFAULT 0,
+                inode             INTEGER,
+                device            INTEGER,
+                size_at_last_read INTEGER NOT NULL DEFAULT 0,
+                updated_at        INTEGER NOT NULL
+             ) STRICT;
+             CREATE TABLE IF NOT EXISTS claude_session_parity (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                path           TEXT    NOT NULL,
+                tailer_count   INTEGER NOT NULL DEFAULT 0,
+                watcher_count  INTEGER NOT NULL DEFAULT 0,
+                mismatch_count INTEGER NOT NULL DEFAULT 0,
+                window_start   INTEGER NOT NULL,
+                window_end     INTEGER NOT NULL
+             ) STRICT;
+             CREATE INDEX IF NOT EXISTS idx_claude_session_parity_path_window
+                 ON claude_session_parity (path, window_start);
+             PRAGMA user_version = 10;",
         )?;
     } else if version != 0 && version != EXPECTED_VERSION {
         anyhow::bail!(
@@ -1648,7 +1675,7 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 9);
+        assert_eq!(v, 10);
     }
 
     #[test]
@@ -1718,7 +1745,7 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 9);
+        assert_eq!(v, 10);
         // Verify envelope_id column exists by inserting with it
         let sid = upsert_session(&conn, "mig-test", "host", "zsh", "user").unwrap();
         let eid = insert_event_at(
@@ -1804,7 +1831,7 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 9);
+        assert_eq!(v, 10);
     }
 
     #[test]
@@ -1906,7 +1933,7 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 9);
+        assert_eq!(v, 10);
 
         // Verify browser tables exist
         let browser_tables = [
@@ -1929,13 +1956,13 @@ mod tests {
             );
         }
 
-        // Close and re-open — should remain at v5 without error
+        // Close and re-open — should remain at current version without error
         drop(conn);
         let conn2 = open_db(&db_path).unwrap();
         let v2: i64 = conn2
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v2, 9);
+        assert_eq!(v2, 10);
     }
 
     fn sample_browser_event() -> BrowserEvent {

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -444,6 +444,8 @@ pub fn open_db(path: &Path) -> Result<Connection> {
              ) STRICT;
              CREATE INDEX IF NOT EXISTS idx_claude_session_parity_path_window
                  ON claude_session_parity (path, window_start);
+             CREATE INDEX IF NOT EXISTS idx_claude_sessions_start_time
+                 ON claude_sessions (start_time DESC);
              PRAGMA user_version = 10;",
         )?;
     } else if version != 0 && version != EXPECTED_VERSION {

--- a/crates/hippo-core/tests/schema_v5_migration.rs
+++ b/crates/hippo-core/tests/schema_v5_migration.rs
@@ -20,8 +20,8 @@ fn v4_db_migrates_to_latest_and_has_workflow_tables() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
-    // v4 → full chain (v5, v6, v7, v8, v9); only the final version is exercised here.
-    assert_eq!(version, 9);
+    // v4 → full chain (v5, v6, v7, v8, v9, v10); only the final version is exercised here.
+    assert_eq!(version, 10);
 
     for table in [
         "workflow_runs",

--- a/crates/hippo-core/tests/schema_v6_migration.rs
+++ b/crates/hippo-core/tests/schema_v6_migration.rs
@@ -20,7 +20,7 @@ fn v5_db_migrates_to_latest_and_has_fts_and_triggers() {
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
     // v5 → full chain (v6, v7, v8, v9); only the final version is exercised here.
-    assert_eq!(version, 9);
+    assert_eq!(version, 10);
 
     let fts_exists: i64 = conn
         .query_row(
@@ -169,7 +169,7 @@ fn fresh_db_has_latest_schema_and_fts_ready() {
         .unwrap();
     // Fresh DB applies the full SCHEMA + any subsequent migrations, so it
     // lands at the latest version rather than v6.
-    assert_eq!(version, 9);
+    assert_eq!(version, 10);
 
     conn.execute(
         "INSERT INTO knowledge_nodes (uuid, content, embed_text, node_type)

--- a/crates/hippo-core/tests/schema_v7_migration.rs
+++ b/crates/hippo-core/tests/schema_v7_migration.rs
@@ -27,7 +27,7 @@ fn v6_db_migrates_to_latest_and_adds_source_kind_and_tool_name() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(version, 9);
+    assert_eq!(version, 10);
 
     // events table must gain source_kind (NOT NULL default 'shell') and tool_name (TEXT).
     let columns: Vec<(String, String, i64, Option<String>)> = conn
@@ -139,7 +139,7 @@ fn fresh_db_has_v9() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(version, 9);
+    assert_eq!(version, 10);
 
     // source_kind / tool_name must exist on a fresh install too
     // (i.e. schema.sql itself must carry them, not just the migration).

--- a/crates/hippo-daemon/Cargo.toml
+++ b/crates/hippo-daemon/Cargo.toml
@@ -37,6 +37,7 @@ tracing-opentelemetry = { workspace = true, optional = true }
 sysinfo = { version = "0.38", optional = true, default-features = false, features = ["system"] }
 which = "8.0.2"
 notify = "8"
+walkdir = "2"
 
 [features]
 default = ["otel"]

--- a/crates/hippo-daemon/Cargo.toml
+++ b/crates/hippo-daemon/Cargo.toml
@@ -36,6 +36,7 @@ opentelemetry-appender-tracing = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 sysinfo = { version = "0.38", optional = true, default-features = false, features = ["system"] }
 which = "8.0.2"
+notify = "8"
 
 [features]
 default = ["otel"]
@@ -52,3 +53,4 @@ otel = [
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wiremock = "0.6"
+proptest = "1"

--- a/crates/hippo-daemon/src/claude_session.rs
+++ b/crates/hippo-daemon/src/claude_session.rs
@@ -711,7 +711,7 @@ fn extract_segments(
                         git_branch: git_branch
                             .clone()
                             .or_else(|| segments.last().and_then(|s| s.git_branch.clone())),
-                        segment_index: next_index - 1,
+                        segment_index: next_index,
                         start_time: ts_ms,
                         end_time: ts_ms,
                         user_prompts: Vec::new(),

--- a/crates/hippo-daemon/src/claude_session.rs
+++ b/crates/hippo-daemon/src/claude_session.rs
@@ -930,6 +930,34 @@ fn insert_segments(conn: &Connection, segments: &[SessionSegment]) -> Result<(us
 /// Logs but does not fail the caller on per-segment insert errors — the
 /// batch importer should still report event-sender progress honestly even
 /// if a single segment row fails.
+/// Extract segments from a JSONL session file and insert them into an existing
+/// connection. Called by the FS watcher (which owns its own connection) to avoid
+/// opening a second writer. Returns `(inserted, skipped, errors)`.
+pub fn ingest_session_file(conn: &Connection, path: &Path) -> (usize, usize, usize) {
+    let redaction = RedactionEngine::builtin();
+    let session_file = SessionFile::from_path(path);
+
+    let segments = match extract_segments(&session_file, &redaction) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(path = %path.display(), %e, "failed to extract session segments");
+            return (0, 0, 1);
+        }
+    };
+
+    if segments.is_empty() {
+        return (0, 0, 0);
+    }
+
+    match insert_segments(conn, &segments) {
+        Ok((inserted, skipped)) => (inserted, skipped, 0),
+        Err(e) => {
+            error!(%e, "failed to insert session segments");
+            (0, 0, 1)
+        }
+    }
+}
+
 fn write_session_segments(db_path: &Path, path: &Path) -> (usize, usize, usize) {
     let redaction = RedactionEngine::builtin();
     let session_file = SessionFile::from_path(path);

--- a/crates/hippo-daemon/src/claude_session.rs
+++ b/crates/hippo-daemon/src/claude_session.rs
@@ -925,11 +925,6 @@ fn insert_segments(conn: &Connection, segments: &[SessionSegment]) -> Result<(us
     Ok((inserted, skipped))
 }
 
-/// Extract segments from a JSONL and upsert them into `claude_sessions`.
-///
-/// Logs but does not fail the caller on per-segment insert errors — the
-/// batch importer should still report event-sender progress honestly even
-/// if a single segment row fails.
 /// Extract segments from a JSONL session file and insert them into an existing
 /// connection. Called by the FS watcher (which owns its own connection) to avoid
 /// opening a second writer. Returns `(inserted, skipped, errors)`.

--- a/crates/hippo-daemon/src/cli.rs
+++ b/crates/hippo-daemon/src/cli.rs
@@ -129,6 +129,10 @@ pub enum Commands {
         #[command(subcommand)]
         action: AlarmsAction,
     },
+    /// Watch ~/.claude/projects/**/*.jsonl for new session content (FSEvents, KeepAlive service)
+    ClaudeSessionWatch,
+    /// Print the current claude_session_mode from config (tmux-tailer | watcher | both)
+    CaptureMode,
 }
 
 #[derive(Subcommand)]

--- a/crates/hippo-daemon/src/lib.rs
+++ b/crates/hippo-daemon/src/lib.rs
@@ -14,6 +14,7 @@ pub mod process_metrics;
 pub mod schema_handshake;
 #[cfg(feature = "otel")]
 pub mod telemetry;
+pub mod watch_claude_sessions;
 pub mod watchdog;
 
 use hippo_core::config::ENV_ALLOWLIST;

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -1,7 +1,7 @@
 mod cli;
 mod install;
 
-use hippo_daemon::{claude_session, commands, daemon, gh_api, gh_poll};
+use hippo_daemon::{claude_session, commands, daemon, gh_api, gh_poll, watch_claude_sessions};
 
 use std::path::PathBuf;
 
@@ -11,6 +11,7 @@ use cli::{
     AlarmsAction, BrainAction, Cli, Commands, ConfigAction, DaemonAction, IngestSource,
     RedactAction, SendEventSource, WatchdogAction,
 };
+use hippo_core::config::ClaudeSessionMode;
 use hippo_core::config::HippoConfig;
 use hippo_daemon::probe;
 use tracing_subscriber::EnvFilter;
@@ -241,6 +242,8 @@ async fn main() -> Result<()> {
                 let brain_was_loaded = install::service_is_loaded("com.hippo.brain");
                 let watchdog_was_loaded = install::service_is_loaded("com.hippo.watchdog");
                 let probe_was_loaded = install::service_is_loaded("com.hippo.probe");
+                let watcher_was_loaded =
+                    install::service_is_loaded("com.hippo.claude-session-watcher");
 
                 if brain_was_loaded {
                     print!("  Draining brain (waiting for in-flight requests)");
@@ -275,12 +278,21 @@ async fn main() -> Result<()> {
                     install::service_bootout(&domain, &launch_agents.join("com.hippo.probe.plist"));
                     println!("  Stopped probe");
                 }
+                if watcher_was_loaded {
+                    install::service_bootout(
+                        &domain,
+                        &launch_agents.join("com.hippo.claude-session-watcher.plist"),
+                    );
+                    println!("  Stopped claude-session-watcher");
+                }
 
                 let daemon_template = include_str!("../../../launchd/com.hippo.daemon.plist");
                 let brain_template = include_str!("../../../launchd/com.hippo.brain.plist");
                 let watchdog_template = include_str!("../../../launchd/com.hippo.watchdog.plist");
                 let gh_poll_template = include_str!("../../../launchd/com.hippo.gh-poll.plist");
                 let probe_template = include_str!("../../../launchd/com.hippo.probe.plist");
+                let watcher_template =
+                    include_str!("../../../launchd/com.hippo.claude-session-watcher.plist");
                 let xcode_claude_template =
                     include_str!("../../../launchd/com.hippo.xcode-claude-ingest.plist");
                 let xcode_codex_template =
@@ -290,6 +302,12 @@ async fn main() -> Result<()> {
                 install::install_plist("com.hippo.brain", brain_template, &vars, force)?;
                 install::install_plist("com.hippo.probe", probe_template, &vars, force)?;
                 install::install_plist("com.hippo.watchdog", watchdog_template, &vars, force)?;
+                install::install_plist(
+                    "com.hippo.claude-session-watcher",
+                    watcher_template,
+                    &vars,
+                    force,
+                )?;
                 install::install_plist(
                     "com.hippo.xcode-claude-ingest",
                     xcode_claude_template,
@@ -368,7 +386,11 @@ async fn main() -> Result<()> {
                 }
 
                 // Reload services that were running before the upgrade.
-                if daemon_was_loaded || brain_was_loaded || watchdog_was_loaded || probe_was_loaded
+                if daemon_was_loaded
+                    || brain_was_loaded
+                    || watchdog_was_loaded
+                    || probe_was_loaded
+                    || watcher_was_loaded
                 {
                     println!();
                     println!("Restarting services...");
@@ -400,6 +422,13 @@ async fn main() -> Result<()> {
                         )?;
                         println!("  Started probe");
                     }
+                    if watcher_was_loaded {
+                        install::service_bootstrap(
+                            &domain,
+                            &launch_agents.join("com.hippo.claude-session-watcher.plist"),
+                        )?;
+                        println!("  Started claude-session-watcher");
+                    }
                 }
 
                 // Only print "Load with:" for services that weren't already cycled.
@@ -407,6 +436,7 @@ async fn main() -> Result<()> {
                     || !brain_was_loaded
                     || !watchdog_was_loaded
                     || !probe_was_loaded
+                    || !watcher_was_loaded
                     || gh_poll_installed;
                 if needs_manual_start {
                     println!();
@@ -429,6 +459,11 @@ async fn main() -> Result<()> {
                     if !probe_was_loaded {
                         println!(
                             "  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.probe.plist"
+                        );
+                    }
+                    if !watcher_was_loaded {
+                        println!(
+                            "  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.claude-session-watcher.plist"
                         );
                     }
                     if gh_poll_installed {
@@ -923,6 +958,17 @@ async fn main() -> Result<()> {
                 commands::handle_alarms_ack(&config, id, note.as_deref())?;
             }
         },
+        Commands::ClaudeSessionWatch => {
+            watch_claude_sessions::run(&config).await?;
+        }
+        Commands::CaptureMode => {
+            let mode = match config.capture.claude_session_mode {
+                ClaudeSessionMode::TmuxTailer => "tmux-tailer",
+                ClaudeSessionMode::Watcher => "watcher",
+                ClaudeSessionMode::Both => "both",
+            };
+            println!("{mode}");
+        }
     }
 
     // Shutdown OTel providers

--- a/crates/hippo-daemon/src/metrics.rs
+++ b/crates/hippo-daemon/src/metrics.rs
@@ -162,3 +162,13 @@ pub static WATCHDOG_ALARMS_FIRED: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .with_description("New capture alarms inserted, labelled by invariant_id")
         .build()
 });
+
+/// Per-source violation counter as specified in docs/capture-reliability/02-invariants.md.
+/// Complements WATCHDOG_ALARMS_FIRED (which slices by invariant_id) with the source dimension
+/// required by the spec for dashboards and alerts.
+pub static WATCHDOG_INVARIANT_VIOLATION: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("hippo.watchdog.invariant_violation")
+        .with_description("Invariant violations by capture source, per spec 02-invariants.md")
+        .build()
+});

--- a/crates/hippo-daemon/src/metrics.rs
+++ b/crates/hippo-daemon/src/metrics.rs
@@ -104,3 +104,61 @@ pub static FALLBACK_RECOVERED: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .with_description("Events recovered from fallback")
         .build()
 });
+
+// --- Watcher ---
+
+pub static WATCHER_SEGMENTS_INGESTED: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("hippo.watcher.segments.ingested")
+        .with_description("Segments inserted by the FS watcher")
+        .build()
+});
+
+pub static WATCHER_PROCESS_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("hippo.watcher.process.duration")
+        .with_description("Per-file processing time in the FS watcher")
+        .with_unit("ms")
+        .build()
+});
+
+pub static WATCHER_EVENTS_DROPPED: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("hippo.watcher.events.dropped")
+        .with_description("FSEvents notifications dropped due to full channel")
+        .build()
+});
+
+// --- Probe ---
+
+/// Increment once per probe run; use `source` and `ok` attributes to slice.
+pub static PROBE_RUN: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("hippo.probe.run")
+        .with_description("Synthetic probe executions, labelled by source and ok")
+        .build()
+});
+
+pub static PROBE_LAG_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("hippo.probe.lag")
+        .with_description("Probe round-trip lag from submission to DB row")
+        .with_unit("ms")
+        .build()
+});
+
+// --- Watchdog ---
+
+pub static WATCHDOG_RUN: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("hippo.watchdog.run")
+        .with_description("Watchdog evaluation cycles completed")
+        .build()
+});
+
+pub static WATCHDOG_ALARMS_FIRED: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("hippo.watchdog.alarms.fired")
+        .with_description("New capture alarms inserted, labelled by invariant_id")
+        .build()
+});

--- a/crates/hippo-daemon/src/probe.rs
+++ b/crates/hippo-daemon/src/probe.rs
@@ -441,5 +441,21 @@ fn write_probe_result(
         );
     }
 
+    #[cfg(feature = "otel")]
+    {
+        use opentelemetry::KeyValue;
+        crate::metrics::PROBE_RUN.add(
+            1,
+            &[
+                KeyValue::new("source", source.to_owned()),
+                KeyValue::new("ok", ok.to_string()),
+            ],
+        );
+        if let Some(lag) = lag_ms {
+            crate::metrics::PROBE_LAG_MS
+                .record(lag as f64, &[KeyValue::new("source", source.to_owned())]);
+        }
+    }
+
     Ok(())
 }

--- a/crates/hippo-daemon/src/probe.rs
+++ b/crates/hippo-daemon/src/probe.rs
@@ -444,16 +444,17 @@ fn write_probe_result(
     #[cfg(feature = "otel")]
     {
         use opentelemetry::KeyValue;
+        let source_owned = source.to_owned();
         crate::metrics::PROBE_RUN.add(
             1,
             &[
-                KeyValue::new("source", source.to_owned()),
+                KeyValue::new("source", source_owned.clone()),
                 KeyValue::new("ok", ok),
             ],
         );
         if let Some(lag) = lag_ms {
             crate::metrics::PROBE_LAG_MS
-                .record(lag as f64, &[KeyValue::new("source", source.to_owned())]);
+                .record(lag as f64, &[KeyValue::new("source", source_owned)]);
         }
     }
 

--- a/crates/hippo-daemon/src/probe.rs
+++ b/crates/hippo-daemon/src/probe.rs
@@ -448,7 +448,7 @@ fn write_probe_result(
             1,
             &[
                 KeyValue::new("source", source.to_owned()),
-                KeyValue::new("ok", ok.to_string()),
+                KeyValue::new("ok", ok),
             ],
         );
         if let Some(lag) = lag_ms {

--- a/crates/hippo-daemon/src/watch_claude_sessions.rs
+++ b/crates/hippo-daemon/src/watch_claude_sessions.rs
@@ -5,7 +5,11 @@
 //! launchd service (`com.hippo.claude-session-watcher`, KeepAlive=true).
 //!
 //! Key invariants:
-//! - Only advances `byte_offset` past the last complete (`\n`-terminated) byte.
+//! - Full-file reparse on every FSEvents notification; `INSERT OR IGNORE` on
+//!   `(session_id, segment_index)` makes repeated processing idempotent.
+//!   `size_at_last_read` is compared to current file size to skip no-op wakeups.
+//!   `byte_offset` is stored as `current_size` (matching `size_at_last_read`) so a
+//!   future seek-based optimisation can use it without a schema change.
 //! - Resets offset on inode/device change (file replaced) or size regression (truncated).
 //! - `INSERT OR IGNORE` in `insert_segments` makes re-processing idempotent.
 //! - Writes `source_health WHERE source='claude-session-watcher'` every 30 s.
@@ -22,6 +26,7 @@ use notify::{
     Config as NotifyConfig, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
 use rusqlite::{Connection, params};
+use tokio::signal::unix::{SignalKind, signal as unix_signal};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
@@ -92,11 +97,13 @@ fn load_offsets(conn: &Connection) -> Result<HashMap<PathBuf, FileState>> {
 /// Persist a file's offset to `claude_session_offsets`.
 fn save_offset(conn: &Connection, path: &Path, state: &FileState) -> Result<()> {
     let now_ms = Utc::now().timestamp_millis();
+    let session_id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
     conn.execute(
         "INSERT INTO claude_session_offsets
-             (path, byte_offset, inode, device, size_at_last_read, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             (path, session_id, byte_offset, inode, device, size_at_last_read, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
          ON CONFLICT(path) DO UPDATE SET
+             session_id        = excluded.session_id,
              byte_offset       = excluded.byte_offset,
              inode             = excluded.inode,
              device            = excluded.device,
@@ -104,6 +111,7 @@ fn save_offset(conn: &Connection, path: &Path, state: &FileState) -> Result<()> 
              updated_at        = excluded.updated_at",
         params![
             path.to_string_lossy(),
+            session_id,
             state.byte_offset as i64,
             state.inode as i64,
             state.device as i64,
@@ -260,8 +268,11 @@ fn write_parity_row(
         )
         .unwrap_or(0) as usize;
 
+    // tailer_count = segments in DB not attributed to the watcher this window.
+    // mismatch_count = same value: segments the watcher missed (tailer-only inserts).
+    // If watcher_count somehow exceeds total (race), clamp to 0 via saturating_sub.
     let tailer_count = total.saturating_sub(watcher_count);
-    let mismatch_count = watcher_count.saturating_sub(total);
+    let mismatch_count = tailer_count;
 
     if let Err(e) = conn.execute(
         "INSERT INTO claude_session_parity
@@ -403,10 +414,18 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
     let mut parity_tick = tokio::time::interval(PARITY_INTERVAL);
     parity_tick.tick().await; // consume first immediate tick
 
+    // Handle both SIGTERM (launchd stop / system shutdown) and SIGINT (ctrl-c).
+    let mut sigterm = unix_signal(SignalKind::terminate())
+        .context("watcher: failed to install SIGTERM handler")?;
+
     loop {
         tokio::select! {
+            _ = sigterm.recv() => {
+                info!("watcher: received SIGTERM, shutting down");
+                break;
+            }
             _ = tokio::signal::ctrl_c() => {
-                info!("watcher: received ctrl-c, shutting down");
+                info!("watcher: received SIGINT, shutting down");
                 break;
             }
 
@@ -415,9 +434,9 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
             }
 
             _ = parity_tick.tick() => {
-                if matches!(mode, ClaudeSessionMode::Both) {
-                    let window_end = Utc::now().timestamp_millis();
-                    for (path, state) in &mut states {
+                let window_end = Utc::now().timestamp_millis();
+                for (path, state) in &mut states {
+                    if matches!(mode, ClaudeSessionMode::Both) {
                         if state.watcher_hour_count > 0 || state.hour_window_start > 0 {
                             write_parity_row(
                                 &conn,

--- a/crates/hippo-daemon/src/watch_claude_sessions.rs
+++ b/crates/hippo-daemon/src/watch_claude_sessions.rs
@@ -205,27 +205,18 @@ fn process_file(path: &Path, state: &mut FileState, conn: &Connection) -> Result
     Ok(inserted)
 }
 
-/// Glob all `~/.claude/projects/**/*.jsonl` files and return their paths.
+/// Walk `~/.claude/projects/**/*.jsonl` recursively (catches subagent files too).
 fn find_session_files(projects_dir: &Path) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    let Ok(entries) = std::fs::read_dir(projects_dir) else {
-        return files;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            let Ok(sub) = std::fs::read_dir(&path) else {
-                continue;
-            };
-            for sub_entry in sub.flatten() {
-                let sub_path = sub_entry.path();
-                if sub_path.extension().is_some_and(|e| e == "jsonl") {
-                    files.push(sub_path);
-                }
-            }
-        }
-    }
-    files
+    walkdir::WalkDir::new(projects_dir)
+        .follow_links(false)
+        .into_iter()
+        .flatten()
+        .filter(|e| {
+            e.file_type().is_file()
+                && e.path().extension().is_some_and(|ext| ext == "jsonl")
+        })
+        .map(|e| e.into_path())
+        .collect()
 }
 
 /// Upsert the watcher's own heartbeat in `source_health`.

--- a/crates/hippo-daemon/src/watch_claude_sessions.rs
+++ b/crates/hippo-daemon/src/watch_claude_sessions.rs
@@ -28,7 +28,7 @@ use notify::{
 use rusqlite::{Connection, params};
 use tokio::signal::unix::{SignalKind, signal as unix_signal};
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use hippo_core::config::{ClaudeSessionMode, HippoConfig};
 use hippo_core::storage::open_db;
@@ -212,8 +212,7 @@ fn find_session_files(projects_dir: &Path) -> Vec<PathBuf> {
         .into_iter()
         .flatten()
         .filter(|e| {
-            e.file_type().is_file()
-                && e.path().extension().is_some_and(|ext| ext == "jsonl")
+            e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "jsonl")
         })
         .map(|e| e.into_path())
         .collect()
@@ -301,16 +300,16 @@ fn write_parity_row(
 
 /// Check whether `path` lives on a remote filesystem (NFS, SMB, etc.) and log
 /// a warning.  FSEvents may not fire reliably for remote volumes.
+/// `statfs::f_fstypename` is macOS-specific; this is a no-op on other platforms.
+#[cfg(target_os = "macos")]
 fn warn_if_remote_fs(path: &Path) {
-    use std::ffi::CStr;
-    use std::ffi::CString;
+    use std::ffi::{CStr, CString};
 
     let Ok(c_path) = CString::new(path.to_string_lossy().as_bytes()) else {
         return;
     };
     let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
-    let ret = unsafe { libc::statfs(c_path.as_ptr(), &mut buf) };
-    if ret != 0 {
+    if unsafe { libc::statfs(c_path.as_ptr(), &mut buf) } != 0 {
         return;
     }
     let fs_type = unsafe { CStr::from_ptr(buf.f_fstypename.as_ptr()) }
@@ -325,6 +324,9 @@ fn warn_if_remote_fs(path: &Path) {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
+fn warn_if_remote_fs(_path: &Path) {}
+
 /// Return the path to `~/.claude/projects/`.
 fn projects_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".claude").join("projects"))
@@ -334,6 +336,21 @@ fn projects_dir() -> Option<PathBuf> {
 pub async fn run(config: &HippoConfig) -> Result<()> {
     let db_path = config.db_path();
     let mode = &config.capture.claude_session_mode;
+
+    // In tmux-tailer mode the watcher service should not run. Idle until shutdown
+    // so launchd KeepAlive doesn't spin-restart this process continuously.
+    if matches!(mode, ClaudeSessionMode::TmuxTailer) {
+        info!(
+            "watcher: capture mode is tmux-tailer; idling (set mode to 'watcher' or 'both' to enable FS watching)"
+        );
+        let mut sigterm = unix_signal(SignalKind::terminate())
+            .context("watcher: failed to install SIGTERM handler")?;
+        tokio::select! {
+            _ = sigterm.recv() => {}
+            _ = tokio::signal::ctrl_c() => {}
+        }
+        return Ok(());
+    }
 
     let projects = match projects_dir() {
         Some(p) => p,
@@ -378,22 +395,44 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
     let mut watcher = RecommendedWatcher::new(
         move |event: notify::Result<Event>| {
             if let Ok(e) = event {
-                let _ = tx.blocking_send(e);
+                // try_send never blocks the notify thread; Full drops events (the full-file
+                // reparse on the next write catches anything missed); Closed means shutdown.
+                if let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) = tx.try_send(e) {
+                    debug!("watcher: FSEvents channel full; event dropped");
+                }
             }
         },
         NotifyConfig::default(),
     )
     .context("watcher: failed to create FSEvents watcher")?;
 
-    if projects.exists() {
+    // Watch `projects` if it exists; otherwise walk up to the nearest ancestor that
+    // does exist (typically `~/.claude`).  This handles fresh installs where
+    // `~/.claude/projects` has not yet been created by Claude — FSEvents on the
+    // ancestor will fire when the subdirectory and its files appear.
+    let watch_root = {
+        let mut p = projects.clone();
+        while !p.exists() {
+            match p.parent() {
+                Some(parent) => p = parent.to_path_buf(),
+                None => break,
+            }
+        }
+        p
+    };
+    if watch_root.exists() {
+        if watch_root != projects {
+            warn!(
+                projects = %projects.display(),
+                watching = %watch_root.display(),
+                "watcher: projects directory does not exist; watching ancestor instead"
+            );
+        }
         watcher
-            .watch(&projects, RecursiveMode::Recursive)
-            .context("watcher: failed to watch projects dir")?;
+            .watch(&watch_root, RecursiveMode::Recursive)
+            .with_context(|| format!("watcher: failed to watch {}", watch_root.display()))?;
     } else {
-        warn!(
-            path = %projects.display(),
-            "watcher: projects directory does not exist; no files will be watched"
-        );
+        warn!("watcher: no watchable directory found; no files will be watched");
     }
 
     info!(
@@ -456,9 +495,12 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
                     if path.extension().is_none_or(|e| e != "jsonl") {
                         continue;
                     }
-                    let state = states.entry(path.clone()).or_insert_with(|| FileState {
-                        hour_window_start: current_hour_start,
-                        ..Default::default()
+                    let state = states.entry(path.clone()).or_insert_with(|| {
+                        let now = Utc::now().timestamp_millis();
+                        FileState {
+                            hour_window_start: now - (now % (3600 * 1000)),
+                            ..Default::default()
+                        }
                     });
                     match process_file(&path, state, &conn) {
                         Ok(0) => {}
@@ -528,7 +570,7 @@ mod tests {
 
         // Write a session with one complete exchange.
         let session_id = "test-sess-0001-0001-0001-0001-000000000001";
-        let jsonl_path = dir.path().join("test-session.jsonl");
+        let jsonl_path = dir.path().join(format!("{session_id}.jsonl"));
         let content = [
             j(session_id, 0, "system", "init"),
             j(session_id, 1, "user", "hello"),
@@ -561,7 +603,7 @@ mod tests {
         let conn = open_test_db(&dir);
 
         let session_id = "test-sess-trunc-0001-0001-0001-000000000001";
-        let jsonl_path = dir.path().join("trunc-session.jsonl");
+        let jsonl_path = dir.path().join(format!("{session_id}.jsonl"));
         let content = j(session_id, 0, "user", "hi") + "\n";
         std::fs::write(&jsonl_path, &content).unwrap();
 
@@ -610,7 +652,7 @@ mod tests {
         let conn = open_test_db(&dir);
 
         let session_id = "test-sess-dedup-0001-0001-0001-000000000001";
-        let jsonl_path = dir.path().join("dedup-session.jsonl");
+        let jsonl_path = dir.path().join(format!("{session_id}.jsonl"));
 
         // Write initial content.
         let line1 = j(session_id, 0, "user", "first") + "\n";

--- a/crates/hippo-daemon/src/watch_claude_sessions.rs
+++ b/crates/hippo-daemon/src/watch_claude_sessions.rs
@@ -1,0 +1,662 @@
+//! Persistent FSEvents watcher for Claude session JSONL files (T-5, P2.1).
+//!
+//! Subscribes to `~/.claude/projects/**/*.jsonl` via `notify`/FSEvents and
+//! re-extracts session segments whenever a file grows.  Runs as a long-lived
+//! launchd service (`com.hippo.claude-session-watcher`, KeepAlive=true).
+//!
+//! Key invariants:
+//! - Only advances `byte_offset` past the last complete (`\n`-terminated) byte.
+//! - Resets offset on inode/device change (file replaced) or size regression (truncated).
+//! - `INSERT OR IGNORE` in `insert_segments` makes re-processing idempotent.
+//! - Writes `source_health WHERE source='claude-session-watcher'` every 30 s.
+//! - In `both` mode, writes a `claude_session_parity` row per file per hour.
+
+use std::collections::HashMap;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use notify::{
+    Config as NotifyConfig, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
+use rusqlite::{Connection, params};
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use hippo_core::config::{ClaudeSessionMode, HippoConfig};
+use hippo_core::storage::open_db;
+
+use crate::claude_session::ingest_session_file;
+use crate::is_missing_source_health_table_error;
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const PARITY_INTERVAL: Duration = Duration::from_secs(3600);
+const BACKOFF_DURATION: Duration = Duration::from_secs(60);
+const PER_FILE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Per-file tracking state (in memory; persisted to `claude_session_offsets`).
+#[derive(Default)]
+struct FileState {
+    byte_offset: u64,
+    inode: u64,
+    device: u64,
+    size_at_last_read: u64,
+    /// When to retry after a processing timeout.
+    cooldown_until: Option<Instant>,
+    /// Segments inserted by this watcher in the current parity hour window.
+    watcher_hour_count: usize,
+    /// Start of the current parity hour window (ms epoch).
+    hour_window_start: i64,
+}
+
+/// Load all saved offsets from `claude_session_offsets` into memory.
+fn load_offsets(conn: &Connection) -> Result<HashMap<PathBuf, FileState>> {
+    let mut stmt = conn.prepare(
+        "SELECT path, byte_offset, inode, device, size_at_last_read
+         FROM claude_session_offsets",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            PathBuf::from(row.get::<_, String>(0)?),
+            row.get::<_, i64>(1).unwrap_or(0) as u64,
+            row.get::<_, i64>(2).unwrap_or(0) as u64,
+            row.get::<_, i64>(3).unwrap_or(0) as u64,
+            row.get::<_, i64>(4).unwrap_or(0) as u64,
+        ))
+    })?;
+
+    let now_ms = Utc::now().timestamp_millis();
+    let hour_window_start = now_ms - (now_ms % (3600 * 1000));
+
+    let mut map = HashMap::new();
+    for row in rows {
+        let (path, offset, inode, device, size) = row?;
+        map.insert(
+            path,
+            FileState {
+                byte_offset: offset,
+                inode,
+                device,
+                size_at_last_read: size,
+                cooldown_until: None,
+                watcher_hour_count: 0,
+                hour_window_start,
+            },
+        );
+    }
+    Ok(map)
+}
+
+/// Persist a file's offset to `claude_session_offsets`.
+fn save_offset(conn: &Connection, path: &Path, state: &FileState) -> Result<()> {
+    let now_ms = Utc::now().timestamp_millis();
+    conn.execute(
+        "INSERT INTO claude_session_offsets
+             (path, byte_offset, inode, device, size_at_last_read, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(path) DO UPDATE SET
+             byte_offset       = excluded.byte_offset,
+             inode             = excluded.inode,
+             device            = excluded.device,
+             size_at_last_read = excluded.size_at_last_read,
+             updated_at        = excluded.updated_at",
+        params![
+            path.to_string_lossy(),
+            state.byte_offset as i64,
+            state.inode as i64,
+            state.device as i64,
+            state.size_at_last_read as i64,
+            now_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Process new content in a single file.  Returns the number of segments inserted.
+fn process_file(path: &Path, state: &mut FileState, conn: &Connection) -> Result<usize> {
+    if let Some(until) = state.cooldown_until {
+        if Instant::now() < until {
+            return Ok(0);
+        }
+        state.cooldown_until = None;
+    }
+
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(path = %path.display(), %e, "watcher: cannot stat file");
+            return Ok(0);
+        }
+    };
+
+    let current_size = meta.len();
+    let current_inode = meta.ino();
+    let current_device = meta.dev();
+
+    // Detect file replacement (inode or device changed).
+    if state.inode != 0 && (current_inode != state.inode || current_device != state.device) {
+        info!(
+            path = %path.display(),
+            old_inode = state.inode,
+            new_inode = current_inode,
+            "watcher: file replaced, resetting offset"
+        );
+        state.byte_offset = 0;
+        state.size_at_last_read = 0;
+    }
+    state.inode = current_inode;
+    state.device = current_device;
+
+    // Detect truncation.
+    if current_size < state.byte_offset {
+        warn!(
+            path = %path.display(),
+            prev_offset = state.byte_offset,
+            current_size,
+            "watcher: file truncated, resetting offset"
+        );
+        state.byte_offset = 0;
+        state.size_at_last_read = 0;
+    }
+
+    // No new complete content.  We use size_at_last_read (not byte_offset) to
+    // detect growth because extract_segments/reader.lines() stops before an
+    // unterminated final line — so byte_offset can equal size_at_last_read
+    // even when the raw file is slightly larger.
+    if current_size <= state.size_at_last_read {
+        return Ok(0);
+    }
+
+    let start = Instant::now();
+    let (inserted, _skipped, errors) = ingest_session_file(conn, path);
+    if start.elapsed() > PER_FILE_TIMEOUT {
+        warn!(
+            path = %path.display(),
+            elapsed_ms = start.elapsed().as_millis(),
+            "watcher: per-file processing was slow"
+        );
+    }
+
+    if errors > 0 {
+        state.cooldown_until = Some(Instant::now() + BACKOFF_DURATION);
+    } else {
+        // Advance offset past the content we just processed.  `extract_segments`
+        // uses `reader.lines()` which stops before an unterminated line, so we
+        // record the raw file size; on the next pass the comparison
+        // `current_size <= size_at_last_read` will hold until more bytes arrive.
+        state.byte_offset = current_size;
+        state.size_at_last_read = current_size;
+        state.watcher_hour_count += inserted;
+        save_offset(conn, path, state).unwrap_or_else(|e| {
+            warn!(path = %path.display(), %e, "watcher: failed to save offset");
+        });
+    }
+
+    Ok(inserted)
+}
+
+/// Glob all `~/.claude/projects/**/*.jsonl` files and return their paths.
+fn find_session_files(projects_dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(entries) = std::fs::read_dir(projects_dir) else {
+        return files;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let Ok(sub) = std::fs::read_dir(&path) else {
+                continue;
+            };
+            for sub_entry in sub.flatten() {
+                let sub_path = sub_entry.path();
+                if sub_path.extension().is_some_and(|e| e == "jsonl") {
+                    files.push(sub_path);
+                }
+            }
+        }
+    }
+    files
+}
+
+/// Upsert the watcher's own heartbeat in `source_health`.
+fn upsert_heartbeat(conn: &Connection) {
+    let now_ms = Utc::now().timestamp_millis();
+    let res = conn.execute(
+        "INSERT INTO source_health (source, last_success_ts, updated_at)
+         VALUES ('claude-session-watcher', ?1, ?1)
+         ON CONFLICT(source) DO UPDATE SET
+             last_success_ts = excluded.last_success_ts,
+             updated_at      = excluded.updated_at",
+        params![now_ms],
+    );
+    match res {
+        Err(e) if !is_missing_source_health_table_error(&e) => {
+            warn!(%e, "watcher: heartbeat upsert failed");
+        }
+        _ => {}
+    }
+}
+
+/// Write a parity row for a file at the end of an hourly window.
+fn write_parity_row(
+    conn: &Connection,
+    path: &Path,
+    watcher_count: usize,
+    window_start: i64,
+    window_end: i64,
+) {
+    // Count all claude_sessions rows for this source_file in the window —
+    // includes both tailer and watcher inserts (INSERT OR IGNORE deduplicates).
+    let total: usize = conn
+        .query_row(
+            "SELECT COUNT(*) FROM claude_sessions
+             WHERE source_file = ?1
+               AND created_at >= ?2
+               AND created_at < ?3",
+            params![path.to_string_lossy(), window_start, window_end],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0) as usize;
+
+    let tailer_count = total.saturating_sub(watcher_count);
+    let mismatch_count = watcher_count.saturating_sub(total);
+
+    if let Err(e) = conn.execute(
+        "INSERT INTO claude_session_parity
+             (path, tailer_count, watcher_count, mismatch_count, window_start, window_end)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            path.to_string_lossy(),
+            tailer_count as i64,
+            watcher_count as i64,
+            mismatch_count as i64,
+            window_start,
+            window_end,
+        ],
+    ) {
+        warn!(%e, path = %path.display(), "watcher: failed to write parity row");
+    }
+
+    if mismatch_count > 0 {
+        warn!(
+            path = %path.display(),
+            tailer_count,
+            watcher_count,
+            mismatch_count,
+            "watcher: parity mismatch in window [{window_start}, {window_end})"
+        );
+    } else {
+        info!(
+            path = %path.display(),
+            tailer_count,
+            watcher_count,
+            "watcher: parity clean for window"
+        );
+    }
+}
+
+/// Check whether `path` lives on a remote filesystem (NFS, SMB, etc.) and log
+/// a warning.  FSEvents may not fire reliably for remote volumes.
+fn warn_if_remote_fs(path: &Path) {
+    use std::ffi::CStr;
+    use std::ffi::CString;
+
+    let Ok(c_path) = CString::new(path.to_string_lossy().as_bytes()) else {
+        return;
+    };
+    let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
+    let ret = unsafe { libc::statfs(c_path.as_ptr(), &mut buf) };
+    if ret != 0 {
+        return;
+    }
+    let fs_type = unsafe { CStr::from_ptr(buf.f_fstypename.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
+    if matches!(fs_type.as_str(), "nfs" | "smbfs" | "cifs" | "ntfs") {
+        warn!(
+            path = %path.display(),
+            fs_type,
+            "watcher: projects dir is on a remote filesystem; FSEvents may miss events"
+        );
+    }
+}
+
+/// Return the path to `~/.claude/projects/`.
+fn projects_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claude").join("projects"))
+}
+
+/// Entry point — runs until SIGTERM/ctrl-c.
+pub async fn run(config: &HippoConfig) -> Result<()> {
+    let db_path = config.db_path();
+    let mode = &config.capture.claude_session_mode;
+
+    let projects = match projects_dir() {
+        Some(p) => p,
+        None => {
+            warn!("watcher: cannot determine home directory; exiting");
+            return Ok(());
+        }
+    };
+
+    warn_if_remote_fs(&projects);
+
+    // Open our own write connection (WAL, separate from the daemon).
+    let conn = open_db(&db_path).context("watcher: failed to open DB")?;
+
+    // Load saved offsets and build initial state map.
+    let mut states: HashMap<PathBuf, FileState> = load_offsets(&conn).unwrap_or_default();
+
+    // Initialize parity window start for any file not already tracked.
+    let now_ms = Utc::now().timestamp_millis();
+    let current_hour_start = now_ms - (now_ms % (3600 * 1000));
+
+    // Startup scan — catch up on any content written while we were down.
+    let initial_files = find_session_files(&projects);
+    info!(count = initial_files.len(), "watcher: startup scan");
+    for path in &initial_files {
+        let state = states.entry(path.clone()).or_insert_with(|| FileState {
+            hour_window_start: current_hour_start,
+            ..Default::default()
+        });
+        match process_file(path, state, &conn) {
+            Ok(n) if n > 0 => {
+                info!(path = %path.display(), inserted = n, "watcher: startup catch-up");
+            }
+            _ => {}
+        }
+    }
+
+    upsert_heartbeat(&conn);
+
+    // Set up FSEvents subscription.
+    let (tx, mut rx) = mpsc::channel::<Event>(256);
+    let mut watcher = RecommendedWatcher::new(
+        move |event: notify::Result<Event>| {
+            if let Ok(e) = event {
+                let _ = tx.blocking_send(e);
+            }
+        },
+        NotifyConfig::default(),
+    )
+    .context("watcher: failed to create FSEvents watcher")?;
+
+    if projects.exists() {
+        watcher
+            .watch(&projects, RecursiveMode::Recursive)
+            .context("watcher: failed to watch projects dir")?;
+    } else {
+        warn!(
+            path = %projects.display(),
+            "watcher: projects directory does not exist; no files will be watched"
+        );
+    }
+
+    info!(
+        path = %projects.display(),
+        "watcher: listening for FSEvents"
+    );
+
+    let mut heartbeat_tick = tokio::time::interval(HEARTBEAT_INTERVAL);
+    let mut parity_tick = tokio::time::interval(PARITY_INTERVAL);
+    parity_tick.tick().await; // consume first immediate tick
+
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                info!("watcher: received ctrl-c, shutting down");
+                break;
+            }
+
+            _ = heartbeat_tick.tick() => {
+                upsert_heartbeat(&conn);
+            }
+
+            _ = parity_tick.tick() => {
+                if matches!(mode, ClaudeSessionMode::Both) {
+                    let window_end = Utc::now().timestamp_millis();
+                    for (path, state) in &mut states {
+                        if state.watcher_hour_count > 0 || state.hour_window_start > 0 {
+                            write_parity_row(
+                                &conn,
+                                path,
+                                state.watcher_hour_count,
+                                state.hour_window_start,
+                                window_end,
+                            );
+                        }
+                        state.watcher_hour_count = 0;
+                        state.hour_window_start = window_end;
+                    }
+                }
+            }
+
+            Some(event) = rx.recv() => {
+                let is_relevant = matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_)
+                );
+                if !is_relevant {
+                    continue;
+                }
+
+                for path in event.paths {
+                    if path.extension().is_none_or(|e| e != "jsonl") {
+                        continue;
+                    }
+                    let state = states.entry(path.clone()).or_insert_with(|| FileState {
+                        hour_window_start: current_hour_start,
+                        ..Default::default()
+                    });
+                    match process_file(&path, state, &conn) {
+                        Ok(0) => {}
+                        Ok(n) => {
+                            info!(path = %path.display(), inserted = n, "watcher: ingested segments");
+                        }
+                        Err(e) => {
+                            warn!(path = %path.display(), %e, "watcher: processing error");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Generate a minimal Claude JSONL line for testing.
+/// Always public so integration tests in `tests/` can import it.
+pub fn make_test_jsonl_line(
+    session_id: &str,
+    ts_offset_secs: u64,
+    msg_type: &str,
+    text: &str,
+) -> String {
+    let ts = chrono::DateTime::from_timestamp((1_700_000_000 + ts_offset_secs) as i64, 0)
+        .unwrap()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string();
+    match msg_type {
+        "system" => format!(
+            r#"{{"type":"system","timestamp":"{ts}","sessionId":"{session_id}","cwd":"/tmp/test","message":{{"role":"system","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+        ),
+        "user" => format!(
+            r#"{{"type":"user","timestamp":"{ts}","sessionId":"{session_id}","cwd":"/tmp/test","message":{{"role":"user","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+        ),
+        "assistant" => format!(
+            r#"{{"type":"assistant","timestamp":"{ts}","sessionId":"{session_id}","cwd":"/tmp/test","message":{{"role":"assistant","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+        ),
+        _ => panic!("unknown msg_type: {msg_type}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hippo_core::storage::open_db;
+    use tempfile::TempDir;
+
+    fn open_test_db(dir: &TempDir) -> Connection {
+        open_db(&dir.path().join("test.db")).expect("open test db")
+    }
+
+    fn j(session_id: &str, ts: u64, kind: &str, text: &str) -> String {
+        make_test_jsonl_line(session_id, ts, kind, text)
+    }
+
+    #[test]
+    fn process_file_inserts_segments() {
+        let dir = TempDir::new().unwrap();
+        let conn = open_test_db(&dir);
+
+        // Write a session with one complete exchange.
+        let session_id = "test-sess-0001-0001-0001-0001-000000000001";
+        let jsonl_path = dir.path().join("test-session.jsonl");
+        let content = [
+            j(session_id, 0, "system", "init"),
+            j(session_id, 1, "user", "hello"),
+            j(session_id, 2, "assistant", "hi there"),
+        ]
+        .join("\n")
+            + "\n";
+        std::fs::write(&jsonl_path, &content).unwrap();
+
+        let mut state = FileState {
+            hour_window_start: 0,
+            ..Default::default()
+        };
+        let inserted = process_file(&jsonl_path, &mut state, &conn).unwrap();
+
+        assert!(inserted > 0, "expected at least one segment inserted");
+        assert_eq!(state.byte_offset, content.len() as u64);
+
+        // Re-process without new content — should be idempotent.
+        let re_inserted = process_file(&jsonl_path, &mut state, &conn).unwrap();
+        assert_eq!(
+            re_inserted, 0,
+            "re-process with no new content should insert 0"
+        );
+    }
+
+    #[test]
+    fn process_file_handles_truncation() {
+        let dir = TempDir::new().unwrap();
+        let conn = open_test_db(&dir);
+
+        let session_id = "test-sess-trunc-0001-0001-0001-000000000001";
+        let jsonl_path = dir.path().join("trunc-session.jsonl");
+        let content = j(session_id, 0, "user", "hi") + "\n";
+        std::fs::write(&jsonl_path, &content).unwrap();
+
+        let mut state = FileState {
+            byte_offset: 9999,
+            size_at_last_read: 9999,
+            hour_window_start: 0,
+            ..Default::default()
+        };
+        // Truncation detected: byte_offset > current_size.
+        let _ = process_file(&jsonl_path, &mut state, &conn);
+        assert_eq!(
+            state.byte_offset,
+            content.len() as u64,
+            "offset reset after truncation"
+        );
+    }
+
+    #[test]
+    fn save_and_load_offset_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let conn = open_test_db(&dir);
+
+        let path = PathBuf::from("/tmp/fake-session.jsonl");
+        let state = FileState {
+            byte_offset: 12345,
+            inode: 42,
+            device: 7,
+            size_at_last_read: 12000,
+            hour_window_start: 0,
+            ..Default::default()
+        };
+        save_offset(&conn, &path, &state).unwrap();
+
+        let loaded = load_offsets(&conn).unwrap();
+        let recovered = loaded.get(&path).expect("offset not found after save");
+        assert_eq!(recovered.byte_offset, 12345);
+        assert_eq!(recovered.inode, 42);
+        assert_eq!(recovered.device, 7);
+        assert_eq!(recovered.size_at_last_read, 12000);
+    }
+
+    #[test]
+    fn no_duplicate_segments_on_repeated_processing() {
+        let dir = TempDir::new().unwrap();
+        let conn = open_test_db(&dir);
+
+        let session_id = "test-sess-dedup-0001-0001-0001-000000000001";
+        let jsonl_path = dir.path().join("dedup-session.jsonl");
+
+        // Write initial content.
+        let line1 = j(session_id, 0, "user", "first") + "\n";
+        let line2 = j(session_id, 1, "assistant", "first reply") + "\n";
+        std::fs::write(&jsonl_path, &(line1.clone() + &line2)).unwrap();
+
+        let mut state = FileState {
+            hour_window_start: 0,
+            ..Default::default()
+        };
+
+        let first = process_file(&jsonl_path, &mut state, &conn).unwrap();
+
+        // Append more content.
+        let line3 = j(session_id, 400, "user", "second prompt") + "\n";
+        let line4 = j(session_id, 401, "assistant", "second reply") + "\n";
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&jsonl_path)
+                .unwrap();
+            write!(f, "{}{}", line3, line4).unwrap();
+        }
+        state.size_at_last_read = (line1.len() + line2.len()) as u64; // simulate previous state
+
+        let second = process_file(&jsonl_path, &mut state, &conn).unwrap();
+
+        // Verify no duplicates: count distinct (session_id, segment_index) pairs.
+        let count: usize = conn
+            .query_row(
+                "SELECT COUNT(*) FROM claude_sessions WHERE session_id = ?1",
+                [session_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap() as usize;
+
+        assert!(
+            first + second >= count,
+            "total inserts should cover all unique segments"
+        );
+
+        // Check uniqueness: no two rows have the same (session_id, segment_index).
+        let dup_count: usize = conn
+            .query_row(
+                "SELECT COUNT(*) FROM (
+                     SELECT session_id, segment_index, COUNT(*) AS n
+                     FROM claude_sessions
+                     WHERE session_id = ?1
+                     GROUP BY session_id, segment_index
+                     HAVING n > 1
+                 )",
+                [session_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap() as usize;
+        assert_eq!(dup_count, 0, "duplicate (session_id, segment_index) found");
+    }
+}

--- a/crates/hippo-daemon/src/watch_claude_sessions.rs
+++ b/crates/hippo-daemon/src/watch_claude_sessions.rs
@@ -200,6 +200,12 @@ fn process_file(path: &Path, state: &mut FileState, conn: &Connection) -> Result
         save_offset(conn, path, state).unwrap_or_else(|e| {
             warn!(path = %path.display(), %e, "watcher: failed to save offset");
         });
+        #[cfg(feature = "otel")]
+        if inserted > 0 {
+            crate::metrics::WATCHER_SEGMENTS_INGESTED.add(inserted as u64, &[]);
+            crate::metrics::WATCHER_PROCESS_DURATION_MS
+                .record(start.elapsed().as_secs_f64() * 1000.0, &[]);
+        }
     }
 
     Ok(inserted)
@@ -399,6 +405,8 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
                 // reparse on the next write catches anything missed); Closed means shutdown.
                 if let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) = tx.try_send(e) {
                     debug!("watcher: FSEvents channel full; event dropped");
+                    #[cfg(feature = "otel")]
+                    crate::metrics::WATCHER_EVENTS_DROPPED.add(1, &[]);
                 }
             }
         },

--- a/crates/hippo-daemon/src/watch_claude_sessions.rs
+++ b/crates/hippo-daemon/src/watch_claude_sessions.rs
@@ -123,7 +123,11 @@ fn save_offset(conn: &Connection, path: &Path, state: &FileState) -> Result<()> 
 }
 
 /// Process new content in a single file.  Returns the number of segments inserted.
-fn process_file(path: &Path, state: &mut FileState, conn: &Connection) -> Result<usize> {
+///
+/// Runs `ingest_session_file` in a `spawn_blocking` task so the async executor
+/// is never stalled by SQLite I/O.  `PER_FILE_TIMEOUT` is enforced as a hard
+/// upper bound; a timeout puts the file into cooldown just as a parsing error would.
+async fn process_file(path: &Path, state: &mut FileState, db_path: &Path) -> Result<usize> {
     if let Some(until) = state.cooldown_until {
         if Instant::now() < until {
             return Ok(0);
@@ -178,18 +182,58 @@ fn process_file(path: &Path, state: &mut FileState, conn: &Connection) -> Result
     }
 
     let start = Instant::now();
-    let (inserted, _skipped, errors) = ingest_session_file(conn, path);
+    let path_owned = path.to_path_buf();
+    let db_path_owned = db_path.to_path_buf();
+
+    let task = tokio::task::spawn_blocking(move || -> Result<(usize, usize, usize)> {
+        let conn = open_db(&db_path_owned)?;
+        let (inserted, skipped, errors) = ingest_session_file(&conn, &path_owned);
+        if errors == 0 {
+            let snap = FileState {
+                byte_offset: current_size,
+                inode: current_inode,
+                device: current_device,
+                size_at_last_read: current_size,
+                ..Default::default()
+            };
+            save_offset(&conn, &path_owned, &snap).unwrap_or_else(|e| {
+                warn!(path = %path_owned.display(), %e, "watcher: failed to save offset");
+            });
+        }
+        Ok((inserted, skipped, errors))
+    });
+
+    let join_result = match tokio::time::timeout(PER_FILE_TIMEOUT, task).await {
+        Err(_elapsed) => {
+            warn!(
+                path = %path.display(),
+                timeout_secs = PER_FILE_TIMEOUT.as_secs(),
+                "watcher: per-file processing timed out; entering cooldown"
+            );
+            state.cooldown_until = Some(Instant::now() + BACKOFF_DURATION);
+            return Ok(0);
+        }
+        Ok(r) => r,
+    };
+
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-    if elapsed_ms > PER_FILE_TIMEOUT.as_secs_f64() * 1000.0 {
-        warn!(
-            path = %path.display(),
-            elapsed_ms,
-            "watcher: per-file processing was slow"
-        );
-    }
 
     #[cfg(feature = "otel")]
     crate::metrics::WATCHER_PROCESS_DURATION_MS.record(elapsed_ms, &[]);
+
+    let (inserted, _skipped, errors) = match join_result {
+        Err(join_err) => {
+            warn!(path = %path.display(), %join_err, "watcher: spawn_blocking task panicked");
+            state.cooldown_until = Some(Instant::now() + BACKOFF_DURATION);
+            return Ok(0);
+        }
+        Ok(Err(e)) => {
+            warn!(path = %path.display(), %e, "watcher: failed to open DB in blocking task");
+            state.cooldown_until = Some(Instant::now() + BACKOFF_DURATION);
+            return Ok(0);
+        }
+        Ok(Ok(triple)) => triple,
+    };
 
     if errors > 0 {
         state.cooldown_until = Some(Instant::now() + BACKOFF_DURATION);
@@ -201,9 +245,6 @@ fn process_file(path: &Path, state: &mut FileState, conn: &Connection) -> Result
         state.byte_offset = current_size;
         state.size_at_last_read = current_size;
         state.watcher_hour_count += inserted;
-        save_offset(conn, path, state).unwrap_or_else(|e| {
-            warn!(path = %path.display(), %e, "watcher: failed to save offset");
-        });
         #[cfg(feature = "otel")]
         if inserted > 0 {
             crate::metrics::WATCHER_SEGMENTS_INGESTED.add(inserted as u64, &[]);
@@ -269,6 +310,12 @@ fn write_parity_row(
     // tailer_count = segments in DB not attributed to the watcher this window.
     // mismatch_count = same value: segments the watcher missed (tailer-only inserts).
     // If watcher_count somehow exceeds total (race), clamp to 0 via saturating_sub.
+    //
+    // Architectural note: in `both` mode the tmux-tailer path (`ingest_tail`) sends
+    // events over the daemon socket to the `events` table, not to `claude_sessions`.
+    // The watcher is the sole writer to `claude_sessions`, so in practice
+    // `total ≈ watcher_count` and `mismatch_count ≈ 0`.  The parity row is kept for
+    // future use if the tailer is extended to write `claude_sessions` rows directly.
     let tailer_count = total.saturating_sub(watcher_count);
     let mismatch_count = tailer_count;
 
@@ -388,7 +435,7 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
             hour_window_start: current_hour_start,
             ..Default::default()
         });
-        match process_file(path, state, &conn) {
+        match process_file(path, state, &db_path).await {
             Ok(n) if n > 0 => {
                 info!(path = %path.display(), inserted = n, "watcher: startup catch-up");
             }
@@ -474,9 +521,13 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
             }
 
             _ = parity_tick.tick() => {
-                let window_end = Utc::now().timestamp_millis();
                 for (path, state) in &mut states {
                     if matches!(mode, ClaudeSessionMode::Both) {
+                        // window_end is derived from window_start rather than Utc::now()
+                        // so that the recorded window boundaries are exact multiples of
+                        // PARITY_INTERVAL regardless of when the tokio interval fires.
+                        let window_end =
+                            state.hour_window_start + PARITY_INTERVAL.as_millis() as i64;
                         if state.watcher_hour_count > 0 || state.hour_window_start > 0 {
                             write_parity_row(
                                 &conn,
@@ -512,7 +563,7 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
                             ..Default::default()
                         }
                     });
-                    match process_file(&path, state, &conn) {
+                    match process_file(&path, state, &db_path).await {
                         Ok(0) => {}
                         Ok(n) => {
                             info!(path = %path.display(), inserted = n, "watcher: ingested segments");
@@ -573,10 +624,11 @@ mod tests {
         make_test_jsonl_line(session_id, ts, kind, text)
     }
 
-    #[test]
-    fn process_file_inserts_segments() {
+    #[tokio::test]
+    async fn process_file_inserts_segments() {
         let dir = TempDir::new().unwrap();
-        let conn = open_test_db(&dir);
+        let db_path = dir.path().join("test.db");
+        open_db(&db_path).expect("init test db");
 
         // Write a session with one complete exchange.
         let session_id = "test-sess-0001-0001-0001-0001-000000000001";
@@ -594,23 +646,28 @@ mod tests {
             hour_window_start: 0,
             ..Default::default()
         };
-        let inserted = process_file(&jsonl_path, &mut state, &conn).unwrap();
+        let inserted = process_file(&jsonl_path, &mut state, &db_path)
+            .await
+            .unwrap();
 
         assert!(inserted > 0, "expected at least one segment inserted");
         assert_eq!(state.byte_offset, content.len() as u64);
 
         // Re-process without new content — should be idempotent.
-        let re_inserted = process_file(&jsonl_path, &mut state, &conn).unwrap();
+        let re_inserted = process_file(&jsonl_path, &mut state, &db_path)
+            .await
+            .unwrap();
         assert_eq!(
             re_inserted, 0,
             "re-process with no new content should insert 0"
         );
     }
 
-    #[test]
-    fn process_file_handles_truncation() {
+    #[tokio::test]
+    async fn process_file_handles_truncation() {
         let dir = TempDir::new().unwrap();
-        let conn = open_test_db(&dir);
+        let db_path = dir.path().join("test.db");
+        open_db(&db_path).expect("init test db");
 
         let session_id = "test-sess-trunc-0001-0001-0001-000000000001";
         let jsonl_path = dir.path().join(format!("{session_id}.jsonl"));
@@ -624,7 +681,7 @@ mod tests {
             ..Default::default()
         };
         // Truncation detected: byte_offset > current_size.
-        let _ = process_file(&jsonl_path, &mut state, &conn);
+        let _ = process_file(&jsonl_path, &mut state, &db_path).await;
         assert_eq!(
             state.byte_offset,
             content.len() as u64,
@@ -656,10 +713,11 @@ mod tests {
         assert_eq!(recovered.size_at_last_read, 12000);
     }
 
-    #[test]
-    fn no_duplicate_segments_on_repeated_processing() {
+    #[tokio::test]
+    async fn no_duplicate_segments_on_repeated_processing() {
         let dir = TempDir::new().unwrap();
-        let conn = open_test_db(&dir);
+        let db_path = dir.path().join("test.db");
+        let conn = open_db(&db_path).expect("init test db");
 
         let session_id = "test-sess-dedup-0001-0001-0001-000000000001";
         let jsonl_path = dir.path().join(format!("{session_id}.jsonl"));
@@ -674,7 +732,9 @@ mod tests {
             ..Default::default()
         };
 
-        let first = process_file(&jsonl_path, &mut state, &conn).unwrap();
+        let first = process_file(&jsonl_path, &mut state, &db_path)
+            .await
+            .unwrap();
 
         // Append more content.
         let line3 = j(session_id, 400, "user", "second prompt") + "\n";
@@ -689,7 +749,9 @@ mod tests {
         }
         state.size_at_last_read = (line1.len() + line2.len()) as u64; // simulate previous state
 
-        let second = process_file(&jsonl_path, &mut state, &conn).unwrap();
+        let second = process_file(&jsonl_path, &mut state, &db_path)
+            .await
+            .unwrap();
 
         // Verify no duplicates: count distinct (session_id, segment_index) pairs.
         let count: usize = conn

--- a/crates/hippo-daemon/src/watch_claude_sessions.rs
+++ b/crates/hippo-daemon/src/watch_claude_sessions.rs
@@ -179,13 +179,17 @@ fn process_file(path: &Path, state: &mut FileState, conn: &Connection) -> Result
 
     let start = Instant::now();
     let (inserted, _skipped, errors) = ingest_session_file(conn, path);
-    if start.elapsed() > PER_FILE_TIMEOUT {
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    if elapsed_ms > PER_FILE_TIMEOUT.as_secs_f64() * 1000.0 {
         warn!(
             path = %path.display(),
-            elapsed_ms = start.elapsed().as_millis(),
+            elapsed_ms,
             "watcher: per-file processing was slow"
         );
     }
+
+    #[cfg(feature = "otel")]
+    crate::metrics::WATCHER_PROCESS_DURATION_MS.record(elapsed_ms, &[]);
 
     if errors > 0 {
         state.cooldown_until = Some(Instant::now() + BACKOFF_DURATION);
@@ -203,8 +207,6 @@ fn process_file(path: &Path, state: &mut FileState, conn: &Connection) -> Result
         #[cfg(feature = "otel")]
         if inserted > 0 {
             crate::metrics::WATCHER_SEGMENTS_INGESTED.add(inserted as u64, &[]);
-            crate::metrics::WATCHER_PROCESS_DURATION_MS
-                .record(start.elapsed().as_secs_f64() * 1000.0, &[]);
         }
     }
 

--- a/crates/hippo-daemon/src/watchdog.rs
+++ b/crates/hippo-daemon/src/watchdog.rs
@@ -221,7 +221,7 @@ pub fn run(config: &HippoConfig) -> Result<()> {
         {
             use opentelemetry::KeyValue;
             crate::metrics::WATCHDOG_ALARMS_FIRED
-                .add(1, &[KeyValue::new("invariant", v.invariant_id.clone())]);
+                .add(1, &[KeyValue::new("invariant_id", v.invariant_id.clone())]);
             crate::metrics::WATCHDOG_INVARIANT_VIOLATION
                 .add(1, &[KeyValue::new("source", v.source.clone())]);
         }

--- a/crates/hippo-daemon/src/watchdog.rs
+++ b/crates/hippo-daemon/src/watchdog.rs
@@ -218,13 +218,13 @@ pub fn run(config: &HippoConfig) -> Result<()> {
         );
 
         #[cfg(feature = "otel")]
-        crate::metrics::WATCHDOG_ALARMS_FIRED.add(
-            1,
-            &[opentelemetry::KeyValue::new(
-                "invariant",
-                v.invariant_id.clone(),
-            )],
-        );
+        {
+            use opentelemetry::KeyValue;
+            crate::metrics::WATCHDOG_ALARMS_FIRED
+                .add(1, &[KeyValue::new("invariant", v.invariant_id.clone())]);
+            crate::metrics::WATCHDOG_INVARIANT_VIOLATION
+                .add(1, &[KeyValue::new("source", v.source.clone())]);
+        }
 
         // Optional macOS notification (only on new alarm row).
         if config.watchdog.notify_macos {

--- a/crates/hippo-daemon/src/watchdog.rs
+++ b/crates/hippo-daemon/src/watchdog.rs
@@ -217,6 +217,15 @@ pub fn run(config: &HippoConfig) -> Result<()> {
             "watchdog: new alarm raised"
         );
 
+        #[cfg(feature = "otel")]
+        crate::metrics::WATCHDOG_ALARMS_FIRED.add(
+            1,
+            &[opentelemetry::KeyValue::new(
+                "invariant",
+                v.invariant_id.clone(),
+            )],
+        );
+
         // Optional macOS notification (only on new alarm row).
         if config.watchdog.notify_macos {
             let message = format!(
@@ -234,6 +243,9 @@ pub fn run(config: &HippoConfig) -> Result<()> {
         "UPDATE source_health SET last_success_ts = ?1 WHERE source = 'watchdog'",
         rusqlite::params![now_ms],
     )?;
+
+    #[cfg(feature = "otel")]
+    crate::metrics::WATCHDOG_RUN.add(1, &[]);
 
     Ok(())
 }

--- a/crates/hippo-daemon/tests/claude_session_watcher_integration.rs
+++ b/crates/hippo-daemon/tests/claude_session_watcher_integration.rs
@@ -1,0 +1,273 @@
+//! Integration tests for the Claude session FS watcher (T-5).
+//!
+//! Verifies that `process_file` + `ingest_session_file` correctly handle:
+//! - 100 synthetic JSONL lines across 3 files
+//! - Random append sequences
+//! - No segment loss, no double-count (unique session_id + segment_index)
+//!
+//! Note: session_id is derived from the **filename stem** by `SessionFile::from_path`,
+//! matching the real Claude layout where each session UUID is the filename.
+
+use std::io::Write;
+use std::path::Path;
+
+use hippo_core::storage::open_db;
+use hippo_daemon::claude_session::ingest_session_file;
+use hippo_daemon::watch_claude_sessions::make_test_jsonl_line;
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn open_test_db(dir: &TempDir) -> Connection {
+    open_db(&dir.path().join("test.db")).expect("open test db")
+}
+
+fn count_segments(conn: &Connection, session_id: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM claude_sessions WHERE session_id = ?1",
+        [session_id],
+        |row| row.get::<_, i64>(0),
+    )
+    .unwrap_or(0)
+}
+
+fn has_duplicates(conn: &Connection, session_id: &str) -> bool {
+    let dup: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM (
+                 SELECT session_id, segment_index, COUNT(*) AS n
+                 FROM claude_sessions
+                 WHERE session_id = ?1
+                 GROUP BY session_id, segment_index
+                 HAVING n > 1
+             )",
+            [session_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0);
+    dup > 0
+}
+
+/// Write a complete synthetic session JSONL to `path`. Returns total line count.
+///
+/// The path stem must equal `session_id` — `SessionFile::from_path` derives
+/// `session_id` from the filename, mirroring real Claude UUID filenames.
+fn write_synthetic_session(path: &Path, session_id: &str, exchange_count: u64) -> usize {
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)
+        .unwrap();
+
+    writeln!(
+        f,
+        "{}",
+        make_test_jsonl_line(session_id, 0, "system", "init")
+    )
+    .unwrap();
+    let mut n = 1usize;
+    for i in 0..exchange_count {
+        writeln!(
+            f,
+            "{}",
+            make_test_jsonl_line(session_id, i * 10 + 1, "user", &format!("prompt {i}"))
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            make_test_jsonl_line(session_id, i * 10 + 2, "assistant", &format!("reply {i}"))
+        )
+        .unwrap();
+        n += 2;
+    }
+    n
+}
+
+fn append_exchanges(path: &Path, session_id: &str, start_ts: u64, count: u64) {
+    let mut f = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+    for i in 0..count {
+        writeln!(
+            f,
+            "{}",
+            make_test_jsonl_line(
+                session_id,
+                start_ts + i * 10 + 1,
+                "user",
+                &format!("late {i}")
+            )
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            make_test_jsonl_line(
+                session_id,
+                start_ts + i * 10 + 2,
+                "assistant",
+                &format!("late reply {i}")
+            )
+        )
+        .unwrap();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// 100+ JSONL lines across 3 session files — no loss, no duplicates.
+#[test]
+fn hundred_lines_across_three_files_no_loss_no_duplicates() {
+    let dir = TempDir::new().unwrap();
+    let conn = open_test_db(&dir);
+
+    // Each session_id IS the filename stem — mirrors the real Claude UUID layout.
+    let sessions = [
+        ("sess-aaa-0001-0001-0001-0001-000000000001", 17u64),
+        ("sess-bbb-0002-0002-0002-0002-000000000002", 16u64),
+        ("sess-ccc-0003-0003-0003-0003-000000000003", 17u64),
+    ];
+
+    for (session_id, exchanges) in &sessions {
+        let path = dir.path().join(format!("{session_id}.jsonl"));
+        write_synthetic_session(&path, session_id, *exchanges);
+        let (inserted, _skipped, errors) = ingest_session_file(&conn, &path);
+        assert_eq!(errors, 0, "session {session_id}: unexpected errors");
+        assert!(
+            inserted > 0,
+            "session {session_id}: expected at least one segment"
+        );
+    }
+
+    for (session_id, _) in &sessions {
+        assert!(
+            !has_duplicates(&conn, session_id),
+            "duplicates for {session_id}"
+        );
+        assert!(
+            count_segments(&conn, session_id) > 0,
+            "no segments for {session_id}"
+        );
+    }
+}
+
+/// Append then reprocess: new segments added, no duplicates.
+#[test]
+fn append_and_reprocess_no_duplicates() {
+    let dir = TempDir::new().unwrap();
+    let conn = open_test_db(&dir);
+
+    let session_id = "sess-app-0001-0001-0001-0001-000000000001";
+    // Filename stem = session_id so SessionFile::from_path derives the right value.
+    let path = dir.path().join(format!("{session_id}.jsonl"));
+
+    write_synthetic_session(&path, session_id, 10);
+    let (first, _, _) = ingest_session_file(&conn, &path);
+
+    // Append 10 more with a gap large enough to force a new segment boundary
+    // (ts_base = 1000s > SEGMENT_GAP_MS = 300s).
+    append_exchanges(&path, session_id, 1000, 10);
+    let (second, _, _) = ingest_session_file(&conn, &path);
+
+    assert!(
+        !has_duplicates(&conn, session_id),
+        "duplicates after append + reprocess"
+    );
+
+    let total_in_db = count_segments(&conn, session_id);
+    assert!(
+        first as i64 + second as i64 >= total_in_db,
+        "total inserts ({}) < segments in DB ({})",
+        first + second,
+        total_in_db
+    );
+}
+
+/// Two sessions in separate files: both stored, no cross-contamination.
+///
+/// Real Claude creates a new UUID file per session — it never reuses a filename
+/// for a different session. This verifies that two concurrent files are ingested
+/// independently without duplicates.
+#[test]
+fn two_sessions_independent_no_duplicates() {
+    let dir = TempDir::new().unwrap();
+    let conn = open_test_db(&dir);
+
+    let sid1 = "sess-trunc-old-0001-0001-0001-000000000001";
+    let sid2 = "sess-trunc-new-0001-0001-0001-000000000001";
+
+    let path1 = dir.path().join(format!("{sid1}.jsonl"));
+    let path2 = dir.path().join(format!("{sid2}.jsonl"));
+
+    write_synthetic_session(&path1, sid1, 5);
+    ingest_session_file(&conn, &path1);
+
+    write_synthetic_session(&path2, sid2, 5);
+    ingest_session_file(&conn, &path2);
+
+    assert!(!has_duplicates(&conn, sid1));
+    assert!(!has_duplicates(&conn, sid2));
+    assert!(count_segments(&conn, sid1) > 0, "first session missing");
+    assert!(count_segments(&conn, sid2) > 0, "second session missing");
+}
+
+/// Repeated reprocessing of the same file with no new content is a no-op.
+#[test]
+fn idempotent_reprocessing() {
+    let dir = TempDir::new().unwrap();
+    let conn = open_test_db(&dir);
+
+    let session_id = "sess-idem-0001-0001-0001-0001-000000000001";
+    let path = dir.path().join(format!("{session_id}.jsonl"));
+    write_synthetic_session(&path, session_id, 8);
+
+    let (first, _, _) = ingest_session_file(&conn, &path);
+    let (second, skipped, _) = ingest_session_file(&conn, &path);
+    let (third, _, _) = ingest_session_file(&conn, &path);
+
+    assert_eq!(second, 0, "second pass should insert 0");
+    let _ = skipped; // may be > 0 or 0 depending on segment boundaries
+    assert_eq!(third, 0, "third pass should also insert 0");
+    assert!(!has_duplicates(&conn, session_id));
+    assert_eq!(count_segments(&conn, session_id), first as i64);
+}
+
+// ---------------------------------------------------------------------------
+// Proptest: random mutation sequences
+// ---------------------------------------------------------------------------
+
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn no_duplicates_under_random_mutations(
+        exchanges_initial in 1u64..=20u64,
+        appends in proptest::collection::vec(1u64..=10u64, 0..5),
+    ) {
+        let dir = TempDir::new().unwrap();
+        let conn = open_test_db(&dir);
+
+        let session_id = "sess-prop-0001-0001-0001-0001-000000000001";
+        let path = dir.path().join(format!("{session_id}.jsonl"));
+
+        write_synthetic_session(&path, session_id, exchanges_initial);
+        ingest_session_file(&conn, &path);
+
+        // Use a 1000s gap between batches to guarantee new segment boundaries
+        // (SEGMENT_GAP_MS = 300s = 300_000ms).
+        let mut ts_base = 1000u64;
+        for extra in appends {
+            append_exchanges(&path, session_id, ts_base, extra);
+            ts_base += 1000 + extra * 10;
+            ingest_session_file(&conn, &path);
+        }
+
+        prop_assert!(!has_duplicates(&conn, session_id));
+        prop_assert!(count_segments(&conn, session_id) > 0);
+    }
+}

--- a/crates/hippo-daemon/tests/claude_session_watcher_integration.rs
+++ b/crates/hippo-daemon/tests/claude_session_watcher_integration.rs
@@ -31,7 +31,7 @@ fn count_segments(conn: &Connection, session_id: &str) -> i64 {
         [session_id],
         |row| row.get::<_, i64>(0),
     )
-    .unwrap_or(0)
+    .expect("count_segments query failed")
 }
 
 fn has_duplicates(conn: &Connection, session_id: &str) -> bool {
@@ -47,7 +47,7 @@ fn has_duplicates(conn: &Connection, session_id: &str) -> bool {
             [session_id],
             |row| row.get::<_, i64>(0),
         )
-        .unwrap_or(0);
+        .expect("has_duplicates query failed");
     dup > 0
 }
 

--- a/docs/capture-reliability/07-roadmap.md
+++ b/docs/capture-reliability/07-roadmap.md
@@ -176,7 +176,7 @@ If that chain exits 0, the watchdog fired at least one alarm within one poll int
 
 ## T-5 · P2.1 — Claude session FS watcher (dual-run mode)
 
-- **Status:** open
+- **Status:** review
 - **Phase:** P2
 - **Depends on:** (P0 — all done). Independent of T-1..T-4; can run in parallel with P1.
 - **Branch:** `feat/p2.1-claude-session-watcher`

--- a/launchd/com.hippo.claude-session-watcher.plist
+++ b/launchd/com.hippo.claude-session-watcher.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>Label</key>
+<string>com.hippo.claude-session-watcher</string>
+
+<key>ProgramArguments</key>
+<array>
+<string>__HIPPO_BIN__</string>
+<string>claude-session-watch</string>
+</array>
+
+<!-- Keep alive: restart automatically if it exits or is killed -->
+<key>KeepAlive</key>
+<true/>
+
+<!-- Start immediately on bootstrap -->
+<key>RunAtLoad</key>
+<true/>
+
+<key>StandardOutPath</key>
+<string>__DATA_DIR__/claude-session-watcher.log</string>
+
+<key>StandardErrorPath</key>
+<string>__DATA_DIR__/claude-session-watcher.log</string>
+
+<key>EnvironmentVariables</key>
+<dict>
+<key>HOME</key>
+<string>__HOME__</string>
+<key>PATH</key>
+<string>__PATH__</string>
+</dict>
+
+<!-- Throttle restarts: if the process exits within 10 s, wait before relaunching -->
+<key>ThrottleInterval</key>
+<integer>10</integer>
+</dict>
+</plist>

--- a/shell/claude-session-hook.sh
+++ b/shell/claude-session-hook.sh
@@ -60,6 +60,29 @@ fi
 
 log "hippo_bin=$HIPPO_BIN"
 
+# Determine capture mode from config.
+# Falls back to "tmux-tailer" if hippo can't be queried (safe default).
+CAPTURE_MODE=$("$HIPPO_BIN" capture-mode 2>/dev/null || echo "tmux-tailer")
+log "capture_mode=$CAPTURE_MODE"
+
+# In watcher/both mode, write a session marker so the FS watcher can correlate
+# the JSONL file with the session that just started.
+if [ "$CAPTURE_MODE" = "watcher" ] || [ "$CAPTURE_MODE" = "both" ]; then
+    MARKER_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/hippo/session-markers"
+    mkdir -p "$MARKER_DIR" 2>/dev/null || true
+    SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null)
+    if [ -n "$SESSION_ID" ]; then
+        echo "$TRANSCRIPT_PATH" > "$MARKER_DIR/${SESSION_ID}" 2>/dev/null || true
+        log "wrote session marker for session_id=$SESSION_ID"
+    fi
+fi
+
+# In watcher-only mode, skip tmux spawn — the FS watcher handles ingestion.
+if [ "$CAPTURE_MODE" = "watcher" ]; then
+    log "watcher mode: skipping tmux spawn"
+    exit 0
+fi
+
 # Resolve Claude's PID. The hook runs as a direct child of Claude Code,
 # so $PPID is the Claude process PID.
 CLAUDE_PID="$PPID"

--- a/shell/claude-session-hook.sh
+++ b/shell/claude-session-hook.sh
@@ -65,18 +65,6 @@ log "hippo_bin=$HIPPO_BIN"
 CAPTURE_MODE=$("$HIPPO_BIN" capture-mode 2>/dev/null || echo "tmux-tailer")
 log "capture_mode=$CAPTURE_MODE"
 
-# In watcher/both mode, write a session marker so the FS watcher can correlate
-# the JSONL file with the session that just started.
-if [ "$CAPTURE_MODE" = "watcher" ] || [ "$CAPTURE_MODE" = "both" ]; then
-    MARKER_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/hippo/session-markers"
-    mkdir -p "$MARKER_DIR" 2>/dev/null || true
-    SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null)
-    if [ -n "$SESSION_ID" ]; then
-        echo "$TRANSCRIPT_PATH" > "$MARKER_DIR/${SESSION_ID}" 2>/dev/null || true
-        log "wrote session marker for session_id=$SESSION_ID"
-    fi
-fi
-
 # In watcher-only mode, skip tmux spawn — the FS watcher handles ingestion.
 if [ "$CAPTURE_MODE" = "watcher" ]; then
     log "watcher mode: skipping tmux spawn"


### PR DESCRIPTION
This pull request introduces schema version 10, adding support for a new Claude session ingestion mode using a file system watcher, along with related configuration, migration, and testing updates. It also adds new dependencies and commands to facilitate this functionality. The most important changes are summarized below.

**Database Schema and Migration:**
* Added two new tables, `claude_session_offsets` (for tracking JSONL file offsets for the FS watcher) and `claude_session_parity` (for parity validation between ingestion modes); incremented schema version to 10 and updated migration logic and tests accordingly. [[1]](diffhunk://#diff-7d201483d471e01cb0c5dac5760f8ea9883bee40d10b11f94030087ef8e8668eL497-R522) [[2]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26R422-R450) [[3]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26L16-R16) [[4]](diffhunk://#diff-764b32fb47d289d04ddae72a940dbd8347c572f5698220d28327610950124a7cL15-R24) [[5]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26L1651-R1680) [[6]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26L1721-R1750) [[7]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26L1807-R1836) [[8]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26L1909-R1938) [[9]](diffhunk://#diff-ece0da619e42f9d4f1b4856968a540854f5d90eb877aa9b3346a3a6bd426ba26L1932-R1967) [[10]](diffhunk://#diff-a30671796cbb18ed9d99ef6334658bd857eefcd000e2ff148b924435818e72c4L23-R24) [[11]](diffhunk://#diff-29cdb8a512e521d8fc3eb14b488b525c9250c52fbb97be947646ca48adca4af2L23-R23) [[12]](diffhunk://#diff-29cdb8a512e521d8fc3eb14b488b525c9250c52fbb97be947646ca48adca4af2L172-R172) [[13]](diffhunk://#diff-74901fb1a61473b061f1dcb8508b3040f54cd3c6ce0dcb5525aa1d4a0ec989d2L30-R30) [[14]](diffhunk://#diff-74901fb1a61473b061f1dcb8508b3040f54cd3c6ce0dcb5525aa1d4a0ec989d2L142-R142)

**Claude Session Ingestion and Configuration:**
* Introduced a new `[capture]` configuration section and `ClaudeSessionMode` enum with options for `tmux-tailer`, `watcher`, and `both`, allowing selection of ingestion strategy. [[1]](diffhunk://#diff-37089099ae58cc485ef6ee16c2cc5105c4d314d164e1303a79b10c72eb3531e2R157-R170) [[2]](diffhunk://#diff-a62f769e06cee8eecfc5f5a153da795f3b32c615ec9d52f7df7d21f6872e1107R25-R26) [[3]](diffhunk://#diff-a62f769e06cee8eecfc5f5a153da795f3b32c615ec9d52f7df7d21f6872e1107R538-R566)
* Added new CLI commands `ClaudeSessionWatch` and `CaptureMode` for controlling and inspecting session ingestion mode.

**Daemon and Main Application Updates:**
* Added the `watch_claude_sessions` module and integrated it into the daemon and main application logic; updated service management to handle the new watcher process. [[1]](diffhunk://#diff-a2d97b37d78fefbfe0d4af1e61bc49ababa2ff88deb3c1637de9c530a449ecd3R17) [[2]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dL4-R4) [[3]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dR14) [[4]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dR245-R246) [[5]](diffhunk://#diff-5eb35f94b3b922ac62b7425df37721294049f9c168dc15cc49bf62c7ae20272dR281-R295)

**Claude Session Logic:**
* Added `ingest_session_file` function for the watcher to ingest session files directly via its own connection, improving modularity and error handling.
* Fixed an off-by-one error in `segment_index` assignment in `extract_segments`.

**Dependencies:**
* Added `notify`, `walkdir`, and `proptest` as dependencies to support file system watching and testing. [[1]](diffhunk://#diff-9122a038cfe19798e2d9bebe905d05a71c80691e85a12e45aaf741ec6dfe0361R39-R40) [[2]](diffhunk://#diff-9122a038cfe19798e2d9bebe905d05a71c80691e85a12e45aaf741ec6dfe0361R57)