### PR TITLE
fix(install,telemetry): hard-fail when telemetry configured-on but dead (v0.17.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.17.1"
+version = "0.17.2"
 requires-python = ">=3.14"
 dependencies = [
     "httpx>=0.28",

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -55,8 +55,14 @@ from hippo_brain.watchdog import (
     preflight_lm_studio,
     reap_stale_locks,
 )
-from hippo_brain.telemetry import get_tracer as _get_tracer
-from hippo_brain.telemetry import add as _add, get_meter, hist as _hist
+from hippo_brain.telemetry import (
+    _is_otel_enabled as _telemetry_is_enabled,
+    add as _add,
+    get_meter,
+    get_tracer as _get_tracer,
+    hist as _hist,
+    is_telemetry_active as _telemetry_is_active,
+)
 
 _meter = get_meter()
 _events_claimed = (
@@ -264,6 +270,12 @@ class BrainServer:
                 "last_success_at_ms": self.last_success_at_ms,
                 "last_error": self.last_error,
                 "last_error_at_ms": self.last_error_at_ms,
+                # Distinguishes "telemetry configured-on AND running" from
+                # "telemetry configured-on but dead" — the failure mode that
+                # caused dashboards to silently go dark when the deployed brain
+                # venv was out of sync with pyproject.toml.
+                "telemetry_enabled": _telemetry_is_enabled(),
+                "telemetry_active": _telemetry_is_active(),
             }
         )
 

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -56,12 +56,12 @@ from hippo_brain.watchdog import (
     reap_stale_locks,
 )
 from hippo_brain.telemetry import (
-    _is_otel_enabled as _telemetry_is_enabled,
     add as _add,
     get_meter,
     get_tracer as _get_tracer,
     hist as _hist,
-    is_telemetry_active as _telemetry_is_active,
+    is_telemetry_active,
+    is_telemetry_enabled,
 )
 
 _meter = get_meter()
@@ -274,8 +274,8 @@ class BrainServer:
                 # "telemetry configured-on but dead" — the failure mode that
                 # caused dashboards to silently go dark when the deployed brain
                 # venv was out of sync with pyproject.toml.
-                "telemetry_enabled": _telemetry_is_enabled(),
-                "telemetry_active": _telemetry_is_active(),
+                "telemetry_enabled": is_telemetry_enabled(),
+                "telemetry_active": is_telemetry_active(),
             }
         )
 

--- a/brain/src/hippo_brain/telemetry.py
+++ b/brain/src/hippo_brain/telemetry.py
@@ -20,7 +20,12 @@ DEFAULT_ENDPOINT = "http://localhost:4318"
 _telemetry_active: bool = False
 
 
-def _is_otel_enabled() -> bool:
+def is_telemetry_enabled() -> bool:
+    """Return True iff the HIPPO_OTEL_ENABLED env gate is set.
+
+    Reflects user intent only — does not guarantee providers are initialized.
+    Use is_telemetry_active() to check actual runtime state.
+    """
     return os.environ.get("HIPPO_OTEL_ENABLED", "").strip() == "1"
 
 
@@ -51,7 +56,7 @@ def init_telemetry(
     """
     global _telemetry_active
 
-    if not _is_otel_enabled():
+    if not is_telemetry_enabled():
         return None
 
     if not endpoint:
@@ -138,7 +143,7 @@ def init_telemetry(
 
 def get_tracer(name: str = "hippo-brain"):
     """Get OTel tracer if available, else return None."""
-    if not _is_otel_enabled():
+    if not is_telemetry_enabled():
         return None
     try:
         from opentelemetry import trace
@@ -155,7 +160,7 @@ def get_meter(name: str = "hippo-brain"):
     will pick up the real MeterProvider once ``init_telemetry()`` calls
     ``set_meter_provider()``.
     """
-    if not _is_otel_enabled():
+    if not is_telemetry_enabled():
         return None
     try:
         from opentelemetry import metrics as otel_metrics

--- a/brain/src/hippo_brain/telemetry.py
+++ b/brain/src/hippo_brain/telemetry.py
@@ -80,14 +80,15 @@ def init_telemetry(
             from opentelemetry.instrumentation.logging.handler import LoggingHandler
         except ImportError:
             from opentelemetry.sdk._logs import LoggingHandler
-    except ImportError as e:
-        # The brain venv was almost certainly installed against an older
-        # pyproject and never re-synced. `uv sync --reinstall` repairs both
-        # missing packages and the half-installed-namespace failure mode
-        # where dist-info is present but the namespace is empty.
+    except (ImportError, AttributeError) as e:
+        # ImportError covers "package missing" and the half-installed-namespace
+        # case (dist-info present, package contents empty) seen 2026-04-26.
+        # AttributeError covers a partially-extracted `__init__.py` that
+        # imports cleanly but is missing the symbols we then access. Both
+        # are "deployed venv out of sync with pyproject.toml" — same recovery.
         msg = (
             "HIPPO_OTEL_ENABLED=1 but OpenTelemetry packages cannot be imported "
-            "(import error: %s). The deployed brain venv is out of sync with "
+            "(error: %s). The deployed brain venv is out of sync with "
             "pyproject.toml. Recover with: "
             "`uv sync --project ~/.local/share/hippo-brain --reinstall` then "
             "restart the brain. If you intended to disable telemetry, unset "
@@ -122,9 +123,13 @@ def init_telemetry(
     meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
     otel_metrics.set_meter_provider(meter_provider)
 
+    # Mark active BEFORE optional process-metrics registration: the providers
+    # are already wired up at this point, and a downstream failure in
+    # _register_process_metrics (e.g., psutil.AccessDenied in a sandbox) must
+    # not leave the flag desynchronized from "providers initialized" state.
+    _telemetry_active = True
     _register_process_metrics()
 
-    _telemetry_active = True
     logger.info(
         "OpenTelemetry initialized: endpoint=%s, service=%s",
         endpoint,

--- a/brain/src/hippo_brain/telemetry.py
+++ b/brain/src/hippo_brain/telemetry.py
@@ -1,7 +1,10 @@
 """OpenTelemetry initialization for Hippo Brain services.
 
 Gated behind HIPPO_OTEL_ENABLED=1 environment variable.
-When disabled or when OTel packages are not installed, all functions are no-ops.
+When the gate is unset, all functions are no-ops. When the gate is set
+explicitly but the OTel Python packages cannot be imported (e.g., a
+half-installed venv after an upgrade), ``init_telemetry`` raises so the
+service fails loud rather than silently shipping zero metrics.
 """
 
 import logging
@@ -11,9 +14,28 @@ logger = logging.getLogger("hippo_brain.telemetry")
 
 DEFAULT_ENDPOINT = "http://localhost:4318"
 
+# Set to True only after init_telemetry() successfully wires up providers.
+# Surfaced via is_telemetry_active() so the /health endpoint and `hippo doctor`
+# can distinguish "configured-on AND running" from "configured-on but dead".
+_telemetry_active: bool = False
+
 
 def _is_otel_enabled() -> bool:
     return os.environ.get("HIPPO_OTEL_ENABLED", "").strip() == "1"
+
+
+def is_telemetry_active() -> bool:
+    """Return True only after init_telemetry() has fully succeeded."""
+    return _telemetry_active
+
+
+class TelemetryInitError(RuntimeError):
+    """HIPPO_OTEL_ENABLED=1 was set but OTel providers could not be wired up.
+
+    Raised on import failure of any OTel SDK module — almost always a stale
+    or half-installed brain venv. The service should crash visibly and let
+    launchd report the failure rather than continue without telemetry.
+    """
 
 
 def init_telemetry(
@@ -22,8 +44,13 @@ def init_telemetry(
 ) -> "callable | None":
     """Initialize OpenTelemetry providers for traces, metrics, and logs.
 
-    Returns a shutdown callable, or None if OTel is disabled/unavailable.
+    Returns a shutdown callable on success, or ``None`` when telemetry is not
+    enabled. Raises ``TelemetryInitError`` when telemetry is explicitly
+    enabled (``HIPPO_OTEL_ENABLED=1``) but the OTel packages cannot be
+    imported — silently degrading would let dashboards go dark unnoticed.
     """
+    global _telemetry_active
+
     if not _is_otel_enabled():
         return None
 
@@ -48,9 +75,21 @@ def init_telemetry(
             from opentelemetry.instrumentation.logging.handler import LoggingHandler
         except ImportError:
             from opentelemetry.sdk._logs import LoggingHandler
-    except ImportError:
-        logger.warning("OpenTelemetry packages not installed — telemetry disabled")
-        return None
+    except ImportError as e:
+        # The brain venv was almost certainly installed against an older
+        # pyproject and never re-synced. `uv sync --reinstall` repairs both
+        # missing packages and the half-installed-namespace failure mode
+        # where dist-info is present but the namespace is empty.
+        msg = (
+            "HIPPO_OTEL_ENABLED=1 but OpenTelemetry packages cannot be imported "
+            "(import error: %s). The deployed brain venv is out of sync with "
+            "pyproject.toml. Recover with: "
+            "`uv sync --project ~/.local/share/hippo-brain --reinstall` then "
+            "restart the brain. If you intended to disable telemetry, unset "
+            "HIPPO_OTEL_ENABLED."
+        ) % e
+        logger.error(msg)
+        raise TelemetryInitError(msg) from e
 
     resource = Resource.create({"service.name": service_name})
 
@@ -80,6 +119,7 @@ def init_telemetry(
 
     _register_process_metrics()
 
+    _telemetry_active = True
     logger.info(
         "OpenTelemetry initialized: endpoint=%s, service=%s",
         endpoint,
@@ -87,6 +127,8 @@ def init_telemetry(
     )
 
     def shutdown() -> None:
+        global _telemetry_active
+        _telemetry_active = False
         tracer_provider.shutdown()
         logger_provider.shutdown()
         meter_provider.shutdown()

--- a/brain/tests/test_server.py
+++ b/brain/tests/test_server.py
@@ -1,6 +1,7 @@
 """Tests for hippo_brain.server — BrainServer endpoints and create_app."""
 
 import asyncio
+import os
 import time
 from unittest.mock import AsyncMock, patch
 
@@ -92,6 +93,13 @@ def test_health_endpoint(tmp_db):
     assert "last_success_at_ms" in data
     assert "last_error" in data
     assert "last_error_at_ms" in data
+    # Telemetry status is consumed by `hippo doctor` to detect the
+    # configured-on-but-dead silent-degrade mode. Locks in the contract so
+    # the doctor check can't go blind to a future /health refactor.
+    assert "telemetry_enabled" in data
+    assert "telemetry_active" in data
+    assert isinstance(data["telemetry_enabled"], bool)
+    assert isinstance(data["telemetry_active"], bool)
     assert data["enrichment_running"] is False
     assert data["db_reachable"] is True
     assert data["queue_depth"] == 0
@@ -99,6 +107,47 @@ def test_health_endpoint(tmp_db):
     assert data["last_success_at_ms"] is None
     assert data["last_error"] is None
     assert data["last_error_at_ms"] is None
+
+
+def test_health_telemetry_fields_reflect_runtime_state(tmp_db):
+    """When telemetry is gated off, /health must report enabled=False AND
+    active=False — the only state combination that's safe in CI without an
+    OTel collector. Then with the gate on and providers initialized, both
+    must flip True. Catches regressions that decouple the fields from the
+    real module-level state.
+    """
+    # Reach into the exact module that server.py's bound function reads from.
+    # `import hippo_brain.telemetry` would resolve via sys.modules, which
+    # other tests can replace via del+reimport — leaving us setting state on
+    # a module that server.py no longer references. The function's
+    # `__globals__` is the unambiguous source of truth.
+    from hippo_brain.server import is_telemetry_active as server_is_active
+
+    telemetry_globals = server_is_active.__globals__
+
+    _, db_path = tmp_db
+    app = _make_app(str(db_path))
+    client = TestClient(app)
+
+    env_off = {k: v for k, v in os.environ.items() if k != "HIPPO_OTEL_ENABLED"}
+    original_active = telemetry_globals.get("_telemetry_active", False)
+    try:
+        with patch.dict(os.environ, env_off, clear=True):
+            telemetry_globals["_telemetry_active"] = False
+            data = client.get("/health").json()
+            assert data["telemetry_enabled"] is False
+            assert data["telemetry_active"] is False
+
+        # Simulate "providers wired up" without actually running
+        # init_telemetry, which would attach a global OTel exporter that
+        # pollutes other tests.
+        with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
+            telemetry_globals["_telemetry_active"] = True
+            data = client.get("/health").json()
+            assert data["telemetry_enabled"] is True
+            assert data["telemetry_active"] is True
+    finally:
+        telemetry_globals["_telemetry_active"] = original_active
 
 
 # ---- /query ----

--- a/brain/tests/test_telemetry.py
+++ b/brain/tests/test_telemetry.py
@@ -5,6 +5,21 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_telemetry_active_state():
+    """Defend against module-level `_telemetry_active` leaking between tests.
+
+    Tests that call init_telemetry() flip the flag True, then call shutdown()
+    which flips it back. If a test fails between those two events, the flag
+    leaks into the next test. Resetting before each test makes failures local.
+    """
+    import hippo_brain.telemetry as telemetry_module
+
+    telemetry_module._telemetry_active = False
+    yield
+    telemetry_module._telemetry_active = False
+
+
 def test_telemetry_disabled_by_default():
     """When HIPPO_OTEL_ENABLED is not set, init_telemetry is a no-op."""
     env = {k: v for k, v in os.environ.items() if k != "HIPPO_OTEL_ENABLED"}
@@ -30,6 +45,22 @@ def test_telemetry_enabled_returns_providers():
             pass
 
 
+def _hide_otel_modules():
+    """Snapshot and remove every `opentelemetry*` and `hippo_brain.telemetry`
+    entry from sys.modules, returning the snapshot so tests can restore them.
+
+    Restoring `hippo_brain.telemetry` is critical: without it, a re-import
+    creates a NEW module object that other consumers (e.g. hippo_brain.server)
+    don't see, leaving the original module's `_telemetry_active` and the new
+    module's `_telemetry_active` desynchronized across the test process.
+    """
+    snapshot = {}
+    for mod_name in list(sys.modules.keys()):
+        if "opentelemetry" in mod_name or mod_name == "hippo_brain.telemetry":
+            snapshot[mod_name] = sys.modules.pop(mod_name)
+    return snapshot
+
+
 def test_telemetry_missing_packages_raises_when_enabled():
     """When HIPPO_OTEL_ENABLED=1 but otel packages are missing, init_telemetry
     must fail loud rather than silently disabling itself.
@@ -39,16 +70,8 @@ def test_telemetry_missing_packages_raises_when_enabled():
     brain to go dark while the brain reported `enrichment_running: true`.
     """
     with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
-        # Hide all opentelemetry modules to simulate missing packages.
-        hidden = {}
-        for mod_name in list(sys.modules.keys()):
-            if "opentelemetry" in mod_name:
-                hidden[mod_name] = sys.modules.pop(mod_name)
-
+        snapshot = _hide_otel_modules()
         try:
-            if "hippo_brain.telemetry" in sys.modules:
-                del sys.modules["hippo_brain.telemetry"]
-
             with patch.dict(sys.modules, {"opentelemetry": None}):
                 from hippo_brain.telemetry import (
                     TelemetryInitError,
@@ -63,7 +86,7 @@ def test_telemetry_missing_packages_raises_when_enabled():
                 assert "uv sync" in str(excinfo.value)
                 assert is_telemetry_active() is False
         finally:
-            sys.modules.update(hidden)
+            sys.modules.update(snapshot)
 
 
 def test_telemetry_missing_packages_silent_when_disabled():
@@ -74,22 +97,15 @@ def test_telemetry_missing_packages_silent_when_disabled():
     """
     env = {k: v for k, v in os.environ.items() if k != "HIPPO_OTEL_ENABLED"}
     with patch.dict(os.environ, env, clear=True):
-        hidden = {}
-        for mod_name in list(sys.modules.keys()):
-            if "opentelemetry" in mod_name:
-                hidden[mod_name] = sys.modules.pop(mod_name)
-
+        snapshot = _hide_otel_modules()
         try:
-            if "hippo_brain.telemetry" in sys.modules:
-                del sys.modules["hippo_brain.telemetry"]
-
             with patch.dict(sys.modules, {"opentelemetry": None}):
                 from hippo_brain.telemetry import init_telemetry, is_telemetry_active
 
                 assert init_telemetry("test-service") is None
                 assert is_telemetry_active() is False
         finally:
-            sys.modules.update(hidden)
+            sys.modules.update(snapshot)
 
 
 def test_telemetry_enabled_creates_meter_provider():
@@ -147,9 +163,19 @@ def test_process_metrics_missing_psutil_is_soft_failure(monkeypatch):
     import sys
 
     monkeypatch.setitem(sys.modules, "psutil", None)
+    # Save and restore the original `hippo_brain.telemetry` module reference.
+    # A bare `del` would leak: the next test runs a fresh import, but
+    # hippo_brain.server still holds function references from the original
+    # module — and `server.is_telemetry_active()` would then read its
+    # `_telemetry_active` from a module that the test can no longer reach.
+    original_telemetry = sys.modules.get("hippo_brain.telemetry")
     if "hippo_brain.telemetry" in sys.modules:
         del sys.modules["hippo_brain.telemetry"]
-    from hippo_brain.telemetry import _register_process_metrics
+    try:
+        from hippo_brain.telemetry import _register_process_metrics
 
-    # Should not raise even with psutil masked out.
-    _register_process_metrics()
+        # Should not raise even with psutil masked out.
+        _register_process_metrics()
+    finally:
+        if original_telemetry is not None:
+            sys.modules["hippo_brain.telemetry"] = original_telemetry

--- a/brain/tests/test_telemetry.py
+++ b/brain/tests/test_telemetry.py
@@ -2,15 +2,18 @@ import os
 import sys
 from unittest.mock import patch
 
+import pytest
+
 
 def test_telemetry_disabled_by_default():
     """When HIPPO_OTEL_ENABLED is not set, init_telemetry is a no-op."""
     env = {k: v for k, v in os.environ.items() if k != "HIPPO_OTEL_ENABLED"}
     with patch.dict(os.environ, env, clear=True):
-        from hippo_brain.telemetry import init_telemetry
+        from hippo_brain.telemetry import init_telemetry, is_telemetry_active
 
         result = init_telemetry("test-service")
         assert result is None
+        assert is_telemetry_active() is False
 
 
 def test_telemetry_enabled_returns_providers():
@@ -21,29 +24,70 @@ def test_telemetry_enabled_returns_providers():
 
             result = init_telemetry("test-service", endpoint="http://localhost:4318")
             assert result is None or callable(result)
+            if callable(result):
+                result()
         except ImportError:
             pass
 
 
-def test_telemetry_missing_packages_returns_none():
-    """When HIPPO_OTEL_ENABLED=1 but otel packages missing, returns None gracefully."""
+def test_telemetry_missing_packages_raises_when_enabled():
+    """When HIPPO_OTEL_ENABLED=1 but otel packages are missing, init_telemetry
+    must fail loud rather than silently disabling itself.
+
+    The silent-warning behavior previously masked a corrupted venv (dist-info
+    present but namespace empty), causing every Grafana panel sourced from the
+    brain to go dark while the brain reported `enrichment_running: true`.
+    """
     with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
-        # Hide all opentelemetry modules to simulate missing packages
+        # Hide all opentelemetry modules to simulate missing packages.
         hidden = {}
         for mod_name in list(sys.modules.keys()):
             if "opentelemetry" in mod_name:
                 hidden[mod_name] = sys.modules.pop(mod_name)
 
         try:
-            # Force reimport of telemetry so it re-attempts the OTel imports
             if "hippo_brain.telemetry" in sys.modules:
                 del sys.modules["hippo_brain.telemetry"]
 
             with patch.dict(sys.modules, {"opentelemetry": None}):
-                from hippo_brain.telemetry import init_telemetry
+                from hippo_brain.telemetry import (
+                    TelemetryInitError,
+                    init_telemetry,
+                    is_telemetry_active,
+                )
 
-                result = init_telemetry("test-service")
-                assert result is None
+                with pytest.raises(TelemetryInitError) as excinfo:
+                    init_telemetry("test-service")
+
+                assert "HIPPO_OTEL_ENABLED=1" in str(excinfo.value)
+                assert "uv sync" in str(excinfo.value)
+                assert is_telemetry_active() is False
+        finally:
+            sys.modules.update(hidden)
+
+
+def test_telemetry_missing_packages_silent_when_disabled():
+    """When HIPPO_OTEL_ENABLED is unset, missing OTel packages are not an error.
+
+    Locks in that the hard-fail only kicks in for explicit opt-in. A user who
+    never enabled telemetry should never see import errors from this module.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "HIPPO_OTEL_ENABLED"}
+    with patch.dict(os.environ, env, clear=True):
+        hidden = {}
+        for mod_name in list(sys.modules.keys()):
+            if "opentelemetry" in mod_name:
+                hidden[mod_name] = sys.modules.pop(mod_name)
+
+        try:
+            if "hippo_brain.telemetry" in sys.modules:
+                del sys.modules["hippo_brain.telemetry"]
+
+            with patch.dict(sys.modules, {"opentelemetry": None}):
+                from hippo_brain.telemetry import init_telemetry, is_telemetry_active
+
+                assert init_telemetry("test-service") is None
+                assert is_telemetry_active() is False
         finally:
             sys.modules.update(hidden)
 
@@ -51,11 +95,12 @@ def test_telemetry_missing_packages_returns_none():
 def test_telemetry_enabled_creates_meter_provider():
     """When OTel is enabled, init_telemetry should set up a meter provider."""
     with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}):
-        from hippo_brain.telemetry import init_telemetry
+        from hippo_brain.telemetry import init_telemetry, is_telemetry_active
 
         shutdown = init_telemetry("test-service", endpoint="http://localhost:4318")
         assert shutdown is not None, "OTel packages are installed; init should succeed"
         try:
+            assert is_telemetry_active() is True
             from opentelemetry import metrics as otel_metrics
 
             meter = otel_metrics.get_meter("test")
@@ -63,6 +108,7 @@ def test_telemetry_enabled_creates_meter_provider():
             counter.add(1)  # Should not raise
         finally:
             shutdown()
+            assert is_telemetry_active() is False
 
 
 def test_get_meter_returns_none_when_disabled():

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.17.1"
+version = "0.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -941,8 +941,8 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
     // the seconds-level `check_source_staleness` below.
     fail_count += check_source_freshness(config);
 
-    // Check OpenTelemetry configuration
-    fail_count += check_otel_status(config, &client).await;
+    // Check OpenTelemetry configuration (incl. brain self-reported status)
+    fail_count += check_otel_status(config, &client, brain_json.as_ref()).await;
 
     // Check GitHub CI-ingest configuration
     fail_count += check_github_source(config);
@@ -1173,7 +1173,11 @@ fn format_duration_ms(ms: i64) -> String {
     format!("{days}d")
 }
 
-async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) -> u32 {
+async fn check_otel_status(
+    config: &HippoConfig,
+    client: &reqwest::Client,
+    brain_json: Option<&serde_json::Value>,
+) -> u32 {
     // Check if OTel feature is compiled in
     #[cfg(feature = "otel")]
     let otel_compiled = true;
@@ -1197,8 +1201,7 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) -> u3
         .map(|r| r.status().is_success())
         .unwrap_or(false);
 
-    // Determine status and provide actionable feedback
-    match (config_enabled, collector_reachable) {
+    let mut fail_count = match (config_enabled, collector_reachable) {
         (true, true) => {
             println!("[OK] OpenTelemetry: enabled and collector reachable");
             0
@@ -1223,6 +1226,48 @@ async fn check_otel_status(config: &HippoConfig, client: &reqwest::Client) -> u3
             println!("[--] OpenTelemetry: disabled (start with: mise run otel:up)");
             0
         }
+    };
+
+    fail_count += check_brain_telemetry_status(brain_json);
+
+    fail_count
+}
+
+/// Surface the brain's self-reported telemetry state. Catches the failure
+/// mode where the brain process is alive and reports `enrichment_running:
+/// true` but ships zero metrics because its venv was never re-synced after a
+/// pyproject change. This is precisely the silent regression that left the
+/// hippo-enrichment dashboard dark on 2026-04-26.
+///
+/// Three outcomes (return 1 only on the configured-on-but-dead case):
+/// - `telemetry_enabled = true,  telemetry_active = true`  → OK, no print
+/// - `telemetry_enabled = true,  telemetry_active = false` → fail loud
+/// - `telemetry_enabled = false`                           → no-op
+/// - either field missing (older brain)                    → unknown, no-op
+fn check_brain_telemetry_status(brain_json: Option<&serde_json::Value>) -> u32 {
+    let Some(json) = brain_json else { return 0 };
+    let enabled = json.get("telemetry_enabled").and_then(|v| v.as_bool());
+    let active = json.get("telemetry_active").and_then(|v| v.as_bool());
+
+    match (enabled, active) {
+        (Some(true), Some(true)) => {
+            println!("[OK] Brain telemetry: initialized and active");
+            0
+        }
+        (Some(true), Some(false)) => {
+            println!("[!!] Brain telemetry: HIPPO_OTEL_ENABLED=1 but providers not initialized");
+            println!("     CAUSE:  Deployed brain venv is out of sync with pyproject.toml,");
+            println!("             or the OTel package namespace was half-installed.");
+            println!("     FIX:    uv sync --project ~/.local/share/hippo-brain --reinstall");
+            println!("             then: launchctl kickstart -k gui/$(id -u)/com.hippo.brain");
+            println!("     DOC:    docs/capture-reliability/03-doctor-upgrades.md");
+            1
+        }
+        (Some(false), _) => 0,
+        // Older brain without the new health fields — treat as unknown.
+        // Don't fail; the existing collector-reachability check above is a
+        // close-enough proxy for installs that haven't been upgraded yet.
+        _ => 0,
     }
 }
 
@@ -3119,5 +3164,54 @@ replacement = "***"
         let fail = check_github_source_with(&config, || true);
         // At least the empty-repos fail (maybe also plist-not-installed in CI).
         assert!(fail >= 1);
+    }
+
+    #[test]
+    fn test_check_brain_telemetry_status_no_brain() {
+        // Brain unreachable → no info to report → no fail.
+        assert_eq!(check_brain_telemetry_status(None), 0);
+    }
+
+    #[test]
+    fn test_check_brain_telemetry_status_disabled() {
+        // telemetry_enabled=false → no fail regardless of active state.
+        let json = serde_json::json!({
+            "telemetry_enabled": false,
+            "telemetry_active": false,
+        });
+        assert_eq!(check_brain_telemetry_status(Some(&json)), 0);
+    }
+
+    #[test]
+    fn test_check_brain_telemetry_status_active() {
+        let json = serde_json::json!({
+            "telemetry_enabled": true,
+            "telemetry_active": true,
+        });
+        assert_eq!(check_brain_telemetry_status(Some(&json)), 0);
+    }
+
+    #[test]
+    fn test_check_brain_telemetry_status_enabled_but_inactive_fails() {
+        // The exact failure mode from the 2026-04-26 dashboard outage:
+        // brain alive, env says telemetry on, but the venv was out of sync
+        // and providers never initialized.
+        let json = serde_json::json!({
+            "telemetry_enabled": true,
+            "telemetry_active": false,
+        });
+        assert_eq!(check_brain_telemetry_status(Some(&json)), 1);
+    }
+
+    #[test]
+    fn test_check_brain_telemetry_status_older_brain_unknown() {
+        // Older brain that doesn't yet expose telemetry_{enabled,active}.
+        // Don't fail — the daemon-side collector check above is a close-enough
+        // proxy until the brain is upgraded.
+        let json = serde_json::json!({
+            "status": "ok",
+            "version": "0.16.0",
+        });
+        assert_eq!(check_brain_telemetry_status(Some(&json)), 0);
     }
 }

--- a/docs/capture-reliability/03-doctor-upgrades.md
+++ b/docs/capture-reliability/03-doctor-upgrades.md
@@ -217,6 +217,33 @@ Reads daemon `PRAGMA user_version` and compares to brain's `expected_schema_vers
 
 ---
 
+## Brain telemetry status (configured-on but dead)
+
+The brain exposes `telemetry_enabled` and `telemetry_active` on `/health`.
+Doctor flags the `enabled=true, active=false` combination — the silent
+failure mode where the brain runs without OTel providers because its venv
+is out of sync with `pyproject.toml`. Recovery in the FIX line:
+
+```
+[!!] Brain telemetry: HIPPO_OTEL_ENABLED=1 but providers not initialized
+     CAUSE:  Deployed brain venv is out of sync with pyproject.toml,
+             or the OTel package namespace was half-installed.
+     FIX:    uv sync --project ~/.local/share/hippo-brain --reinstall
+             then: launchctl kickstart -k gui/$(id -u)/com.hippo.brain
+```
+
+**Expected behavior of a misconfigured brain:** because `init_telemetry`
+now hard-fails on import errors when the gate is on, a misconfigured brain
+crashes at startup. With `KeepAlive=true` on `com.hippo.brain.plist`,
+launchd respawns it every ~10 s. The telltale signature in
+`~/.local/share/hippo/brain.stderr.log` is a repeated stack trace ending
+in `TelemetryInitError: HIPPO_OTEL_ENABLED=1 but OpenTelemetry packages
+cannot be imported …`. This is intentional: the loud failure surfaces
+on the first `hippo doctor` run rather than letting metrics quietly
+disappear from Grafana for hours.
+
+---
+
 ## `hippo doctor --explain` mode
 
 When `--explain` is passed, each failing check appends a remediation block:

--- a/mise.toml
+++ b/mise.toml
@@ -441,6 +441,55 @@ run = "cargo run --bin hippo -- entities"
 
 # ── Service management ───────────────────────────────────────────────
 
+[tasks."install:verify-brain-imports"]
+description = "Verify deployed brain venv can import its critical dependencies"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Catches the half-installed-namespace failure mode where `uv sync` reports
+# success but the package contents weren't fully extracted. Observed on
+# macOS arm64 with cached wheels: dist-info present, namespace empty, every
+# dependent dashboard goes dark with no error message anywhere.
+#
+# The fix is `uv sync --reinstall`, which we'll run automatically once
+# before bailing — install should self-heal on the common case rather than
+# leave the user to debug it.
+
+BRAIN_INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/hippo-brain"
+PROBE='
+import sys
+try:
+    from opentelemetry import metrics, trace
+    from opentelemetry.sdk.metrics import MeterProvider  # noqa: F401
+    from opentelemetry.sdk.trace import TracerProvider  # noqa: F401
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter  # noqa: F401
+    import psutil  # noqa: F401
+    import sqlite_vec  # noqa: F401
+    sys.exit(0)
+except Exception as exc:
+    print(f"brain import probe failed: {exc!r}", file=sys.stderr)
+    sys.exit(1)
+'
+
+if (cd "$BRAIN_INSTALL_DIR" && uv run --no-sync python -c "$PROBE"); then
+    echo "  Brain imports OK"
+    exit 0
+fi
+
+echo "==> Brain imports failed; running uv sync --reinstall to repair..."
+(cd "$BRAIN_INSTALL_DIR" && uv sync --reinstall)
+
+if (cd "$BRAIN_INSTALL_DIR" && uv run --no-sync python -c "$PROBE"); then
+    echo "  Brain imports OK after reinstall"
+    exit 0
+fi
+
+echo "ERROR: brain venv at $BRAIN_INSTALL_DIR is unusable even after --reinstall."
+echo "Manual recovery: rm -rf '$BRAIN_INSTALL_DIR/.venv' && cd '$BRAIN_INSTALL_DIR' && uv sync"
+exit 1
+'''
+
 [tasks.install]
 description = "Full clean-install: stop, build, install, configure, start, verify"
 run = '''
@@ -552,7 +601,15 @@ rsync -a --delete \
 # but must land under $BRAIN_INSTALL_DIR/shell/ so doctor and the Claude hook find it.
 rsync -a --delete shell/ "$BRAIN_INSTALL_DIR/shell/"
 echo "==> Rebuilding brain venv at ${BRAIN_INSTALL_DIR}..."
+# `uv sync` against a stale .venv has, in the wild, left dist-info present
+# while leaving the namespace package half-extracted (observed 2026-04-26 on
+# macOS arm64: opentelemetry/{exporter,instrumentation,proto,sdk} present but
+# opentelemetry/{api,metrics,trace} missing). A subsequent `--reinstall`
+# repaired it. Rather than risk that race in production, nuke the venv first
+# so uv builds it from scratch — and verify imports below.
+rm -rf "$BRAIN_INSTALL_DIR/.venv"
 (cd "$BRAIN_INSTALL_DIR" && uv sync)
+mise run install:verify-brain-imports
 
 # ── 5. Install plists + symlink ─────────────────────────────────────
 echo "==> Installing LaunchAgents + symlink..."

--- a/mise.toml
+++ b/mise.toml
@@ -468,7 +468,9 @@ try:
     from hippo_brain.server import create_app  # noqa: F401
     sys.exit(0)
 except Exception as exc:
-    print(f"brain import probe failed: {exc!r}", file=sys.stderr)
+    # Print to stdout: any CI capture that records only stdout still gets
+    # the diagnostic, and the non-zero exit already signals failure.
+    print(f"brain import probe failed: {exc!r}")
     sys.exit(1)
 '
 

--- a/mise.toml
+++ b/mise.toml
@@ -457,15 +457,15 @@ set -euo pipefail
 # leave the user to debug it.
 
 BRAIN_INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/hippo-brain"
+# Importing `create_app` is a strict superset of probing individual third-party
+# packages: it transitively pulls in the entire startup graph the brain uses
+# (starlette, uvicorn, httpx, sqlite_vec, opentelemetry, psutil, plus the
+# hippo_brain.* internal modules). If any of them is half-installed, this
+# probe trips at install time instead of on the first launchd start.
 PROBE='
 import sys
 try:
-    from opentelemetry import metrics, trace
-    from opentelemetry.sdk.metrics import MeterProvider  # noqa: F401
-    from opentelemetry.sdk.trace import TracerProvider  # noqa: F401
-    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter  # noqa: F401
-    import psutil  # noqa: F401
-    import sqlite_vec  # noqa: F401
+    from hippo_brain.server import create_app  # noqa: F401
     sys.exit(0)
 except Exception as exc:
     print(f"brain import probe failed: {exc!r}", file=sys.stderr)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -276,7 +276,9 @@ try:
     from hippo_brain.server import create_app  # noqa: F401
     sys.exit(0)
 except Exception as exc:
-    print(f"brain import probe failed: {exc!r}", file=sys.stderr)
+    # Print to stdout: any CI capture that records only stdout still gets
+    # the diagnostic, and the non-zero exit already signals failure.
+    print(f"brain import probe failed: {exc!r}")
     sys.exit(1)
 '
     (cd "${brain_dir}" && uv run --no-sync python -c "${probe}")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -265,15 +265,15 @@ install_daemon() {
 # that surfaces only at brain-startup time as a generic ImportError.
 verify_brain_imports() {
     local brain_dir="$1"
+    # Importing `create_app` exercises the full startup import graph
+    # (starlette, uvicorn, httpx, sqlite_vec, opentelemetry, psutil, plus the
+    # hippo_brain.* internal modules). A strict superset of probing the
+    # third-party packages individually — protects against the same shape of
+    # bug surfacing in any startup-path dep, not just opentelemetry.
     local probe='
 import sys
 try:
-    from opentelemetry import metrics, trace  # noqa: F401
-    from opentelemetry.sdk.metrics import MeterProvider  # noqa: F401
-    from opentelemetry.sdk.trace import TracerProvider  # noqa: F401
-    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter  # noqa: F401
-    import psutil  # noqa: F401
-    import sqlite_vec  # noqa: F401
+    from hippo_brain.server import create_app  # noqa: F401
     sys.exit(0)
 except Exception as exc:
     print(f"brain import probe failed: {exc!r}", file=sys.stderr)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -259,6 +259,29 @@ install_daemon() {
     log_success "Daemon installed"
 }
 
+# Probe the deployed brain venv for the imports the brain process needs at
+# startup. Returns 0 on success, 1 on any import failure. Catches the
+# half-installed-namespace bug (dist-info present, package contents empty)
+# that surfaces only at brain-startup time as a generic ImportError.
+verify_brain_imports() {
+    local brain_dir="$1"
+    local probe='
+import sys
+try:
+    from opentelemetry import metrics, trace  # noqa: F401
+    from opentelemetry.sdk.metrics import MeterProvider  # noqa: F401
+    from opentelemetry.sdk.trace import TracerProvider  # noqa: F401
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter  # noqa: F401
+    import psutil  # noqa: F401
+    import sqlite_vec  # noqa: F401
+    sys.exit(0)
+except Exception as exc:
+    print(f"brain import probe failed: {exc!r}", file=sys.stderr)
+    sys.exit(1)
+'
+    (cd "${brain_dir}" && uv run --no-sync python -c "${probe}")
+}
+
 # Install brain package
 install_brain() {
     local tag="$1"
@@ -309,6 +332,37 @@ install_brain() {
 
     rm -rf "${BRAIN_DIR}"
     mv "${brain_staging}" "${BRAIN_DIR}"
+
+    # Eagerly build the venv at install time and verify imports. Without this
+    # step `uv run` lazy-creates the venv on first launchd start, which has
+    # in the wild left a half-installed namespace (dist-info present but the
+    # package contents missing). The brain then runs alongside a "telemetry
+    # disabled" warning and every Grafana panel fed by brain metrics goes
+    # dark. Recovered by `uv sync --reinstall`; we now do that proactively.
+    if command -v uv >/dev/null 2>&1; then
+        log_info "Syncing brain Python dependencies..."
+        if ! (cd "${BRAIN_DIR}" && uv sync 2>&1); then
+            log_error "uv sync failed in ${BRAIN_DIR}"
+            exit 1
+        fi
+
+        log_info "Verifying brain imports..."
+        if ! verify_brain_imports "${BRAIN_DIR}"; then
+            log_warning "Brain imports failed after sync; retrying with --reinstall..."
+            if ! (cd "${BRAIN_DIR}" && uv sync --reinstall 2>&1); then
+                log_error "uv sync --reinstall failed in ${BRAIN_DIR}"
+                exit 1
+            fi
+            if ! verify_brain_imports "${BRAIN_DIR}"; then
+                log_error "Brain venv at ${BRAIN_DIR} is unusable even after --reinstall."
+                log_error "Manual recovery: rm -rf '${BRAIN_DIR}/.venv' && cd '${BRAIN_DIR}' && uv sync"
+                exit 1
+            fi
+        fi
+        log_success "Brain dependencies verified"
+    else
+        log_warning "uv not found; skipping eager brain venv build (will lazy-init on first launch)"
+    fi
 
     write_receipt "brain" "${expected_checksum}"
     log_success "Brain installed"


### PR DESCRIPTION
## Summary

Fixes the silent dashboard outage observed 2026-04-26: brain reported `enrichment_running: true` for ~25 minutes while every Grafana panel sourced from `hippo_brain_*` metrics went dark. Root cause was a deployed brain venv out of sync with `pyproject.toml`, with a half-installed `opentelemetry` namespace (dist-info present, package contents missing). Recovered manually via `uv sync --reinstall`.

Three layers of defense so this cannot recur silently:

1. **Hard-fail telemetry init** — `brain/src/hippo_brain/telemetry.py` now raises `TelemetryInitError` when `HIPPO_OTEL_ENABLED=1` is set but OTel imports fail. launchd surfaces the crash instead of swallowing a single startup WARNING.
2. **Health-endpoint exposure + doctor check** — `/health` adds `telemetry_enabled` and `telemetry_active`. `hippo doctor` flags the configured-on-but-dead state with the exact recovery command in the FIX line. Older brains missing the fields are treated as "unknown" (no fail) for back-compat during upgrades.
3. **Eager venv build + import probe** — `mise run install` now nukes the deployed `.venv` before sync (so `uv` rebuilds from scratch, sidestepping the half-extract race) and runs a new `mise run install:verify-brain-imports` task that probes the imports the brain actually does at startup. The public `scripts/install.sh` adopts the same contract via a shared probe block. Both auto-recover with `uv sync --reinstall` once before bailing.

## Why now / why bundled

This is one bug that needed three layers because each layer enforces a different invariant: the brain must crash visibly (1), the doctor must observe brain-internal state, not just collector reachability (2), and install must validate the artifact instead of trusting `uv sync`'s exit code (3). Splitting them ships a partial fix.

## Test plan

- [x] `cargo test -p hippo-daemon --lib --features otel` — 137 pass (incl. 5 new for `check_brain_telemetry_status`)
- [x] `cargo clippy --all-targets --features otel -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `uv run --project brain pytest brain/tests` — 722 pass / 1 skip / 1 xfail / 1 xpass (incl. 4 new/updated telemetry tests covering the hard-fail, silent-when-disabled, and active-tracking paths)
- [x] `uv run --project brain ruff check brain/` and `ruff format --check` — clean
- [x] `mise run install:verify-brain-imports` against the live (recovered) brain venv — passes

## Verified live

After deploying this branch: brain restarted clean (`OpenTelemetry initialized: endpoint=http://localhost:4318, service=hippo-brain`), `hippo_brain_enrichment_queue_depth` series flowing, dashboard panels populated, `hippo doctor` reports `[OK] Brain telemetry: initialized and active`.

## Out of scope (intentionally)

- No changes to capture-reliability anti-pattern docs — telemetry init is observability tooling, not a capture-path concern.
- No GUI version bump — no GUI surface area touched.
- No changes to the OTel docker-compose stack or collector config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)