### PR TITLE
feat(capture): T-7 — flip claude_session_mode default to watcher

### DIFF
--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -157,16 +157,20 @@ watched_repos = []             # e.g., ["stevencarpenter/hippo"]
 [capture]
 # Controls how Claude session JSONL files are ingested.
 #
-# "tmux-tailer" (default): the SessionStart hook spawns one tmux window per
-#   session that tails the JSONL until Claude exits.
+# "watcher" (default): a persistent FSEvents service (com.hippo.claude-session-watcher)
+#   watches ~/.claude/projects/**/*.jsonl continuously. No tmux dependency.
+#   Validated 2026-04-25 against 7 days of dual-run data: 99.36% capture vs the
+#   tailer's 12.9% — see docs/capture-reliability/m3-decision.md.
 #
-# "watcher": a persistent FSEvents daemon (com.hippo.claude-session-watcher)
-#   watches ~/.claude/projects/**/*.jsonl continuously. No tmux windows.
-#   Flip to this default in T-7 after 48 h of parity validation.
+# "tmux-tailer" (legacy): the SessionStart hook spawns one tmux window per
+#   session that tails the JSONL until Claude exits. Retained as a one-command
+#   rollback during the watcher rollout. Slated for removal in T-8.
 #
-# "both": runs the tmux tailer AND the watcher concurrently. INSERT OR IGNORE
-#   deduplicates at the DB layer. Use during M3 parity gate.
-claude_session_mode = "tmux-tailer"
+# "both": runs both concurrently. INSERT OR IGNORE deduplicates at the DB layer.
+#   Useful for short-term re-validation if the watcher is suspected of regressing.
+#
+# Rollback: `hippo config set capture.claude_session_mode tmux-tailer && hippo daemon restart`
+claude_session_mode = "watcher"
 
 [watchdog]
 # Capture-reliability watchdog — enabled by default since T-2 (launchd plist ships).

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -166,8 +166,12 @@ watched_repos = []             # e.g., ["stevencarpenter/hippo"]
 #   session that tails the JSONL until Claude exits. Retained as a one-command
 #   rollback during the watcher rollout. Slated for removal in T-8.
 #
-# "both": runs both concurrently. INSERT OR IGNORE deduplicates at the DB layer.
-#   Useful for short-term re-validation if the watcher is suspected of regressing.
+# "both": runs both concurrently. The two paths write to disjoint tables — the
+#   tmux tailer sends per-line tool-call events to `events`, the watcher writes
+#   conversation segments to `claude_sessions` — so there's no DB-level overlap
+#   to dedupe (this is also why the `claude_session_parity` table can never
+#   surface watcher-vs-tailer divergence; see docs/capture-reliability/m3-decision.md).
+#   Useful for short-term side-by-side comparison if the watcher is suspected of regressing.
 #
 # Rollback: `hippo config set capture.claude_session_mode tmux-tailer && hippo daemon restart`
 claude_session_mode = "watcher"

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -542,8 +542,9 @@ pub fn socket_path(data_dir: &Path) -> PathBuf {
 #[serde(rename_all = "kebab-case")]
 pub enum ClaudeSessionMode {
     /// FSEvents watcher process watches all JSONL files continuously.
-    /// Validated 2026-04-25 against 7 days of dual-run data (99.36% capture
-    /// vs the tailer's 12.9%) and made the default in T-7.
+    /// Made the default in T-7 (PR #88) on 2026-04-25 after empirical
+    /// validation against 7 days of dual-run data — see
+    /// `docs/capture-reliability/m3-decision.md` for the canonical numbers.
     #[default]
     Watcher,
     /// Legacy tmux-based tailer (one window per session). Retained as a

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -541,12 +541,17 @@ pub fn socket_path(data_dir: &Path) -> PathBuf {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ClaudeSessionMode {
-    /// Legacy tmux-based tailer (one window per session). Default until T-7.
-    #[default]
-    TmuxTailer,
     /// FSEvents watcher process watches all JSONL files continuously.
+    /// Validated 2026-04-25 against 7 days of dual-run data (99.36% capture
+    /// vs the tailer's 12.9%) and made the default in T-7.
+    #[default]
     Watcher,
-    /// Both: tailer + watcher run concurrently for parity validation (M3 gate).
+    /// Legacy tmux-based tailer (one window per session). Retained as a
+    /// one-command rollback during the watcher rollout. Slated for removal
+    /// in T-8.
+    TmuxTailer,
+    /// Both: tailer + watcher run concurrently. Useful for short-term
+    /// re-validation if the watcher is suspected of regressing.
     Both,
 }
 
@@ -559,7 +564,7 @@ pub struct CaptureConfig {
 impl Default for CaptureConfig {
     fn default() -> Self {
         Self {
-            claude_session_mode: ClaudeSessionMode::TmuxTailer,
+            claude_session_mode: ClaudeSessionMode::Watcher,
         }
     }
 }

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::Utc;
-use hippo_core::config::{ENV_ALLOWLIST, HippoConfig};
+use hippo_core::config::{ClaudeSessionMode, ENV_ALLOWLIST, HippoConfig};
 use hippo_core::events::{CapturedOutput, EventEnvelope, EventPayload, GitState, ShellEvent};
 use hippo_core::protocol::{DaemonRequest, DaemonResponse};
 use hippo_core::redaction::RedactionEngine;
@@ -931,6 +931,9 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
 
     // Check Claude session hook
     check_claude_session_hook(config);
+
+    // Warn if still on the legacy tmux tailer (T-7 made watcher the default)
+    check_capture_mode(config);
 
     // Check Firefox extension build + Native Messaging manifest
     check_firefox_extension();
@@ -2284,6 +2287,33 @@ pub fn check_schema_version(
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Warn if `capture.claude_session_mode` is still the legacy `tmux-tailer`.
+/// The watcher has been the default since T-7 (2026-04-25) and is documented
+/// to be substantially more reliable; the tailer path is slated for removal
+/// in T-8. `[OK]` for `watcher` or `both`; `[WW]` (not `[!!]`) for the legacy
+/// setting so existing users aren't punished mid-rollout.
+fn check_capture_mode(config: &HippoConfig) {
+    match config.capture.claude_session_mode {
+        ClaudeSessionMode::Watcher => {
+            println!("[OK] Capture mode: watcher");
+        }
+        ClaudeSessionMode::Both => {
+            println!("[OK] Capture mode: both (watcher + tmux tailer)");
+        }
+        ClaudeSessionMode::TmuxTailer => {
+            println!("[WW] Capture mode: tmux-tailer (legacy)");
+            println!(
+                "     The watcher path is the documented default since T-7 and is significantly"
+            );
+            println!("     more reliable. The tmux tailer is slated for removal in T-8.");
+            println!(
+                "     Switch:  hippo config set capture.claude_session_mode watcher && hippo daemon restart"
+            );
+            println!("     DOC:     docs/capture-reliability/06-claude-session-watcher.md");
+        }
+    }
+}
+
 fn check_claude_session_hook(config: &HippoConfig) {
     let settings_path = dirs::home_dir()
         .map(|h| h.join(".claude/settings.json"))
@@ -3038,5 +3068,29 @@ replacement = "***"
         let fail = check_github_source_with(&config, || true);
         // At least the empty-repos fail (maybe also plist-not-installed in CI).
         assert!(fail >= 1);
+    }
+
+    #[test]
+    fn test_default_capture_mode_is_watcher() {
+        // T-7: defaulting to the FS watcher must survive serde round-trips
+        // and the explicit Default impl on CaptureConfig.
+        let cfg = HippoConfig::default();
+        assert_eq!(cfg.capture.claude_session_mode, ClaudeSessionMode::Watcher);
+    }
+
+    #[test]
+    fn test_check_capture_mode_runs_for_every_variant() {
+        // The check is print-only (no return), so this is a smoke test:
+        // verify each enum variant flows through without panicking. The
+        // [WW] line for TmuxTailer is the user-facing T-7 deliverable.
+        for mode in [
+            ClaudeSessionMode::Watcher,
+            ClaudeSessionMode::TmuxTailer,
+            ClaudeSessionMode::Both,
+        ] {
+            let mut cfg = HippoConfig::default();
+            cfg.capture.claude_session_mode = mode;
+            check_capture_mode(&cfg);
+        }
     }
 }

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -2306,10 +2306,12 @@ fn check_capture_mode(config: &HippoConfig) {
                 "     The watcher path is the documented default since T-7 and is significantly"
             );
             println!("     more reliable. The tmux tailer is slated for removal in T-8.");
-            println!(
-                "     Switch:  hippo config set capture.claude_session_mode watcher && hippo daemon restart"
-            );
-            println!("     DOC:     docs/capture-reliability/06-claude-session-watcher.md");
+            println!("     Switch (run all three — `daemon install --force` is required to");
+            println!("     bootstrap the watcher LaunchAgent on hosts that pre-date T-5):");
+            println!("       hippo daemon install --force");
+            println!("       hippo config set capture.claude_session_mode watcher");
+            println!("       hippo daemon restart");
+            println!("     DOC: docs/capture-reliability/06-claude-session-watcher.md");
         }
     }
 }

--- a/docs/capture-reliability/07-roadmap.md
+++ b/docs/capture-reliability/07-roadmap.md
@@ -1,6 +1,6 @@
 # Capture-Reliability Overhaul: Task Queue
 
-**Status (2026-04-25):** P0, P1, P2 shipped. Three small P3 tasks remain (T-7, T-8, T-9), all currently blocked on a decision about M3 (see [P2 Phase Gate](#p2-phase-gate--milestone-m3)).
+**Status (2026-04-26):** P0, P1, P2 shipped. T-7 shipped in PR #88. Two small P3 tasks remain (T-8, T-9); the M3 decision is resolved (see [m3-decision.md](m3-decision.md)).
 
 **Workflow note:** This was originally framed as a Ralph Loop autonomous queue (T-1 through T-6 were eligible to be picked up by a loop). In practice, every task shipped via standard PR review by hand — the Ralph Loop framing is now retired. The doc remains useful as an ordered tracker of what's done, what's left, and what gates each step. Status fields and DoD checkboxes below reflect the actual state of `main`, not aspirational planning.
 

--- a/docs/capture-reliability/07-roadmap.md
+++ b/docs/capture-reliability/07-roadmap.md
@@ -1,20 +1,16 @@
-# Capture-Reliability Overhaul: Ralph Loop Task Queue
+# Capture-Reliability Overhaul: Task Queue
 
-**TL;DR:** P0 shipped in v0.16.0. Everything below is an ordered, self-contained task queue. A Ralph Loop picks the lowest-numbered task whose `Status:` is `open` and whose `Depends on:` are all `done`, implements it on the named branch, runs the `Success criterion`, opens the PR, and waits for `review` → `done`. Update `Status:` in this file *in the same PR* that finishes the task — this doc is the source of truth, not GitHub.
+**Status (2026-04-25):** P0, P1, P2 shipped. Three small P3 tasks remain (T-7, T-8, T-9), all currently blocked on a decision about M3 (see [P2 Phase Gate](#p2-phase-gate--milestone-m3)).
+
+**Workflow note:** This was originally framed as a Ralph Loop autonomous queue (T-1 through T-6 were eligible to be picked up by a loop). In practice, every task shipped via standard PR review by hand — the Ralph Loop framing is now retired. The doc remains useful as an ordered tracker of what's done, what's left, and what gates each step. Status fields and DoD checkboxes below reflect the actual state of `main`, not aspirational planning.
 
 ---
 
-## Ralph Loop Execution Contract
+## How to use this doc
 
-Violating any invariant below breaks autonomous execution:
-
-1. **Pick-up rule.** Take the lowest-numbered task with `Status: open` whose `Depends on` is empty or all `done`. Never claim a task marked `review` — a human is mid-ack.
-2. **Branching.** Check out the task's `Branch:` in an isolated worktree. One branch per task; never share.
-3. **DoD gate.** Every `[ ]` under `DoD:` must be checked off before opening the PR. The `Success criterion:` is the machine-checkable subset — it MUST exit 0 locally before `git push`.
-4. **Consensus review.** Tasks marked `Consensus review: yes` require human ack. On push, flip `Status: review` and wait. Do not merge on your own.
-5. **Status update.** The PR that finishes the task must include an edit to this file flipping the task's `Status:` to `done` (or `review` on push, then `done` at merge). No silent drift.
-6. **Scope creep.** If a task grows beyond its `Files:` list, STOP. Open a doc-only PR splitting the task (`T-N` → `T-Na` + `T-Nb`) before touching implementation.
-7. **Regression.** If `Success criterion:` fails on `main` after merge, revert the PR, set `Status: open`, add a regression test *first*, then retry.
+1. **Reading it.** Tasks below are in dependency order. Each has `Status:` (`open` / `done` / `blocked`), the PR that shipped it (if any), the files it touched, and a DoD checklist. Phase gates between sections describe what must hold before the next phase can start.
+2. **Editing it.** When you ship a task, flip its `Status:` and check off completed DoD items in the same PR. This file is the source of truth for "what's left" — keep it honest. If a task grows beyond its `Files:` list, split it (`T-N` → `T-Na` + `T-Nb`) rather than letting scope drift silently.
+3. **Phase gates.** A blocked task only unblocks when its gate predicate is genuinely true. Don't flip `blocked` → `open` because the predicate is "close enough" — fix the gate or document why it's not load-bearing.
 
 ---
 
@@ -176,31 +172,31 @@ If that chain exits 0, the watchdog fired at least one alarm within one poll int
 
 ## T-5 · P2.1 — Claude session FS watcher (dual-run mode)
 
-- **Status:** review
+- **Status:** done — shipped via [PR #86](https://github.com/stevencarpenter/hippo/pull/86), schema v10
 - **Phase:** P2
-- **Depends on:** (P0 — all done). Independent of T-1..T-4; can run in parallel with P1.
-- **Branch:** `feat/p2.1-claude-session-watcher`
+- **Depends on:** (P0 — all done). Independent of T-1..T-4; ran in parallel with P1.
+- **Branch:** `feat/p2.1-claude-session-watcher` (merged to `main` as `f441066`)
 - **Files:**
   - `crates/hippo-daemon/src/watch_claude_sessions.rs` (new)
-  - `crates/hippo-core/src/schema.sql` (next migration: `claude_session_offsets` + `claude_session_parity` tables)
-  - `crates/hippo-core/src/storage.rs` (bump `EXPECTED_VERSION`; coordinate with T-1's v9)
+  - `crates/hippo-core/src/schema.sql` (v9→v10: `claude_session_offsets` + `claude_session_parity` tables)
+  - `crates/hippo-core/src/storage.rs` (bumped `EXPECTED_VERSION` to 10)
   - `launchd/com.hippo.claude-session-watcher.plist` (new; `KeepAlive=true`, `RunAtLoad=true`)
-  - `crates/hippo-daemon/src/main.rs` (register subcommand + install integration)
-  - `config/config.default.toml` (`[capture] claude_session_mode = "tmux-tailer"` default; also `"watcher"` or `"both"`)
-  - `shell/claude-session-hook.sh` (branch on `claude_session_mode`; tmux path preserved)
-  - `Cargo.toml` (add `notify` crate)
-  - `brain/src/hippo_brain/schema_version.py` (bump to coordinated version)
-  - `crates/hippo-daemon/tests/claude_session_watcher_integration.rs` (new)
+  - `crates/hippo-daemon/src/main.rs` (subcommand + install integration)
+  - `config/config.default.toml` (`[capture] claude_session_mode = "tmux-tailer"` default)
+  - `shell/claude-session-hook.sh` (branches on `claude_session_mode` via `hippo capture-mode`)
+  - `Cargo.toml` (added `notify` crate)
+  - `brain/src/hippo_brain/schema_version.py` (bumped to 10)
+  - `crates/hippo-daemon/tests/claude_session_watcher_integration.rs` (new; 5 integration tests)
 - **DoD:**
-  - [ ] `notify` crate FSEvents subscription on `~/.claude/projects/**/*.jsonl`; startup scan + continuous events.
-  - [ ] `claude_session_offsets` tracks `path`/`session_id`/`byte_offset`/`inode`/`device`/`size_at_last_read` per file.
-  - [ ] Inode/device change OR size-regression triggers offset reset; partial-line safety (only advance past `\n`-terminated bytes); 30s per-file timeout + 60s backoff.
-  - [ ] `claude_session_parity` row inserted hourly during `claude_session_mode = "both"`: one row per path with `tailer_count`, `watcher_count`, `mismatch_count`, `window_start`, `window_end`.
-  - [ ] `source_health WHERE source='claude-session-watcher'` heartbeat upserted every 30s regardless of file activity.
-  - [ ] Parity test: write 100 synthetic Claude JSONL lines across 3 files with random append/truncate/rename; assert no loss + no double-count via `envelope_id` uniqueness.
-  - [ ] Property test (proptest) covers random mutation sequences.
-  - [ ] `shell/claude-session-hook.sh` branches on `claude_session_mode`; `tmux-tailer` path unchanged; `watcher` path writes marker only; `both` does both.
-  - [ ] NFS/iCloud detection via `statfs` `f_fstypename` at startup; log warning if remote FS.
+  - [x] `notify` crate FSEvents subscription on `~/.claude/projects/**/*.jsonl`; startup scan + continuous events.
+  - [x] `claude_session_offsets` tracks `path`/`session_id`/`byte_offset`/`inode`/`device`/`size_at_last_read` per file.
+  - [x] Inode/device change OR size-regression triggers offset reset; partial-line safety (only advance past `\n`-terminated bytes); 30s per-file timeout + 60s backoff.
+  - [x] `claude_session_parity` row inserted hourly during `claude_session_mode = "both"` — **but see M3 caveat below: `mismatch_count` is structurally always 0 because the tmux tailer writes to `events`, not `claude_sessions`. The parity table records watcher activity, not divergence.**
+  - [x] `source_health WHERE source='claude-session-watcher'` heartbeat upserted every 30s (verified live: row exists, `updated_at` advances).
+  - [x] Integration test covers random mutation sequence across 3 files (`claude_session_watcher_integration.rs`).
+  - [x] Property test (proptest) — `claude_session_watcher_integration.rs:246` `proptest!` block covers random append sequences.
+  - [x] `shell/claude-session-hook.sh` branches on `hippo capture-mode`; `watcher` path skips tmux spawn entirely; `both`/`tmux-tailer` retain the tmux-spawn path.
+  - [x] NFS/iCloud detection via `statfs` `f_fstypename` at startup; log warning if remote FS.
 - **Success criterion:**
   ```bash
   cargo test -p hippo-daemon --test claude_session_watcher_integration && \
@@ -253,9 +249,21 @@ If that chain exits 0, the watchdog fired at least one alarm within one poll int
 
 ---
 
+<a id="p2-phase-gate--milestone-m3"></a>
 ## P2 PHASE GATE — Milestone M3
 
-**Predicate:** T-5, T-6 both `done` AND `claude_session_mode = "both"` has run for ≥ 48 h AND parity is clean:
+> **⚠️ DECISION NEEDED — gate as written is non-functional.**
+> The original predicate below assumes `claude_session_parity.mismatch_count > 0` would surface watcher/tailer divergence. It cannot, by construction:
+>
+> - The watcher writes to `claude_sessions` (`watch_claude_sessions.rs:188-204` → `claude_session::insert_segments`).
+> - The tmux tailer (`claude_session::ingest_tail` invoked via the hook's inline path) writes only to the `events` table; it never inserts `claude_sessions` rows. The non-tmux fallback `ingest_batch` does write `claude_sessions`, but the hook only reaches it when no tmux server is running.
+> - `write_parity_row` (`watch_claude_sessions.rs:299-308`) computes `total = COUNT(*) FROM claude_sessions WHERE source_file = ?` and `tailer_count = total - watcher_count`. With the watcher as the sole writer, `total ≡ watcher_count` and `mismatch_count ≡ 0` regardless of whether the tailer is running, dead, or running and dropping events.
+>
+> **Empirical confirmation (2026-04-25, this machine):** 2,037 parity rows in the live DB; aggregate `watcher_count = 632`, `tailer_count = 0`, `mismatch_count = 0`. The "M3 clean" predicate already passes — but it would also pass if the watcher were the only thing capturing.
+>
+> Until this is resolved, T-7 must not be unblocked solely by the predicate below. The four candidate resolutions are tracked in [`docs/capture-reliability/m3-decision.md`](m3-decision.md). Pick one before flipping T-7 to `open`.
+
+**Original predicate (kept for reference; no longer load-bearing):**
 
 ```bash
 sqlite3 ~/.local/share/hippo/hippo.db \
@@ -270,29 +278,30 @@ sqlite3 ~/.local/share/hippo/hippo.db \
   | grep -qx '0'
 ```
 
-Both queries return 0 → M3 ratified: zero parity mismatches in the last 48 h AND every source probed within the last 15 min.
+The second clause (probe freshness) is still meaningful — it confirms T-6 probes are running. The first clause is the broken one.
 
 ---
 
 ## T-7 · P3.1 — Flip `claude_session_mode` default to `watcher`
 
-- **Status:** blocked
+- **Status:** done — shipped via PR #87
 - **Phase:** P3
-- **Depends on:** T-5 (done), T-6 (done), **M3 parity predicate passing for 48 h** (see above).
-- **Branch:** `feat/p3.1-watcher-default`
+- **Depends on:** T-5 (done), T-6 (done), and the M3 decision recorded in `m3-decision.md` (Option D — empirical validation against 7 days of dual-run data on `main`).
+- **Branch:** `feat/p3.1-watcher-default` (merged to `main`)
 - **Files:**
-  - `config/config.default.toml` (flip default to `"watcher"`)
-  - `crates/hippo-daemon/src/commands.rs` (doctor emits `[WW]` if `claude_session_mode == "tmux-tailer"` on a post-T-5 binary)
-  - `docs/RELEASE.md` (release-note snippet)
+  - `config/config.default.toml` (default flipped to `"watcher"`)
+  - `crates/hippo-core/src/config.rs` (Rust-side default + `ClaudeSessionMode` doc comments)
+  - `crates/hippo-daemon/src/commands.rs` (doctor `check_capture_mode` emits `[WW]` for `tmux-tailer`; tests added)
+  - `docs/capture-reliability/m3-decision.md` (Outcome section recording Option D)
+  - `docs/capture-reliability/07-roadmap.md` (this file: T-7 status flipped)
 - **DoD:**
-  - [ ] Default config flag flipped from `"tmux-tailer"` to `"watcher"`.
-  - [ ] Doctor warns (`[WW]`, not `[!!]`) on `tmux-tailer` setting with pointer to `docs/capture-reliability/06-claude-session-watcher.md`.
-  - [ ] Release note calls out the switch, the parity evidence, and the single-command rollback (`hippo config set capture.claude_session_mode tmux-tailer && hippo daemon restart`).
-  - [ ] No code changes to the watcher/tailer paths themselves.
+  - [x] Default config flag flipped from `"tmux-tailer"` to `"watcher"` in both `config.default.toml` and `CaptureConfig::default()`.
+  - [x] Doctor warns (`[WW]`, not `[!!]`) on `tmux-tailer` setting with pointer to `docs/capture-reliability/06-claude-session-watcher.md`.
+  - [x] Release note (PR description) calls out the switch, the parity evidence, and the single-command rollback (`hippo config set capture.claude_session_mode tmux-tailer && hippo daemon restart`).
+  - [x] No code changes to the watcher/tailer paths themselves.
 - **Success criterion:**
   ```bash
-  [ "$(sqlite3 ~/.local/share/hippo/hippo.db 'SELECT COUNT(*) FROM claude_session_parity WHERE mismatch_count > 0 AND window_start > strftime("%s","now")*1000 - 172800000;')" = "0" ] && \
-    cargo test -p hippo-daemon -- watcher_default_warning
+  cargo test -p hippo-daemon -- check_capture_mode default_capture_mode
   ```
 - **Consensus review:** yes
 
@@ -361,45 +370,14 @@ Tmux-spawn code gone AND no investigation issue still open → M4 ratified.
 
 ---
 
-# Parallelization Notes for Agent Teams
+# Risk Register (residual)
 
-The Ralph Loop is single-threaded by default, but if operated as a team (per `feedback_agent_teams.md`), these tasks can run truly in parallel:
-
-| Wave | Parallelizable tasks | Schema coordination |
-|------|----------------------|---------------------|
-| W1 | T-1, T-3, T-4 | T-1 owns the next schema version; T-5 if launched here must wait on assignment |
-| W2 | T-2 (after T-1), T-5, T-6 | T-5 takes next-next schema version if launched alongside T-1 |
-| W3 | T-7 gated on M3; T-8 gated on T-7 + 7d soak; T-9 gated on T-8 | — |
-
-When running a team, set `Status: claimed` on the row the moment an agent checks out the branch. This prevents two agents from picking the same task.
-
----
-
-# Risk Register
+Most risks here were retired with their parent tasks. Live ones for the remaining P3 work:
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|-----------|
-| Migration failure mid-deploy (daemon new schema, brain lags) | Medium | High | `schema_handshake` (v0.13 pattern); `ACCEPTED_READ_VERSIONS` keeps N−1 runnable. |
-| Watchdog alarm fatigue during bring-up | High | Medium | T-1 defaults `alarm_rate_limit_minutes = 60`, `notify_macos = false`; step down to 15 min in v0.18 after 7-day soak. |
-| FSEvents quirks cause watcher to miss events | Low | High | Dual-run writes to `claude_session_parity`; T-7 flips default only after 48 h parity clean. |
-| `probe_tag` filter missing from a query path | Medium | Medium | T-6's Semgrep rule fails CI; upstream filter at daemon is load-bearing. |
-| Schema version collision between T-1 and T-5 branches | Medium | Low | Team lead assigns next version number on branch creation; PR template requires `PRAGMA user_version` check. |
-| New tmux-targeting patch during P1–P2 (AP-10 violation) | High | Low | Review blocks any PR of this shape with pointer to T-5; manual recovery is `hippo ingest claude-session --batch`. |
-| `daemon.rs` / `commands.rs` become hot-file merge surfaces | Medium | Low | Worktrees + sequential T-1 → T-2 + T-4 rebase cadence; coordinate via `Status:` column. |
+| FSEvents quirks cause the watcher to miss events after T-7 default flip | Low | High | Whichever M3 resolution is chosen must give a real "watcher captured everything the tailer would have" signal before T-7 ships. Single-command rollback documented in T-7 release note. |
+| Closing #49–#53 in T-9 without surfacing actual root causes | Medium | Medium | T-9 DoD requires each closing comment to cite the PR(s) that mitigated it OR an explicit "won't fix — reason." No bare closures. |
+| Watcher heartbeat column drift in `source_health` | Low | Low | Watcher-row `updated_at` is fresh on this machine but `last_heartbeat_ts` is NULL — worth a quick check before T-7 to confirm doctor's freshness query points at the right column. |
 
----
-
-# Ralph Loop Quick Reference
-
-```bash
-# Find the next task
-grep -nE '^- \*\*Status:\*\* open$' docs/capture-reliability/07-roadmap.md \
-  | head -1
-
-# Check dependencies are satisfied (for task T-N)
-awk '/^## T-N /,/^---/' docs/capture-reliability/07-roadmap.md | \
-  grep -A1 'Depends on:' | head -2
-
-# Run the success criterion for a task (copy from the task's section)
-# When it exits 0, you can git push and open the PR.
-```
+Retired risks (kept for historical reference): migration failure mid-deploy (handled by `ACCEPTED_READ_VERSIONS`), watchdog alarm fatigue (T-1 defaults shipped), `probe_tag` filter gaps (T-6 semgrep rule + upstream filter shipped), schema version collisions (T-5 ended up at v10 cleanly), AP-10 tmux patches during dev (none merged), `daemon.rs` hot-file merges (no conflicts hit).

--- a/docs/capture-reliability/07-roadmap.md
+++ b/docs/capture-reliability/07-roadmap.md
@@ -284,7 +284,7 @@ The second clause (probe freshness) is still meaningful — it confirms T-6 prob
 
 ## T-7 · P3.1 — Flip `claude_session_mode` default to `watcher`
 
-- **Status:** done — shipped via PR #87
+- **Status:** done — shipped via PR #88
 - **Phase:** P3
 - **Depends on:** T-5 (done), T-6 (done), and the M3 decision recorded in `m3-decision.md` (Option D — empirical validation against 7 days of dual-run data on `main`).
 - **Branch:** `feat/p3.1-watcher-default` (merged to `main`)

--- a/docs/capture-reliability/m3-decision.md
+++ b/docs/capture-reliability/m3-decision.md
@@ -1,6 +1,6 @@
 # M3 Decision: how do we validate the watcher before flipping the default?
 
-**Status:** resolved 2026-04-25 — proceeded with **Option D** (skip the formal validation step) after a query session against the live DB on `main` produced ground-truth evidence equivalent to what Option C would have produced. T-7 ships next.
+**Status:** resolved 2026-04-25 — proceeded with **Option D** (skip the formal validation step) after a query session against the live DB on `main` produced ground-truth evidence equivalent to what Option C would have produced. T-7 shipped in PR #88 on 2026-04-25.
 
 **Outcome summary:**
 - Last 7 days: 466 JSONL files modified on disk; **463 captured by the watcher** (99.36%).

--- a/docs/capture-reliability/m3-decision.md
+++ b/docs/capture-reliability/m3-decision.md
@@ -6,7 +6,7 @@
 - Last 7 days: 466 JSONL files modified on disk; **463 captured by the watcher** (99.36%).
 - The 3 unrepresented files were verified by hand: in all three, `claude_session_offsets.byte_offset == size_at_last_read == filesize` (watcher fully read them); `extract_segments` returned 0 segments for legitimate reasons (very short conversations or non-conversation snapshot files).
 - Same 7 days: tmux tailer captured 94 distinct sessions; watcher captured 727. Tailer-only sessions: **0**. Watcher-only sessions: **633**. The watcher is dramatically more reliable than the tailer it replaces.
-- The query session that produced these numbers is recorded in PR #87 (T-7) as the M3 evidence.
+- The query session that produced these numbers is recorded in PR #88 (T-7) as the M3 evidence.
 
 The Option C reconciliation script was **not** built. The full original analysis is preserved below for posterity.
 
@@ -130,7 +130,9 @@ Run it once before T-7. If it returns clean across N days of session files, M3 i
 
 ---
 
-## Recommendation
+### Recommendation (superseded — see Outcome at top of file)
+
+> Note: this section is the pre-decision draft recommendation. The actual outcome was Option D (skip the formal validation step entirely after the live-DB query produced equivalent ground-truth evidence). Kept for the historical reasoning.
 
 **Option C.** Reasoning:
 
@@ -141,13 +143,15 @@ Run it once before T-7. If it returns clean across N days of session files, M3 i
 
 If you also want continuous monitoring after T-7 ships, a reduced version of the same script can run as a periodic check (probe-style). But that's a P4 question, not an M3 question.
 
-## What I would NOT recommend
+### What I would NOT recommend (pre-decision draft)
 
 - Trying to "fix" `claude_session_parity` to produce a useful number. The table's design assumed both paths write `claude_sessions`. They don't. Salvaging it costs more than replacing it.
 - Removing the `claude_session_parity` table now. It's a cheap heartbeat trace and may become useful if a future ingestion path does write `claude_sessions`. Leaving it is harmless.
 - Waiting for "more parity data" before deciding. More rows of `(632, 0, 0)` won't change the answer.
 
-## If Option C is approved, here's the work to unblock T-7
+### If Option C is approved, here's the work to unblock T-7 (not done — Option D was chosen)
+
+> Note: This work was never done — Option D was chosen instead. Kept as historical context for what the Option C path would have looked like.
 
 1. Implement `scripts/m3-reconcile.sh` (or `hippo doctor m3-reconcile`).
 2. Run it across ≥7 days of session files. Confirm exit 0.

--- a/docs/capture-reliability/m3-decision.md
+++ b/docs/capture-reliability/m3-decision.md
@@ -1,0 +1,158 @@
+# M3 Decision: how do we validate the watcher before flipping the default?
+
+**Status:** resolved 2026-04-25 — proceeded with **Option D** (skip the formal validation step) after a query session against the live DB on `main` produced ground-truth evidence equivalent to what Option C would have produced. T-7 ships next.
+
+**Outcome summary:**
+- Last 7 days: 466 JSONL files modified on disk; **463 captured by the watcher** (99.36%).
+- The 3 unrepresented files were verified by hand: in all three, `claude_session_offsets.byte_offset == size_at_last_read == filesize` (watcher fully read them); `extract_segments` returned 0 segments for legitimate reasons (very short conversations or non-conversation snapshot files).
+- Same 7 days: tmux tailer captured 94 distinct sessions; watcher captured 727. Tailer-only sessions: **0**. Watcher-only sessions: **633**. The watcher is dramatically more reliable than the tailer it replaces.
+- The query session that produced these numbers is recorded in PR #87 (T-7) as the M3 evidence.
+
+The Option C reconciliation script was **not** built. The full original analysis is preserved below for posterity.
+
+---
+
+## Original analysis (2026-04-25)
+
+The M3 phase gate as originally written cannot detect what it claims to detect. We need to pick a different validation strategy for T-7. Four options below; **recommendation: Option C** (one-shot manual reconciliation script). It's ~50 LOC, gives ground truth, and avoids adding ongoing runtime cost or new tests.
+
+---
+
+## What the gate was supposed to do
+
+T-5 shipped a "dual-run" mode (`claude_session_mode = "both"`) so we could run the new FS watcher *alongside* the existing tmux tailer for ≥48 h, compare their outputs, and only flip the default to `"watcher"` after the comparison was clean. The fear being mitigated: FSEvents on macOS sometimes drops events for high-churn paths or specific filesystems (NFS, iCloud-synced volumes, fast atomic-rename patterns). If the watcher silently missed something the tailer caught, dual-run would surface it.
+
+The mechanism was supposed to be the `claude_session_parity` table — one row per file per hour with `tailer_count`, `watcher_count`, `mismatch_count`. The M3 gate is `SELECT COUNT(*) WHERE mismatch_count > 0` returning zero across the last 48 h.
+
+## What the gate actually does
+
+Two separate ingestion paths, two different tables.
+
+**Watcher path** (`crates/hippo-daemon/src/watch_claude_sessions.rs:188-204`):
+```rust
+let task = tokio::task::spawn_blocking(move || {
+    let conn = open_db(&db_path_owned)?;
+    let (inserted, skipped, errors) = ingest_session_file(&conn, &path_owned);
+    ...
+});
+```
+`ingest_session_file` → `insert_segments` → `INSERT OR IGNORE INTO claude_sessions`.
+
+**Tmux tailer path** (`shell/claude-session-hook.sh:96` → `hippo ingest claude-session --inline` → `crates/hippo-daemon/src/claude_session.rs:1088 ingest_tail`):
+```rust
+for envelope in envelopes {
+    send_event_fire_and_forget(socket_path, &envelope, timeout_ms).await
+}
+```
+Sends per-line envelopes over the daemon socket. The daemon writes them to the **`events`** table via `storage::insert_event_at` (`daemon.rs:362`). It does **not** call `write_session_segments`. It does **not** insert `claude_sessions` rows.
+
+(There's one exception: `claude_session::ingest_batch` — used only when no tmux server is running, hook line 124 — *does* call `write_session_segments` after streaming events. This is a corner case the parity gate isn't designed around.)
+
+**Parity computation** (`watch_claude_sessions.rs:299-308, 319-320`):
+```rust
+let total = SELECT COUNT(*) FROM claude_sessions WHERE source_file = ?;
+let tailer_count = total.saturating_sub(watcher_count);
+let mismatch_count = tailer_count;
+```
+The watcher is the sole writer to `claude_sessions`. So `total ≡ watcher_count`. So `tailer_count ≡ 0`. So `mismatch_count ≡ 0`. Always. The function-internal comment at `watch_claude_sessions.rs:314-318` already acknowledges this.
+
+**Live evidence on this machine (2026-04-25, ~2h sample):**
+```
+2,037 parity rows
+SUM(watcher_count)  = 632
+SUM(tailer_count)   = 0
+SUM(mismatch_count) = 0
+```
+The gate "passes" trivially. It would also pass if the tailer were dead, the watcher were the only thing capturing, or the file were never read at all.
+
+## What we actually want from M3
+
+Plainly: *"I am confident that defaulting to `watcher`-only mode will not silently drop Claude sessions that the existing tailer would have captured."*
+
+That confidence can come from three independent signals:
+
+1. **Comparative measurement** — for each session file, the segments the watcher inserted equal the segments a perfect ingestion would have produced. (Counted once at decision time, or continuously during the soak.)
+2. **Coverage measurement** — every recent session file in `~/.claude/projects/` has a corresponding `claude_sessions` row.
+3. **Operational evidence** — the watcher has been running in `both` (or even `watcher`-only) mode for some period without surfacing issues in your day-to-day use.
+
+Signal #3 is partially earned already — your machine has been on `both` mode and the watcher has captured 632 segments in the recent window with no complaints. That's not zero confidence; it's just not formal validation.
+
+---
+
+## Options
+
+### Option A — Make the tailer also write `claude_sessions`
+
+**What:** Modify `claude_session::ingest_tail` to also call `write_session_segments` (or equivalent) after the per-line envelope dispatch, so both paths populate `claude_sessions`. Then `total = COUNT(*)` would be the union of both writers' inserts, and (because of `INSERT OR IGNORE` on `(session_id, segment_index)`) any mismatch would be a real divergence.
+
+**Cost:** ~30-50 LOC in `claude_session.rs`; the tailer process now does extra SQLite work it didn't before; new test coverage required to confirm the dual-write doesn't double-count; need to be careful about which writer "wins" the offset advance and how `claude_session_offsets` interacts.
+
+**Risk:** Adds runtime cost to a code path we're about to delete (T-8 deletes the tmux-spawn path entirely). Spending engineering effort to instrument code that's scheduled for removal.
+
+**Bottom line:** Defensible, but you're optimising for a measurement that you'll throw away.
+
+### Option B — Compute a "shadow tailer count" from the `events` table
+
+**What:** Instead of changing the tailer, derive what the tailer "should have written" by counting `events WHERE source_kind = 'claude-tool' AND envelope_id LIKE ...` (or some proxy) within the parity window, then comparing to `watcher_count`. The mapping between Claude session JSONL lines and `events` rows is many-to-many in places (a single tool-use line can produce two envelopes; non-tool messages don't produce events at all), so the comparison would have to be a proxy like "number of distinct session_ids in `events` matches number of distinct session_ids in `claude_sessions`."
+
+**Cost:** ~40-80 LOC in `watch_claude_sessions::write_parity_row`; nontrivial reasoning about which `events` rows correspond to which JSONL lines; the comparison won't be exact.
+
+**Risk:** False positives. The tailer captures *tool calls*; the watcher captures *conversation segments*. Forcing them into a count comparison invites spurious "mismatches" that everyone learns to ignore — exactly the alarm-fatigue pattern that the watchdog defaults already try to prevent.
+
+**Bottom line:** Engineering busy-work for a metric that was never going to be apples-to-apples.
+
+### Option C — One-shot manual reconciliation script ★ recommended
+
+**What:** A short script (~50 LOC, can live in `scripts/m3-reconcile.sh` or as a `hippo` subcommand) that:
+
+1. Globs `~/.claude/projects/**/*.jsonl` modified in the last 7 days.
+2. For each file, runs `extract_segments` once (the same parser the watcher and batch importer use) and records the expected segment count.
+3. Queries `SELECT COUNT(*) FROM claude_sessions WHERE source_file = ?` for the same path.
+4. Reports any file where actual ≠ expected, plus the magnitude of the gap.
+
+Run it once before T-7. If it returns clean across N days of session files, M3 is satisfied empirically. The `claude_session_parity` table stays as a "watcher is alive" trace; the M3 gate predicate becomes "this script exits 0 across at least 7 days of session files."
+
+**Cost:** ~50 LOC of Rust (or shell + sqlite3). Reuses `extract_segments` directly. No runtime overhead. No new tests beyond a smoke test on the script itself.
+
+**Risk:** Only validates at the moment you run it — doesn't catch a future regression. But T-8 deletes the tailer code anyway, so there's no "future regression" to catch except FSEvents itself, which a continuous parity check wouldn't validate either.
+
+**Bottom line:** Cheapest, gives you the actual ground-truth answer, no ongoing maintenance.
+
+### Option D — Drop dual-run entirely; soak + spot check
+
+**What:** Acknowledge that you've already been running `both` mode on your daily-driver machine for some time, watcher has captured 632+ segments in the recent window, no issues observed. Skip M3 as a formal gate. Flip T-7's `Depends on` to "30 days of `both` or `watcher` operational, no user-reported gaps." Spot-check 5–10 sessions before flipping.
+
+**Cost:** Zero engineering. The risk register entry "FSEvents quirks cause the watcher to miss events" remains, but it always was going to remain — the parity table never could have caught a systematic FSEvents issue without independent ingestion to compare against.
+
+**Risk:** Highest in theory (no measurement), but lowest in practice if you have soak time. Honest assessment of what dual-run was buying.
+
+**Bottom line:** The most intellectually honest option, but easy for reviewers/future-you to read as "skipped the validation step."
+
+---
+
+## Recommendation
+
+**Option C.** Reasoning:
+
+- It produces the only number you actually care about: "for the JSONL files on disk, did we capture the right number of segments?"
+- The implementation reuses an existing function (`extract_segments`) — no new parsing logic, no new tests for the parser.
+- It avoids investing engineering effort in code that T-8 will delete (Option A) or in a metric that's structurally noisy (Option B).
+- It produces a single boolean ("M3 passed at <date>") that can go in the T-7 PR description as evidence, rather than a continuous gauge that gets argued about.
+
+If you also want continuous monitoring after T-7 ships, a reduced version of the same script can run as a periodic check (probe-style). But that's a P4 question, not an M3 question.
+
+## What I would NOT recommend
+
+- Trying to "fix" `claude_session_parity` to produce a useful number. The table's design assumed both paths write `claude_sessions`. They don't. Salvaging it costs more than replacing it.
+- Removing the `claude_session_parity` table now. It's a cheap heartbeat trace and may become useful if a future ingestion path does write `claude_sessions`. Leaving it is harmless.
+- Waiting for "more parity data" before deciding. More rows of `(632, 0, 0)` won't change the answer.
+
+## If Option C is approved, here's the work to unblock T-7
+
+1. Implement `scripts/m3-reconcile.sh` (or `hippo doctor m3-reconcile`).
+2. Run it across ≥7 days of session files. Confirm exit 0.
+3. Edit `07-roadmap.md` — flip T-7 `Status: blocked` → `open` and update its `Depends on:` to cite the reconciliation result.
+4. Ship T-7 (it's a 3-file, ~10-line behaviour change).
+5. Wait the documented 7-day soak under the new default before unblocking T-8.
+
+Total effort to unblock T-7: ~2 hours (script + 7-day waiting period for the reconciliation window).


### PR DESCRIPTION
## Summary

- `claude_session_mode` default flips from `"tmux-tailer"` to `"watcher"` (the FS watcher shipped in T-5/#86).
- `hippo doctor` gains a `check_capture_mode` step that emits `[WW]` when the legacy tmux tailer is still configured, with the switch/rollback commands inline.
- Roadmap T-7 marked done; new `docs/capture-reliability/m3-decision.md` records the M3 decision with empirical evidence.

The original parity-table gate (`claude_session_parity.mismatch_count > 0`) was non-functional by construction — the watcher is the sole writer to `claude_sessions`, so the comparison would always evaluate to zero regardless of whether the tailer was running, dead, or perfectly capturing. Rather than salvage a metric we're about to delete in T-8, we validated against ground truth from the live DB. See `docs/capture-reliability/m3-decision.md` for the full reasoning.

## M3 evidence (last 7 days, this machine)

**Coverage check — JSONL on disk vs `claude_sessions`:**

| Metric | Value |
| --- | --- |
| JSONL files modified on disk | 466 |
| Captured by watcher | 463 |
| **Effective watcher capture** | **99.36%** |

The 3 "missing" files were verified by hand: in all three, `claude_session_offsets.byte_offset == size_at_last_read == filesize` (watcher fully read them). `extract_segments` returned 0 segments for legitimate reasons (very short conversations or non-conversation snapshot files containing `{type, messageId, snapshot, isSnapshotUpdate}` keys). True capture loss: **0**.

**Head-to-head — distinct session UUIDs:**

| | Watcher (`claude_sessions`) | Tailer (`events` via `sessions.shell='claude-code'`) |
| --- | --- | --- |
| Distinct sessions captured | **727** | **94** |
| Tailer-only (in tailer but not watcher) | — | **0** |
| Watcher-only (in watcher but not tailer) | **633** | — |

The watcher captures everything the tailer captures, plus 6.7× more. The tailer's historical unreliability is empirically real.

## Rollback

```bash
hippo config set capture.claude_session_mode tmux-tailer && hippo daemon restart
```

The tmux tailer code path is unchanged — anyone who flips back gets the exact behavior they had pre-merge. T-8 will remove the tmux path entirely; until then, the rollback is risk-free.

## Test plan

- [x] `cargo test -p hippo-core -p hippo-daemon` — 391 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New unit tests in `crates/hippo-daemon/src/commands.rs::tests`:
  - `test_default_capture_mode_is_watcher` — verifies the Rust-side default flip
  - `test_check_capture_mode_runs_for_every_variant` — smoke-tests every enum variant
- [x] No Python references to `claude_session_mode` in `brain/` (verified via grep)
- [ ] Post-merge: bump version + tag

🤖 Generated with [Claude Code](https://claude.ai/code)