### PR TITLE
fix(brain): enrichment quality — worktree pollution, verbatim facts, design_decisions (#98)

### DIFF
--- a/brain/scripts/dedup-entities.py
+++ b/brain/scripts/dedup-entities.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python3
-"""One-shot entity deduplication migration (R-16).
+"""One-shot entity deduplication migration.
 
-Re-canonicalizes all entities using the new entity_resolver rules and merges
-rows where (type, new_canonical) would collide. Keeps the oldest row (smallest
-created_at), re-points all knowledge_node_entities to the survivor, then
-deletes the duplicate entity rows.
+Re-canonicalizes all entities using the current entity_resolver rules and
+merges rows where (type, new_canonical) would collide. Keeps the oldest row
+(smallest created_at), re-points all knowledge_node_entities to the survivor,
+then deletes the duplicate entity rows.
+
+This script handles two flavors of duplication transparently because it
+delegates to canonicalize():
+
+  1. Multiple project roots resolving to the same logical file (e.g.
+     hippo vs. hippo-postgres) — the original v5→v6 use case.
+  2. Ephemeral parallel-agent worktrees under .claude/worktrees/<X>/...
+     (issue #98). Worktree subdirectory names vary (`agent-*`, `feat-*`,
+     adjective-noun-hex), and the directories are removed once the agent's
+     work is merged or discarded — leaving polluted entity rows. Re-running
+     this script after canonicalize() learns the worktree-strip rule
+     collapses N copies of every commonly-edited file to one canonical row.
 
 Usage:
     uv run --project brain python brain/scripts/dedup-entities.py [--data-dir PATH] [--dry-run]
@@ -13,7 +25,7 @@ Environment:
     HIPPO_PROJECT_ROOTS  Colon-separated list of absolute project root paths to
                          strip from path-type entity values (e.g.
                          /home/user/projects/hippo:/home/user/projects/hippo-postgres).
-                         Required for worktree-prefix dedup to work correctly.
+                         Required for project-root dedup to work correctly.
 
 Exits 0 on success. Non-zero on error.
 """

--- a/brain/src/hippo_brain/browser_enrichment.py
+++ b/brain/src/hippo_brain/browser_enrichment.py
@@ -20,13 +20,24 @@ Extract what they were researching, learning, or investigating. Focus on technic
 
 IMPORTANT: Be specific. Use actual page titles, URLs, technical concepts, and search queries from the data. Generic descriptions like "browsed some pages" are unacceptable.
 
-The embed_text field should read like a developer's research log — specific enough that searching for "Rust Display trait implementation" or "cargo proc-macro error" would find it.
+VERBATIM PRESERVATION RULE: In every text field (summary, intent, key_decisions, problems_encountered, design_decisions, embed_text), reproduce the following kinds of tokens EXACTLY as they appeared in the page titles, URLs, or search queries. Do NOT paraphrase, normalize, or guess at them:
+  - Environment variable names (UPPERCASE_WITH_UNDERSCORES)
+  - Constants and ALL_CAPS identifiers matching [A-Z][A-Z0-9_]{2,}
+  - Semantic versions matching \\d+\\.\\d+\\.\\d+ (e.g. 1.75.0, 22.3.1)
+  - Package@version pairs (e.g. "tokio@1.40.0")
+  - Symbol names: function, method, class, struct, trait, and constant identifiers
+  - CLI flag names (--release, --no-default-features)
+  - File paths and command names
+If you are unsure of an exact name or version, OMIT it rather than guess.
+
+The embed_text field is what powers semantic search over this research session. It MUST be identifier-dense: include every symbol name, package name, version string, search query, and technical term that appears in the page data. Density of identifiers beats prose elegance — a future agent will search this field by keyword. A good embed_text reads like a tag soup of the actual technical content (e.g. "tokio mpsc unbounded_channel rust async-trait stackoverflow tokio-rs docs.rs"), not like a polished paragraph.
 
 Output a JSON object with these fields:
 - summary: Specific description of what was researched or learned
 - intent: The developer's goal (e.g., "research", "debugging", "learning", "reference")
 - outcome: One of "success", "partial", "failure", "unknown"
 - key_decisions: List of decisions informed by the research
+- design_decisions: List of "considered X, chose Y, reason Z" structured decisions when the research shows an alternative was evaluated and rejected. Each entry is an object with keys "considered", "chosen", and "reason". Empty list if no alternatives were weighed.
 - problems_encountered: List of obstacles or dead ends
 - entities: An object with lists of extracted entities:
   - projects: Project names mentioned or inferred
@@ -36,7 +47,7 @@ Output a JSON object with these fields:
   - errors: Error messages being researched
   - domains: Key domains visited (e.g., "stackoverflow.com", "docs.rs")
 - tags: Descriptive, specific tags
-- embed_text: A detailed paragraph describing the research session. Specific topics, search queries, and sources. Optimized for semantic search.
+- embed_text: A detailed, identifier-dense paragraph (see rule above). Optimized for keyword retrieval, not prose.
 
 Output ONLY valid JSON, no markdown fences or extra text."""
 
@@ -303,6 +314,7 @@ def write_browser_knowledge_node(
             "tags": result.tags,
             "key_decisions": result.key_decisions,
             "problems_encountered": result.problems_encountered,
+            "design_decisions": result.design_decisions,
         }
     )
     tags_json = json.dumps(result.tags)

--- a/brain/src/hippo_brain/claude_sessions.py
+++ b/brain/src/hippo_brain/claude_sessions.py
@@ -12,6 +12,7 @@ from hippo_brain.enrichment import (
     is_enrichment_eligible,
     upsert_entities,
 )
+from hippo_brain.entity_resolver import strip_worktree_prefix
 from hippo_brain.models import EnrichmentResult
 from hippo_brain.watchdog import DEFAULT_LOCK_TIMEOUT_MS
 
@@ -26,13 +27,24 @@ Produce structured enrichment data capturing the knowledge from this work sessio
 
 IMPORTANT: Be specific. Use actual file names, function names, error messages, and outcomes from the session data. Generic descriptions are unacceptable.
 
-The embed_text field should read like a developer's work log entry — specific enough that searching for "embedding model configuration" or "clippy warning fix" would find it.
+VERBATIM PRESERVATION RULE: In every text field (summary, intent, key_decisions, problems_encountered, design_decisions, embed_text), reproduce the following kinds of tokens EXACTLY as they appeared in the session data. Do NOT paraphrase, normalize, or guess at them:
+  - Environment variable names (UPPERCASE_WITH_UNDERSCORES, e.g. HIPPO_FORCE)
+  - Constants and ALL_CAPS identifiers matching [A-Z][A-Z0-9_]{2,}
+  - Semantic versions matching \\d+\\.\\d+\\.\\d+ (e.g. 0.0.26, 2.20.0)
+  - Package@version pairs (e.g. "python-multipart 0.0.26", "pygments@2.20.0")
+  - Symbol names: function, method, class, struct, trait, type, and constant identifiers
+  - CLI flag names (--no-verify, -uall, --release)
+  - File paths and command names
+If you are unsure of an exact name or version, OMIT it rather than guess. A hallucinated identifier is worse than a missing one — a future agent can re-read the source data to recover what was missed, but cannot un-believe a wrong name.
+
+The embed_text field is what powers semantic search over this work session. It MUST be identifier-dense: include every symbol name, file path, package name, version string, and CLI command that appears in the session data. Density of identifiers beats prose elegance — a future agent will search this field by keyword, not read it aloud. A good embed_text reads like a tag soup of the actual technical content (e.g. "schema_handshake.rs daemon brain handshake parse_protocol_version v0.13.0 sqlite-vec install.sh"), not like a polished paragraph.
 
 Output a JSON object with these fields:
 - summary: Specific description of what was accomplished
 - intent: The developer's goal (e.g., "feature development", "debugging", "refactoring", "configuration")
 - outcome: One of "success", "partial", "failure", "unknown"
 - key_decisions: List of decisions made and why
+- design_decisions: List of "considered X, chose Y, reason Z" structured decisions when the session shows an alternative was evaluated and rejected. Each entry is an object with keys "considered" (the abandoned approach), "chosen" (what was picked), and "reason" (why the chosen approach won). Empty list if no alternatives were weighed.
 - problems_encountered: List of errors/failures and how they were resolved
 - entities: An object with lists of extracted entities:
   - projects: Project names mentioned or inferred
@@ -41,7 +53,7 @@ Output a JSON object with these fields:
   - services: Services interacted with (databases, APIs, etc.)
   - errors: Actual error messages encountered
 - tags: Descriptive, specific tags
-- embed_text: A detailed paragraph a developer would write in a work log. Specific file names, error messages, and outcomes. Optimized for semantic search.
+- embed_text: A detailed, identifier-dense paragraph (see rule above). Optimized for keyword retrieval, not prose.
 
 Output ONLY valid JSON, no markdown fences or extra text."""
 
@@ -332,10 +344,18 @@ def extract_segments(
 
 
 def build_claude_enrichment_prompt(segments: list[SessionSegment]) -> str:
-    """Format session segments into the enrichment prompt."""
+    """Format session segments into the enrichment prompt.
+
+    The segment `cwd` is normalized via `strip_worktree_prefix` so the
+    LLM sees the parent-repo path rather than the ephemeral
+    `.claude/worktrees/<X>/` subdirectory created by parallel agents.
+    """
     parts = []
     for seg in segments:
-        header = f"Claude Code session segment (project: {seg.cwd}, branch: {seg.git_branch or 'unknown'})"
+        cwd = strip_worktree_prefix(seg.cwd)
+        header = (
+            f"Claude Code session segment (project: {cwd}, branch: {seg.git_branch or 'unknown'})"
+        )
         if seg.start_time and seg.end_time:
             start = datetime.fromtimestamp(seg.start_time / 1000).strftime("%Y-%m-%d %H:%M")
             end = datetime.fromtimestamp(seg.end_time / 1000).strftime("%H:%M")
@@ -629,6 +649,7 @@ def write_claude_knowledge_node(
             "tags": result.tags,
             "key_decisions": result.key_decisions,
             "problems_encountered": result.problems_encountered,
+            "design_decisions": result.design_decisions,
         }
     )
     tags_json = json.dumps(result.tags)

--- a/brain/src/hippo_brain/codex_sessions.py
+++ b/brain/src/hippo_brain/codex_sessions.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from hippo_brain.claude_sessions import SessionSegment
+from hippo_brain.entity_resolver import strip_worktree_prefix
 
 # 5-minute gap between user prompts = task boundary
 TASK_GAP_MS = 5 * 60 * 1000
@@ -303,10 +304,16 @@ def _extract_user_text_from_codex_message(message: str) -> str:
 
 
 def build_codex_enrichment_summary(segments: list[SessionSegment]) -> str:
-    """Format Codex segments into a summary for the enrichment prompt."""
+    """Format Codex segments into a summary for the enrichment prompt.
+
+    The segment `cwd` is normalized via `strip_worktree_prefix` so the LLM
+    sees the parent-repo path rather than the ephemeral
+    `.claude/worktrees/<X>/` subdirectory created by parallel agents.
+    """
     parts = []
     for seg in segments:
-        header = f"GitHub Copilot (Codex) session (project: {seg.cwd})"
+        cwd = strip_worktree_prefix(seg.cwd)
+        header = f"GitHub Copilot (Codex) session (project: {cwd})"
         if seg.start_time and seg.end_time:
             start = datetime.fromtimestamp(seg.start_time / 1000, tz=timezone.utc).strftime(
                 "%Y-%m-%d %H:%M"

--- a/brain/src/hippo_brain/enrichment.py
+++ b/brain/src/hippo_brain/enrichment.py
@@ -3,7 +3,7 @@ import re
 import time
 import uuid
 
-from hippo_brain.entity_resolver import canonicalize
+from hippo_brain.entity_resolver import canonicalize, strip_worktree_prefix
 from hippo_brain.models import EnrichmentResult, validate_enrichment_data
 from hippo_brain.watchdog import DEFAULT_LOCK_TIMEOUT_MS
 
@@ -124,13 +124,24 @@ distinction in your summary — attribute actions to the correct actor.
 
 IMPORTANT: Be specific. Use actual file names, function names, error messages, and outcomes from the event data. Generic descriptions like "edited a Rust file" are unacceptable. Instead say "added build.rs to hippo-daemon that embeds git metadata via cargo:rustc-env".
 
-The embed_text field should read like a developer's work log entry — specific enough that searching for "embedding model configuration" or "clippy warning fix" would find it.
+VERBATIM PRESERVATION RULE: In every text field (summary, intent, key_decisions, problems_encountered, design_decisions, embed_text), reproduce the following kinds of tokens EXACTLY as they appeared in the source events. Do NOT paraphrase, normalize, or guess at them:
+  - Environment variable names (UPPERCASE_WITH_UNDERSCORES, e.g. HIPPO_FORCE)
+  - Constants and ALL_CAPS identifiers matching [A-Z][A-Z0-9_]{2,}
+  - Semantic versions matching \\d+\\.\\d+\\.\\d+ (e.g. 0.0.26, 2.20.0)
+  - Package@version pairs (e.g. "python-multipart 0.0.26", "pygments@2.20.0")
+  - Symbol names: function, method, class, struct, trait, type, and constant identifiers
+  - CLI flag names (--no-verify, -uall, --release)
+  - File paths and command names
+If you are unsure of an exact name or version, OMIT it rather than guess. A hallucinated identifier is worse than a missing one — a future agent can re-read the source events to recover what was missed, but cannot un-believe a wrong name.
+
+The embed_text field is what powers semantic search over this work session. It MUST be identifier-dense: include every symbol name, file path, package name, version string, and CLI command that appears in the source events. Density of identifiers beats prose elegance — a future agent will search this field by keyword, not read it aloud. A good embed_text reads like a tag soup of the actual technical content (e.g. "drain_brain pgrep launchctl uv run wrapper crates/hippo-daemon/src/install.rs parse_launchctl_pid"), not like a polished paragraph.
 
 Output a JSON object with these fields:
 - summary: Specific description of what was accomplished (not what tools were used)
 - intent: The developer's goal (e.g., "testing", "debugging", "deploying", "refactoring")
 - outcome: One of "success", "partial", "failure", "unknown"
 - key_decisions: List of decisions made and why (e.g., "Chose build.rs over vergen crate for zero dependencies")
+- design_decisions: List of "considered X, chose Y, reason Z" structured decisions when the events show an alternative was evaluated and rejected. Each entry is an object with keys "considered" (the abandoned approach), "chosen" (what was picked), and "reason" (why the chosen approach won). Empty list if no alternatives were weighed.
 - problems_encountered: List of errors/failures and how they were resolved
 - entities: An object with lists of extracted entities:
   - projects: Project names mentioned or inferred
@@ -139,7 +150,7 @@ Output a JSON object with these fields:
   - services: Services interacted with (databases, APIs, etc.)
   - errors: Actual error messages encountered (not generic descriptions)
 - tags: Descriptive, specific tags (not "success" or "editing")
-- embed_text: A detailed paragraph a developer would write in a work log. Specific file names, error messages, and outcomes. Optimized for semantic search.
+- embed_text: A detailed, identifier-dense paragraph (see rule above). Optimized for keyword retrieval, not prose.
 
 Output ONLY valid JSON, no markdown fences or extra text."""
 
@@ -151,7 +162,13 @@ def _actor_label(shell: str) -> str:
 
 
 def build_enrichment_prompt(events: list[dict], browser_context: str = "") -> str:
-    """Format events into the user prompt template."""
+    """Format events into the user prompt template.
+
+    `cwd` is normalized to strip Claude Code worktree segments
+    (`.claude/worktrees/<X>/`) so the LLM sees the parent-repo path rather
+    than the ephemeral agent worktree subdirectory. The raw value is
+    preserved in the events table.
+    """
     lines = []
     for i, ev in enumerate(events, 1):
         actor = _actor_label(ev.get("shell", ""))
@@ -159,7 +176,7 @@ def build_enrichment_prompt(events: list[dict], browser_context: str = "") -> st
         parts.append(f"  command: {ev.get('command', '')}")
         parts.append(f"  exit_code: {ev.get('exit_code', '')}")
         parts.append(f"  duration_ms: {ev.get('duration_ms', '')}")
-        parts.append(f"  cwd: {ev.get('cwd', '')}")
+        parts.append(f"  cwd: {strip_worktree_prefix(ev.get('cwd', ''))}")
         if ev.get("git_branch"):
             parts.append(f"  git_branch: {ev['git_branch']}")
         if ev.get("git_commit"):
@@ -369,6 +386,7 @@ def write_knowledge_node(
             "tags": result.tags,
             "key_decisions": result.key_decisions,
             "problems_encountered": result.problems_encountered,
+            "design_decisions": result.design_decisions,
         }
     )
     tags_json = json.dumps(result.tags)

--- a/brain/src/hippo_brain/entity_resolver.py
+++ b/brain/src/hippo_brain/entity_resolver.py
@@ -5,8 +5,16 @@ Canonical form rules:
 - Lowercase + strip surrounding whitespace
 - Strip trailing slashes
 - Collapse internal whitespace runs to single space
-- For path-like types (file, directory, path): strip known project root prefixes
-  so the same file under different worktree paths resolves to the same canonical.
+- For path-like types (file, directory, path):
+    1. Strip Claude Code parallel-agent worktree segments
+       (`.claude/worktrees/<anything>/`). These are ephemeral worktrees
+       created by the Task/TeamCreate tools that get deleted after the
+       agent's work merges or is discarded; entity rows pointing inside
+       them rot. Stripping them collapses N copies of the same logical
+       file (one per agent run) to a single canonical row.
+    2. Strip known project root prefixes so the same file under different
+       project root paths (e.g. `hippo` vs. `hippo-postgres`) resolves to
+       the same canonical.
 
 Project root precedence (highest to lowest):
 1. Explicit project_roots= passed to canonicalize() — useful in tests and scripts
@@ -29,6 +37,13 @@ from pathlib import Path
 
 _PATH_TYPES = frozenset({"file", "directory", "path"})
 _logger = logging.getLogger(__name__)
+
+# Matches `.claude/worktrees/<single-segment>/` anywhere in a path.
+# `<single-segment>` is any non-slash directory name — Claude Code worktrees
+# are named with varied schemes (`agent-XXXX`, `feat-XXXX`, adjective-noun-hex,
+# etc.), so we cannot rely on a fixed prefix. Trailing `/` is required so we
+# don't accidentally strip a file literally named ".claude/worktrees/foo".
+_WORKTREE_SEGMENT_RE = re.compile(r"\.claude/worktrees/[^/]+/")
 
 
 def _load_config_roots() -> list[str]:
@@ -86,6 +101,16 @@ def _resolve_project_roots(override: list[str] | None) -> list[str]:
     return list(_cached_fallback_roots())
 
 
+def strip_worktree_prefix(path: str) -> str:
+    """Strip every `.claude/worktrees/<X>/` segment from `path`.
+
+    Worktree subdirectory names vary (`agent-*`, `feat-*`, adjective-noun-hex
+    pairs from Claude Code's namer, etc.), so the stripping is segment-name
+    agnostic — anything between `.claude/worktrees/` and the next `/` is removed.
+    """
+    return _WORKTREE_SEGMENT_RE.sub("", path)
+
+
 def canonicalize(
     entity_type: str,
     value: str,
@@ -101,6 +126,13 @@ def canonicalize(
     v = re.sub(r"\s+", " ", v)
 
     if entity_type in _PATH_TYPES:
+        # Strip worktree segments first so a path like
+        #   /users/carpenter/projects/hippo/.claude/worktrees/agent-XX/src/foo.rs
+        # collapses to
+        #   /users/carpenter/projects/hippo/src/foo.rs
+        # before the project-root strip turns it into `src/foo.rs`.
+        v = strip_worktree_prefix(v)
+
         roots = _resolve_project_roots(project_roots)
         for root in roots:
             normalized = os.path.expanduser(root).lower().rstrip("/")

--- a/brain/src/hippo_brain/entity_resolver.py
+++ b/brain/src/hippo_brain/entity_resolver.py
@@ -38,12 +38,11 @@ from pathlib import Path
 _PATH_TYPES = frozenset({"file", "directory", "path"})
 _logger = logging.getLogger(__name__)
 
-# Matches `.claude/worktrees/<single-segment>/` anywhere in a path.
-# `<single-segment>` is any non-slash directory name — Claude Code worktrees
-# are named with varied schemes (`agent-XXXX`, `feat-XXXX`, adjective-noun-hex,
-# etc.), so we cannot rely on a fixed prefix. Trailing `/` is required so we
-# don't accidentally strip a file literally named ".claude/worktrees/foo".
-_WORKTREE_SEGMENT_RE = re.compile(r"\.claude/worktrees/[^/]+/")
+# Matches `/.claude/worktrees/<single-segment>/` or the same pattern at the
+# start of a relative path. `<single-segment>` is any non-slash directory name
+# — Claude Code worktrees are named with varied schemes (`agent-XXXX`,
+# `feat-XXXX`, adjective-noun-hex, etc.), so we cannot rely on a fixed prefix.
+_WORKTREE_SEGMENT_RE = re.compile(r"(^|/)\.claude/worktrees/[^/]+(/|$)")
 
 
 def _load_config_roots() -> list[str]:
@@ -106,9 +105,18 @@ def strip_worktree_prefix(path: str) -> str:
 
     Worktree subdirectory names vary (`agent-*`, `feat-*`, adjective-noun-hex
     pairs from Claude Code's namer, etc.), so the stripping is segment-name
-    agnostic — anything between `.claude/worktrees/` and the next `/` is removed.
+    agnostic — anything between `.claude/worktrees/` and the next `/` (or the
+    end of the path) is removed.
     """
-    return _WORKTREE_SEGMENT_RE.sub("", path)
+    stripped = path
+    while True:
+        next_value = _WORKTREE_SEGMENT_RE.sub(
+            lambda match: "" if match.group(2) == "" else match.group(1),
+            stripped,
+        )
+        if next_value == stripped:
+            return next_value
+        stripped = next_value
 
 
 def canonicalize(

--- a/brain/src/hippo_brain/entity_resolver.py
+++ b/brain/src/hippo_brain/entity_resolver.py
@@ -120,11 +120,13 @@ def strip_worktree_prefix(path: str) -> str:
     end of the path) is removed.
     """
     stripped = path
-    while True:
+    max_passes = path.count(".claude/worktrees/") + 1
+    for _ in range(max_passes):
         next_value = _WORKTREE_SEGMENT_RE.sub(_replace_worktree_match, stripped)
         if next_value == stripped:
             return next_value
         stripped = next_value
+    return stripped
 
 
 def canonicalize(

--- a/brain/src/hippo_brain/entity_resolver.py
+++ b/brain/src/hippo_brain/entity_resolver.py
@@ -45,6 +45,17 @@ _logger = logging.getLogger(__name__)
 _WORKTREE_SEGMENT_RE = re.compile(r"(^|/)\.claude/worktrees/[^/]+(/|$)")
 
 
+def _replace_worktree_match(match: re.Match[str]) -> str:
+    """Preserve path separators while dropping one worktree directory segment.
+
+    group(1) is the leading separator (or start-of-string), and group(2) is the
+    separator after the worktree name (or end-of-string). When the worktree is a
+    leaf path segment, we drop the whole match; otherwise we keep the leading
+    separator so the parent path still joins cleanly to the remaining suffix.
+    """
+    return "" if match.group(2) == "" else match.group(1)
+
+
 def _load_config_roots() -> list[str]:
     """Load [entities] project_roots from ~/.config/hippo/config.toml."""
     config_path = Path.home() / ".config" / "hippo" / "config.toml"
@@ -110,10 +121,7 @@ def strip_worktree_prefix(path: str) -> str:
     """
     stripped = path
     while True:
-        next_value = _WORKTREE_SEGMENT_RE.sub(
-            lambda match: "" if match.group(2) == "" else match.group(1),
-            stripped,
-        )
+        next_value = _WORKTREE_SEGMENT_RE.sub(_replace_worktree_match, stripped)
         if next_value == stripped:
             return next_value
         stripped = next_value

--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -575,6 +575,7 @@ def _result_to_dict(result) -> dict:
         "cwd": result.cwd,
         "git_branch": result.git_branch,
         "captured_at": result.captured_at,
+        "design_decisions": list(result.design_decisions),
         "linked_event_ids": list(result.linked_event_ids),
     }
 

--- a/brain/src/hippo_brain/models.py
+++ b/brain/src/hippo_brain/models.py
@@ -19,6 +19,10 @@ class EnrichmentResult:
     embed_text: str = ""
     key_decisions: list = field(default_factory=list)
     problems_encountered: list = field(default_factory=list)
+    # Structured "considered X, chose Y, reason Z" alternatives that were
+    # weighed during the work session. Each entry is a dict with keys
+    # "considered", "chosen", and "reason" (all str). Issue #98 F3.
+    design_decisions: list = field(default_factory=list)
 
 
 @dataclass
@@ -115,6 +119,30 @@ def validate_enrichment_data(data: dict) -> EnrichmentResult:
         raw_problems = []
     problems_encountered = [p for p in raw_problems if isinstance(p, str)]
 
+    # Design decisions: list of {considered, chosen, reason} objects (optional).
+    # Skip entries that aren't dicts or lack the three string keys — a partial
+    # entry is worse than no entry because a future agent can't trust it.
+    raw_design = data.get("design_decisions", [])
+    if not isinstance(raw_design, list):
+        raw_design = []
+    design_decisions: list[dict[str, str]] = []
+    for entry in raw_design:
+        if not isinstance(entry, dict):
+            continue
+        considered = entry.get("considered")
+        chosen = entry.get("chosen")
+        reason = entry.get("reason")
+        if not (
+            isinstance(considered, str)
+            and considered
+            and isinstance(chosen, str)
+            and chosen
+            and isinstance(reason, str)
+            and reason
+        ):
+            continue
+        design_decisions.append({"considered": considered, "chosen": chosen, "reason": reason})
+
     # Tags must be a list of strings (skip non-string items)
     raw_tags = data.get("tags", [])
     if not isinstance(raw_tags, list):
@@ -130,4 +158,5 @@ def validate_enrichment_data(data: dict) -> EnrichmentResult:
         embed_text=data["embed_text"],
         key_decisions=key_decisions,
         problems_encountered=problems_encountered,
+        design_decisions=design_decisions,
     )

--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -210,10 +210,14 @@ def _build_rag_prompt(
             d_len = len(_design_decision_payload(h.get("design_decisions") or []))
             total_payload = e_len + c_len + d_len
             if total_payload == 0:
+                # Structural fields (summary/cwd/tags/etc.) still render; only
+                # payload-heavy fields get a zero cap in this branch.
                 e_cap = c_cap = d_cap = 0
             else:
                 e_cap = (per_hit * e_len) // total_payload if e_len else 0
                 c_cap = (per_hit * c_len) // total_payload if c_len else 0
+                # The final field absorbs rounding remainder so the caps sum to
+                # exactly per_hit instead of drifting upward.
                 d_cap = per_hit - e_cap - c_cap
             blocks.append("\n".join(_hit_lines(i, h, e_cap, c_cap, d_cap)))
 

--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -95,7 +95,13 @@ def _shape_rag_sources(
     return sources[:limit]
 
 
-def _hit_lines(index: int, hit: dict, embed_cap: int, cmd_cap: int) -> list[str]:
+def _hit_lines(
+    index: int,
+    hit: dict,
+    embed_cap: int,
+    cmd_cap: int,
+    design_cap: int,
+) -> list[str]:
     """Render a single retrieval hit as a list of context lines."""
     score = round(1.0 - hit.get("_distance", 1.0), 4)
     ts = hit.get("captured_at", 0)
@@ -109,17 +115,10 @@ def _hit_lines(index: int, hit: dict, embed_cap: int, cmd_cap: int) -> list[str]
     # Render design_decisions verbatim — the "considered X, chose Y, reason Z"
     # structure is exactly what the synthesis LLM needs to answer questions
     # about why a particular approach was picked. (Issue #98 F3.)
-    design_decisions = hit.get("design_decisions") or []
-    if isinstance(design_decisions, list) and design_decisions:
+    design_lines = _render_design_decision_lines(hit.get("design_decisions") or [], design_cap)
+    if design_lines:
         lines.append("Design decisions:")
-        for d in design_decisions:
-            if not isinstance(d, dict):
-                continue
-            considered = d.get("considered", "")
-            chosen = d.get("chosen", "")
-            reason = d.get("reason", "")
-            if considered and chosen and reason:
-                lines.append(f"  - considered {considered!r}; chose {chosen!r}; reason: {reason}")
+        lines.extend(design_lines)
     if hit.get("commands_raw"):
         lines.append(f"Commands: {_truncate(hit['commands_raw'], cmd_cap)}")
     if hit.get("cwd"):
@@ -140,6 +139,32 @@ def _hit_lines(index: int, hit: dict, embed_cap: int, cmd_cap: int) -> list[str]
     return lines
 
 
+def _design_decision_payload(design_decisions: list[dict] | object) -> str:
+    """Render valid design_decisions entries as plain text for budgeting."""
+    if not isinstance(design_decisions, list):
+        return ""
+    rendered: list[str] = []
+    for decision in design_decisions:
+        if not isinstance(decision, dict):
+            continue
+        considered = decision.get("considered", "")
+        chosen = decision.get("chosen", "")
+        reason = decision.get("reason", "")
+        if considered and chosen and reason:
+            rendered.append(f"  - considered {considered!r}; chose {chosen!r}; reason: {reason}")
+    return "\n".join(rendered)
+
+
+def _render_design_decision_lines(
+    design_decisions: list[dict] | object, max_chars: int
+) -> list[str]:
+    """Render design_decisions under a total character cap."""
+    payload = _design_decision_payload(design_decisions)
+    if not payload or max_chars <= 0:
+        return []
+    return _truncate(payload, max_chars).splitlines()
+
+
 def _build_rag_prompt(
     question: str,
     hits: list[dict],
@@ -148,43 +173,49 @@ def _build_rag_prompt(
     """Build chat messages for the synthesis LLM from question + retrieved hits.
 
     If the rendered context exceeds ``max_chars``, the long per-hit fields
-    (``embed_text`` and ``commands_raw``) are truncated proportionally so the
-    final prompt fits the budget.
+    (``embed_text``, ``commands_raw``, and ``design_decisions``) are truncated
+    proportionally so the final prompt fits the budget.
     """
     # First pass: render with generous caps.
     embed_cap = 2_000
     cmd_cap = 2_000
-    blocks = ["\n".join(_hit_lines(i, h, embed_cap, cmd_cap)) for i, h in enumerate(hits, 1)]
+    blocks = [
+        "\n".join(_hit_lines(i, h, embed_cap, cmd_cap, cmd_cap)) for i, h in enumerate(hits, 1)
+    ]
     total = sum(len(b) for b in blocks) + max(0, (len(blocks) - 1)) * 2
 
     if total > max_chars and hits:
         # How much budget is consumed by structural text (headers, cwd, tags, etc)
         # that we don't want to truncate? Approximate by re-rendering with the
-        # two big fields stripped.
+        # large payload fields stripped.
         structural = 0
         for i, h in enumerate(hits, 1):
             stripped = dict(h)
             stripped["embed_text"] = ""
             stripped["commands_raw"] = ""
-            structural += len("\n".join(_hit_lines(i, stripped, 0, 0)))
+            stripped["design_decisions"] = []
+            structural += len("\n".join(_hit_lines(i, stripped, 0, 0, 0)))
         structural += max(0, (len(hits) - 1)) * 2
 
         remaining = max(max_chars - structural, _MIN_PER_HIT_FIELD_CHARS * len(hits))
         # Split remaining budget across hits, then split per-hit budget across
-        # embed_text and commands_raw proportionally to their current sizes.
+        # embed_text, commands_raw, and design_decisions proportionally to their
+        # current rendered sizes.
         per_hit = max(remaining // max(len(hits), 1), _MIN_PER_HIT_FIELD_CHARS)
 
         blocks = []
         for i, h in enumerate(hits, 1):
             e_len = len(h.get("embed_text", "") or "")
             c_len = len(h.get("commands_raw", "") or "")
-            total_payload = e_len + c_len
+            d_len = len(_design_decision_payload(h.get("design_decisions") or []))
+            total_payload = e_len + c_len + d_len
             if total_payload == 0:
-                e_cap = c_cap = per_hit // 2
+                e_cap = c_cap = d_cap = 0
             else:
-                e_cap = max(int(per_hit * e_len / total_payload), 40) if e_len else 0
-                c_cap = max(per_hit - e_cap, 40) if c_len else 0
-            blocks.append("\n".join(_hit_lines(i, h, e_cap, c_cap)))
+                e_cap = (per_hit * e_len) // total_payload if e_len else 0
+                c_cap = (per_hit * c_len) // total_payload if c_len else 0
+                d_cap = per_hit - e_cap - c_cap
+            blocks.append("\n".join(_hit_lines(i, h, e_cap, c_cap, d_cap)))
 
     context = "\n\n".join(blocks)
     return [
@@ -291,6 +322,7 @@ def _result_to_hit(r: SearchResult) -> dict:
         "captured_at": r.captured_at,
         "outcome": r.outcome or "",
         "tags": json.dumps(r.tags) if r.tags else "",
+        "design_decisions": list(r.design_decisions),
         "uuid": r.uuid,
         "linked_event_ids": list(r.linked_event_ids),
     }

--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -106,6 +106,20 @@ def _hit_lines(index: int, hit: dict, embed_cap: int, cmd_cap: int) -> list[str]
         lines.append(f"Summary: {hit['summary']}")
     if hit.get("embed_text"):
         lines.append(f"Detail: {_truncate(hit['embed_text'], embed_cap)}")
+    # Render design_decisions verbatim — the "considered X, chose Y, reason Z"
+    # structure is exactly what the synthesis LLM needs to answer questions
+    # about why a particular approach was picked. (Issue #98 F3.)
+    design_decisions = hit.get("design_decisions") or []
+    if isinstance(design_decisions, list) and design_decisions:
+        lines.append("Design decisions:")
+        for d in design_decisions:
+            if not isinstance(d, dict):
+                continue
+            considered = d.get("considered", "")
+            chosen = d.get("chosen", "")
+            reason = d.get("reason", "")
+            if considered and chosen and reason:
+                lines.append(f"  - considered {considered!r}; chose {chosen!r}; reason: {reason}")
     if hit.get("commands_raw"):
         lines.append(f"Commands: {_truncate(hit['commands_raw'], cmd_cap)}")
     if hit.get("cwd"):

--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -165,6 +165,49 @@ def _render_design_decision_lines(
     return _truncate(payload, max_chars).splitlines()
 
 
+def _allocate_payload_caps(
+    per_hit: int, *, embed_len: int, cmd_len: int, design_len: int
+) -> tuple[int, int, int]:
+    """Split one hit's payload budget across embed/cmd/design fields.
+
+    Uses proportional floor division, distributes any remainder to the largest
+    fields, and preserves at least one character for each non-empty field when
+    the per-hit budget is large enough to do so.
+    """
+    lengths = {
+        "embed": max(embed_len, 0),
+        "cmd": max(cmd_len, 0),
+        "design": max(design_len, 0),
+    }
+    total = sum(lengths.values())
+    if total == 0:
+        return 0, 0, 0
+
+    caps = {name: (per_hit * length) // total if length else 0 for name, length in lengths.items()}
+    remainder = per_hit - sum(caps.values())
+
+    ranked = sorted(lengths, key=lambda name: lengths[name], reverse=True)
+    for name in ranked:
+        if remainder <= 0:
+            break
+        if lengths[name]:
+            caps[name] += 1
+            remainder -= 1
+
+    non_empty = [name for name, length in lengths.items() if length]
+    if per_hit >= len(non_empty):
+        for name in non_empty:
+            if caps[name] > 0:
+                continue
+            donor = next((candidate for candidate in ranked if caps[candidate] > 1), None)
+            if donor is None:
+                break
+            caps[donor] -= 1
+            caps[name] = 1
+
+    return caps["embed"], caps["cmd"], caps["design"]
+
+
 def _build_rag_prompt(
     question: str,
     hits: list[dict],
@@ -210,15 +253,16 @@ def _build_rag_prompt(
             d_len = len(_design_decision_payload(h.get("design_decisions") or []))
             total_payload = e_len + c_len + d_len
             if total_payload == 0:
-                # Structural fields (summary/cwd/tags/etc.) still render; only
-                # payload-heavy fields get a zero cap in this branch.
+                # All payload-heavy fields are suppressed in this branch;
+                # structural fields (summary/cwd/tags/etc.) still render.
                 e_cap = c_cap = d_cap = 0
             else:
-                e_cap = (per_hit * e_len) // total_payload if e_len else 0
-                c_cap = (per_hit * c_len) // total_payload if c_len else 0
-                # The final field absorbs rounding remainder so the caps sum to
-                # exactly per_hit instead of drifting upward.
-                d_cap = per_hit - e_cap - c_cap
+                e_cap, c_cap, d_cap = _allocate_payload_caps(
+                    per_hit,
+                    embed_len=e_len,
+                    cmd_len=c_len,
+                    design_len=d_len,
+                )
             blocks.append("\n".join(_hit_lines(i, h, e_cap, c_cap, d_cap)))
 
     context = "\n\n".join(blocks)

--- a/brain/src/hippo_brain/retrieval.py
+++ b/brain/src/hippo_brain/retrieval.py
@@ -457,6 +457,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
     details: dict[int, dict] = {}
     for node_id, uuid, content_str, embed_text, outcome, tags_str, created_at in rows:
         summary = _extract_summary(content_str)
+        design_decisions = _extract_design_decisions(content_str)
         tags = _parse_tags(tags_str)
         details[node_id] = {
             "id": node_id,
@@ -465,6 +466,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
             "embed_text": embed_text or "",
             "outcome": outcome,
             "tags": tags,
+            "design_decisions": design_decisions,
             "cwd": "",
             "git_branch": "",
             "captured_at": created_at,
@@ -649,6 +651,28 @@ def _extract_summary(content_str: str | None) -> str:
     if isinstance(payload, dict):
         return payload.get("summary") or ""
     return ""
+
+
+def _extract_design_decisions(content_str: str | None) -> list[dict]:
+    """Extract design_decisions list from a knowledge_node content JSON blob.
+
+    Older nodes (pre-issue #98) won't have this key; return an empty list so
+    the RAG context renderer can skip it cleanly. Each surviving entry is
+    expected to be a dict with `considered`, `chosen`, `reason` keys —
+    written through `validate_enrichment_data` so the shape is enforced.
+    """
+    if not content_str:
+        return []
+    try:
+        payload = json.loads(content_str)
+    except json.JSONDecodeError, TypeError:
+        return []
+    if not isinstance(payload, dict):
+        return []
+    raw = payload.get("design_decisions")
+    if not isinstance(raw, list):
+        return []
+    return [entry for entry in raw if isinstance(entry, dict)]
 
 
 def _parse_tags(tags_str: str | None) -> list[str]:

--- a/brain/src/hippo_brain/retrieval.py
+++ b/brain/src/hippo_brain/retrieval.py
@@ -46,6 +46,7 @@ class SearchResult:
     cwd: str
     git_branch: str
     captured_at: int
+    design_decisions: list[dict] = field(default_factory=list)
     linked_event_ids: list[int] = field(default_factory=list)
 
 
@@ -625,6 +626,7 @@ def _to_result(score: float, detail: dict | None) -> SearchResult:
             cwd="",
             git_branch="",
             captured_at=0,
+            design_decisions=[],
             linked_event_ids=[],
         )
     return SearchResult(
@@ -637,6 +639,7 @@ def _to_result(score: float, detail: dict | None) -> SearchResult:
         cwd=detail["cwd"],
         git_branch=detail["git_branch"],
         captured_at=detail["captured_at"],
+        design_decisions=list(detail.get("design_decisions") or []),
         linked_event_ids=list(detail["linked_event_ids"]),
     )
 

--- a/brain/tests/test_claude_sessions.py
+++ b/brain/tests/test_claude_sessions.py
@@ -270,6 +270,26 @@ class TestBuildClaudeEnrichmentPrompt:
         assert "Read: /src/enrichment.py" in prompt
         assert "Looking at enrichment.py" in prompt
 
+    def test_strips_worktree_from_cwd(self):
+        """Issue #98 F1c: Claude segment cwd from an agent worktree must be
+        normalized to the parent repo path before reaching the LLM.
+        """
+        seg = SessionSegment(
+            session_id="s1",
+            project_dir="proj",
+            cwd="/projects/hippo/.claude/worktrees/agent-ac83d4d3/crates/hippo-core",
+            git_branch="main",
+            segment_index=0,
+            start_time=1711612800000,
+            end_time=1711614600000,
+            user_prompts=["test"],
+            message_count=1,
+        )
+        prompt = build_claude_enrichment_prompt([seg])
+        assert "/projects/hippo/crates/hippo-core" in prompt
+        assert ".claude/worktrees" not in prompt
+        assert "agent-ac83d4d3" not in prompt
+
 
 class TestInsertAndClaim:
     def test_insert_segment(self, tmp_db):

--- a/brain/tests/test_claude_sessions.py
+++ b/brain/tests/test_claude_sessions.py
@@ -431,6 +431,66 @@ class TestInsertAndClaim:
         ).fetchone()
         assert status[0] == "done"
 
+    def test_write_claude_knowledge_node_persists_design_decisions(self, tmp_db):
+        """Protect the Claude-session writer's content JSON shape.
+
+        This function overlaps with PR #101's content-hash propagation changes,
+        so pinning `design_decisions` here helps catch a bad conflict
+        resolution that keeps one change but drops the other.
+        """
+        db_conn, _ = tmp_db
+        seg = SessionSegment(
+            session_id="kn-session-design",
+            project_dir="proj",
+            cwd="/test",
+            git_branch="main",
+            segment_index=0,
+            start_time=1000,
+            end_time=2000,
+            user_prompts=["test"],
+            message_count=1,
+            source_file="/tmp/test.jsonl",
+        )
+        seg_id = insert_segment(db_conn, seg)
+
+        result = EnrichmentResult(
+            summary="Test summary",
+            intent="testing",
+            outcome="success",
+            entities={
+                "projects": ["test"],
+                "tools": ["cargo"],
+                "files": [],
+                "services": [],
+                "errors": [],
+            },
+            tags=["test"],
+            embed_text="Test embed text for search",
+            key_decisions=["chose testing approach"],
+            problems_encountered=[],
+            design_decisions=[
+                {
+                    "considered": "plain prose summary only",
+                    "chosen": "structured design_decisions field",
+                    "reason": "better why-X-over-Y recall",
+                }
+            ],
+        )
+
+        node_id = write_claude_knowledge_node(db_conn, result, [seg_id], "test-model")
+        row = db_conn.execute(
+            "SELECT content FROM knowledge_nodes WHERE id = ?",
+            (node_id,),
+        ).fetchone()
+        content = json.loads(row[0])
+        assert content["design_decisions"] == [
+            {
+                "considered": "plain prose summary only",
+                "chosen": "structured design_decisions field",
+                "reason": "better why-X-over-Y recall",
+            }
+        ]
+
         # Verify entities created
         entity = db_conn.execute(
             "SELECT name FROM entities WHERE type = 'project' AND canonical = 'test'"

--- a/brain/tests/test_codex_sessions.py
+++ b/brain/tests/test_codex_sessions.py
@@ -702,6 +702,30 @@ def test_extract_codex_segments_skips_entries_with_non_dict_payload():
         assert segments[0].user_prompts == ["real"]
 
 
+def test_build_codex_enrichment_summary_strips_worktree_from_cwd():
+    """Issue #98 F1c: Codex segment cwd from an agent worktree must be
+    normalized to the parent repo path before reaching the LLM.
+    """
+    from hippo_brain.claude_sessions import SessionSegment
+
+    seg = SessionSegment(
+        session_id="s1",
+        project_dir="demo",
+        cwd="/projects/hippo/.claude/worktrees/feat-watchdog/crates/hippo-core",
+        git_branch=None,
+        segment_index=0,
+        start_time=1711612800000,
+        end_time=1711614600000,
+        user_prompts=["x"],
+        message_count=1,
+        source="codex",
+    )
+    out = build_codex_enrichment_summary([seg])
+    assert "/projects/hippo/crates/hippo-core" in out
+    assert ".claude/worktrees" not in out
+    assert "feat-watchdog" not in out
+
+
 def test_build_codex_enrichment_summary_includes_tools_and_assistant():
     """build_codex_enrichment_summary renders tool_calls and
     assistant_texts sections when present — the enrichment prompt relies

--- a/brain/tests/test_enrichment.py
+++ b/brain/tests/test_enrichment.py
@@ -31,6 +31,45 @@ def test_build_enrichment_prompt():
     assert "abc1234" in prompt
 
 
+def test_build_enrichment_prompt_strips_worktree_from_cwd():
+    """Issue #98 F1c: cwd values from agent worktrees must be normalized to
+    the parent repo path before reaching the LLM, otherwise generated entities
+    inherit the ephemeral worktree prefix.
+    """
+    events = [
+        {
+            "command": "cargo test",
+            "exit_code": 0,
+            "duration_ms": 1000,
+            "cwd": "/Users/dev/projects/hippo/.claude/worktrees/agent-ac83d4d3/crates/hippo-core",
+            "git_branch": "main",
+        }
+    ]
+    prompt = build_enrichment_prompt(events)
+    assert "/Users/dev/projects/hippo/crates/hippo-core" in prompt
+    assert ".claude/worktrees" not in prompt
+    assert "agent-ac83d4d3" not in prompt
+
+
+def test_build_enrichment_prompt_strips_non_agent_worktree_styles():
+    """Worktree subdirectories aren't always `agent-*` — also `feat-*`,
+    adjective-noun-hex, etc. The strip must be name-agnostic.
+    """
+    for wt_name in ("feat-p1.1a-watchdog", "gracious-williamson-8c3e1f"):
+        events = [
+            {
+                "command": "ls",
+                "exit_code": 0,
+                "duration_ms": 5,
+                "cwd": f"/Users/dev/projects/hippo/.claude/worktrees/{wt_name}/src",
+                "git_branch": "main",
+            }
+        ]
+        prompt = build_enrichment_prompt(events)
+        assert wt_name not in prompt, f"worktree segment {wt_name!r} not stripped"
+        assert "/Users/dev/projects/hippo/src" in prompt
+
+
 def test_parse_enrichment_response():
     raw = (
         '{"summary": "Ran tests", "intent": "testing", "outcome": "success", '
@@ -112,6 +151,59 @@ def test_parse_rejects_entities_not_dict():
 def test_parse_rejects_invalid_json():
     with pytest.raises(json.JSONDecodeError):
         parse_enrichment_response("not json")
+
+
+# ---------------------------------------------------------------------------
+# Issue #98 F3: design_decisions field validation.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_design_decisions_accepts_valid_entries():
+    data = _valid_enrichment_dict(
+        design_decisions=[
+            {
+                "considered": "Stage GUI inside /Applications/.hippo-staging/HippoGUI.app",
+                "chosen": "Stage GUI in $TMPDIR, swap via mv to /Applications",
+                "reason": "Launch Services crawls /Applications recursively and may register the transient hidden bundle",
+            }
+        ]
+    )
+    result = parse_enrichment_response(json.dumps(data))
+    assert len(result.design_decisions) == 1
+    entry = result.design_decisions[0]
+    assert entry["considered"].startswith("Stage GUI inside /Applications/")
+    assert entry["chosen"].startswith("Stage GUI in $TMPDIR")
+    assert "Launch Services" in entry["reason"]
+
+
+def test_parse_design_decisions_skips_partial_entries():
+    """An entry missing any of considered/chosen/reason is dropped — partial
+    decisions are worse than no decision because they cannot be trusted.
+    """
+    data = _valid_enrichment_dict(
+        design_decisions=[
+            {"considered": "X", "chosen": "Y", "reason": "Z"},  # valid
+            {"considered": "X", "chosen": "Y"},  # missing reason — drop
+            {"chosen": "Y", "reason": "Z"},  # missing considered — drop
+            {"considered": "", "chosen": "Y", "reason": "Z"},  # empty string — drop
+            "not a dict",  # wrong type — drop
+        ]
+    )
+    result = parse_enrichment_response(json.dumps(data))
+    assert len(result.design_decisions) == 1
+    assert result.design_decisions[0] == {"considered": "X", "chosen": "Y", "reason": "Z"}
+
+
+def test_parse_design_decisions_default_empty():
+    data = _valid_enrichment_dict()  # no design_decisions key
+    result = parse_enrichment_response(json.dumps(data))
+    assert result.design_decisions == []
+
+
+def test_parse_design_decisions_non_list_becomes_empty():
+    data = _valid_enrichment_dict(design_decisions="not a list")
+    result = parse_enrichment_response(json.dumps(data))
+    assert result.design_decisions == []
 
 
 def test_claim_and_write(tmp_db):
@@ -471,6 +563,46 @@ def test_write_knowledge_node_stores_key_decisions(tmp_db):
     content = json.loads(row[0])
     assert content["key_decisions"] == ["Chose build.rs over vergen for zero deps"]
     assert content["problems_encountered"] == ["clippy warning on unused import"]
+
+
+def test_write_knowledge_node_persists_design_decisions(tmp_db):
+    """Issue #98 F3: design_decisions must round-trip through the content JSON
+    blob so RAG retrieval can surface them later.
+    """
+    conn, _ = tmp_db
+    _seed_event_with_queue(conn, event_id=1)
+
+    result = EnrichmentResult(
+        summary="Picked staging strategy",
+        intent="design",
+        outcome="success",
+        entities={
+            "projects": ["hippo"],
+            "tools": [],
+            "files": [],
+            "services": [],
+            "errors": [],
+        },
+        tags=["install"],
+        embed_text="GUI staging $TMPDIR /Applications Launch Services",
+        design_decisions=[
+            {
+                "considered": "Stage GUI inside /Applications/.hippo-staging/HippoGUI.app",
+                "chosen": "Stage GUI in $TMPDIR, mv to /Applications atomically",
+                "reason": "Launch Services crawls /Applications recursively",
+            }
+        ],
+    )
+
+    node_id = write_knowledge_node(conn, result, [1], "test-model")
+    row = conn.execute("SELECT content FROM knowledge_nodes WHERE id = ?", (node_id,)).fetchone()
+    content = json.loads(row[0])
+
+    assert len(content["design_decisions"]) == 1
+    entry = content["design_decisions"][0]
+    assert entry["considered"].startswith("Stage GUI inside /Applications")
+    assert entry["chosen"].startswith("Stage GUI in $TMPDIR")
+    assert "Launch Services" in entry["reason"]
 
 
 # ---------------------------------------------------------------------------

--- a/brain/tests/test_entity_resolver.py
+++ b/brain/tests/test_entity_resolver.py
@@ -9,6 +9,7 @@ from hippo_brain.entity_resolver import (
     _cached_fallback_roots,
     _resolve_project_roots,
     canonicalize,
+    strip_worktree_prefix,
 )
 
 SCHEMA_PATH = Path(__file__).parent.parent.parent / "crates" / "hippo-core" / "src" / "schema.sql"
@@ -268,3 +269,172 @@ class TestExactRootMatchBasename:
         r2 = canonicalize("directory", "/users/carpenter/projects/hippo", project_roots=roots)
         assert r1 == r2 == "hippo"
         assert r1 != ""
+
+
+# ---------------------------------------------------------------------------
+# Worktree-prefix stripping (issue #98 — F1: ephemeral parallel-agent worktree
+# pollution). The worktree subdirectory naming scheme is NOT just `agent-*`;
+# Claude Code names worktrees with a mix of schemes, so the stripping must be
+# segment-name agnostic.
+# ---------------------------------------------------------------------------
+
+
+class TestStripWorktreePrefix:
+    def test_strip_agent_worktree(self):
+        assert (
+            strip_worktree_prefix(
+                "/users/carpenter/projects/hippo/.claude/worktrees/agent-ac83d4d3/src/foo.rs"
+            )
+            == "/users/carpenter/projects/hippo/src/foo.rs"
+        )
+
+    def test_strip_feat_worktree(self):
+        # `feat-p1.1a-watchdog-core` style — does NOT start with `agent-`.
+        assert (
+            strip_worktree_prefix(
+                "/users/carpenter/projects/hippo/.claude/worktrees/feat-p1.1a-watchdog-core/src/foo.rs"
+            )
+            == "/users/carpenter/projects/hippo/src/foo.rs"
+        )
+
+    def test_strip_adjective_noun_worktree(self):
+        # `gracious-williamson-8c3e1f` style — Claude Code's adjective-noun-hex namer.
+        assert (
+            strip_worktree_prefix(
+                "/users/carpenter/projects/hippo/.claude/worktrees/gracious-williamson-8c3e1f/src/foo.rs"
+            )
+            == "/users/carpenter/projects/hippo/src/foo.rs"
+        )
+
+    def test_strip_noop_on_non_worktree_path(self):
+        assert (
+            strip_worktree_prefix("/users/carpenter/projects/hippo/src/foo.rs")
+            == "/users/carpenter/projects/hippo/src/foo.rs"
+        )
+
+    def test_strip_handles_relative_path(self):
+        assert (
+            strip_worktree_prefix(".claude/worktrees/agent-XX/crates/hippo-daemon/src/foo.rs")
+            == "crates/hippo-daemon/src/foo.rs"
+        )
+
+    def test_strip_only_one_segment(self):
+        # Only the segment immediately after `worktrees/` is stripped — nested
+        # worktrees would be unusual but the regex must not greedily eat more.
+        assert (
+            strip_worktree_prefix(
+                "/repo/.claude/worktrees/agent-XX/.claude/worktrees/agent-YY/file.txt"
+            )
+            == "/repo/file.txt"
+        )
+
+    def test_strip_does_not_match_directory_named_like_worktree(self):
+        # A directory literally named ".claude/worktrees/foo" with no trailing
+        # slash (i.e. the worktree IS the leaf) is preserved — without a
+        # trailing slash there's no segment AFTER the worktree dir to anchor on.
+        assert (
+            strip_worktree_prefix("/repo/.claude/worktrees/agent-XX")
+            == "/repo/.claude/worktrees/agent-XX"
+        )
+
+
+class TestCanonicalizeStripsWorktreeBeforeProjectRoot:
+    """canonicalize() must strip the worktree segment BEFORE the project-root
+    strip, otherwise the project-root no longer matches the prefix of the
+    worktree path.
+    """
+
+    def test_agent_worktree_collapses_to_canonical(self):
+        roots = ["/users/carpenter/projects/hippo"]
+        result = canonicalize(
+            "file",
+            "/users/carpenter/projects/hippo/.claude/worktrees/agent-ac83d4d3/crates/hippo-daemon/src/schema_handshake.rs",
+            project_roots=roots,
+        )
+        assert result == "crates/hippo-daemon/src/schema_handshake.rs"
+
+    def test_canonical_path_and_worktree_path_resolve_same(self):
+        roots = ["/users/carpenter/projects/hippo"]
+        canonical_input = (
+            "/users/carpenter/projects/hippo/crates/hippo-daemon/src/schema_handshake.rs"
+        )
+        worktree_input = "/users/carpenter/projects/hippo/.claude/worktrees/agent-ac83d4d3/crates/hippo-daemon/src/schema_handshake.rs"
+        a = canonicalize("file", canonical_input, project_roots=roots)
+        b = canonicalize("file", worktree_input, project_roots=roots)
+        assert a == b == "crates/hippo-daemon/src/schema_handshake.rs"
+
+    def test_three_different_worktree_styles_all_collapse(self):
+        roots = ["/users/carpenter/projects/hippo"]
+        paths = [
+            "/users/carpenter/projects/hippo/.claude/worktrees/agent-ac83d4d3/src/foo.rs",
+            "/users/carpenter/projects/hippo/.claude/worktrees/feat-p1.1a-watchdog/src/foo.rs",
+            "/users/carpenter/projects/hippo/.claude/worktrees/gracious-williamson-8c3e1f/src/foo.rs",
+        ]
+        results = {canonicalize("file", p, project_roots=roots) for p in paths}
+        assert results == {"src/foo.rs"}
+
+    def test_dedup_collapses_worktree_polluted_entities(self, monkeypatch):
+        """End-to-end: existing dedup-entities.py picks up worktree-polluted
+        rows now that canonicalize strips the worktree segment.
+        """
+        monkeypatch.setenv("HIPPO_PROJECT_ROOTS", "/users/carpenter/projects/hippo")
+
+        conn, db_path = _make_db()
+        try:
+            now_ms = 1_700_000_000_000
+            # Insert canonical + 3 worktree variants of the same file.
+            conn.execute(
+                "INSERT INTO entities (type, name, canonical, first_seen, last_seen, created_at) VALUES (?,?,?,?,?,?)",
+                (
+                    "file",
+                    "/users/carpenter/projects/hippo/crates/hippo-daemon/src/schema_handshake.rs",
+                    "/users/carpenter/projects/hippo/crates/hippo-daemon/src/schema_handshake.rs",
+                    now_ms,
+                    now_ms,
+                    now_ms,
+                ),
+            )
+            for i, wt in enumerate(
+                [
+                    "agent-ac83d4d3",
+                    "agent-a5642c4b",
+                    "feat-p1.1a-watchdog",
+                ],
+                start=1,
+            ):
+                conn.execute(
+                    "INSERT INTO entities (type, name, canonical, first_seen, last_seen, created_at) VALUES (?,?,?,?,?,?)",
+                    (
+                        "file",
+                        f"/users/carpenter/projects/hippo/.claude/worktrees/{wt}/crates/hippo-daemon/src/schema_handshake.rs",
+                        f"/users/carpenter/projects/hippo/.claude/worktrees/{wt}/crates/hippo-daemon/src/schema_handshake.rs",
+                        now_ms + i,
+                        now_ms + i,
+                        now_ms + i,
+                    ),
+                )
+            conn.commit()
+
+            import importlib.util
+            import sys
+
+            scripts_root = Path(__file__).parent.parent / "scripts"
+            spec = importlib.util.spec_from_file_location(
+                "dedup_entities_worktree", scripts_root / "dedup-entities.py"
+            )
+            assert spec is not None and spec.loader is not None
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["dedup_entities_worktree"] = mod
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+            stats = mod.run(conn, dry_run=False)
+
+            rows = conn.execute("SELECT canonical FROM entities").fetchall()
+            assert len(rows) == 1
+            assert rows[0]["canonical"] == "crates/hippo-daemon/src/schema_handshake.rs"
+            assert stats["deleted"] == 3
+        finally:
+            conn.close()
+            db_path.unlink(missing_ok=True)
+            db_path.with_suffix(".db-wal").unlink(missing_ok=True)
+            db_path.with_suffix(".db-shm").unlink(missing_ok=True)

--- a/brain/tests/test_entity_resolver.py
+++ b/brain/tests/test_entity_resolver.py
@@ -328,14 +328,8 @@ class TestStripWorktreePrefix:
             == "/repo/file.txt"
         )
 
-    def test_strip_does_not_match_directory_named_like_worktree(self):
-        # A directory literally named ".claude/worktrees/foo" with no trailing
-        # slash (i.e. the worktree IS the leaf) is preserved — without a
-        # trailing slash there's no segment AFTER the worktree dir to anchor on.
-        assert (
-            strip_worktree_prefix("/repo/.claude/worktrees/agent-XX")
-            == "/repo/.claude/worktrees/agent-XX"
-        )
+    def test_strip_leaf_worktree_directory(self):
+        assert strip_worktree_prefix("/repo/.claude/worktrees/agent-XX") == "/repo"
 
 
 class TestCanonicalizeStripsWorktreeBeforeProjectRoot:

--- a/brain/tests/test_mcp_server_extended.py
+++ b/brain/tests/test_mcp_server_extended.py
@@ -132,6 +132,7 @@ class TestSearchHybridTool:
             "cwd",
             "git_branch",
             "captured_at",
+            "design_decisions",
             "linked_event_ids",
         }
         assert expected_keys.issubset(r.keys()), (

--- a/brain/tests/test_rag.py
+++ b/brain/tests/test_rag.py
@@ -226,6 +226,25 @@ class TestBuildRagPrompt:
         assert "considered 'X'" in user
         assert "considered 'A'" not in user
 
+    def test_design_decisions_are_truncated_with_context_budget(self):
+        hit = dict(
+            SAMPLE_HITS[0],
+            embed_text="",
+            commands_raw="",
+            design_decisions=[
+                {
+                    "considered": "A" * 400,
+                    "chosen": "B" * 400,
+                    "reason": "C" * 400,
+                }
+            ],
+        )
+        messages = _build_rag_prompt("test", [hit], max_chars=220)
+        user = messages[1]["content"]
+        assert "Design decisions:" in user
+        assert "…" in user
+        assert ("A" * 200) not in user
+
 
 class TestFormatRagResponse:
     def test_formats_answer_and_sources(self):
@@ -481,6 +500,7 @@ def _fake_search_result(**overrides):
         cwd="/home/user/projects/hippo",
         git_branch="postgres",
         captured_at=1743379200000,
+        design_decisions=[],
         linked_event_ids=[42, 43],
     )
     base.update(overrides)
@@ -621,6 +641,35 @@ class TestFilteredRetrievalRouting:
             assert result["sources"][1]["linked_event_ids"] == []
             # Score round-trips from SearchResult.score through the _distance adapter.
             assert result["sources"][0]["score"] == pytest.approx(0.91, abs=0.001)
+        finally:
+            sentinel_conn.close()
+
+    @pytest.mark.asyncio
+    async def test_filters_path_surfaces_design_decisions_in_prompt(self):
+        client = _healthy_client(chat_return="ok")
+        sentinel_conn = sqlite3.connect(":memory:")
+        try:
+            with patch("hippo_brain.rag.retrieval_search") as retrieval_mock:
+                retrieval_mock.return_value = [
+                    _fake_search_result(
+                        design_decisions=[
+                            {
+                                "considered": "sqlite direct reads",
+                                "chosen": "hybrid retrieval",
+                                "reason": "better recall",
+                            }
+                        ]
+                    )
+                ]
+                await ask(
+                    "why hybrid?", client, None, "m", "e", project="/home/user", conn=sentinel_conn
+                )
+
+            prompt = client.chat.call_args.args[0][1]["content"]
+            assert "Design decisions:" in prompt
+            assert "sqlite direct reads" in prompt
+            assert "hybrid retrieval" in prompt
+            assert "better recall" in prompt
         finally:
             sentinel_conn.close()
 

--- a/brain/tests/test_rag.py
+++ b/brain/tests/test_rag.py
@@ -185,6 +185,47 @@ class TestBuildRagPrompt:
         # No truncation ellipsis should appear for this small corpus
         assert "…" not in context
 
+    def test_design_decisions_rendered_in_context(self):
+        """Issue #98 F3: when a hit carries `design_decisions`, the
+        considered/chosen/reason structure must surface in the synthesis prompt
+        so the LLM can answer "why X over Y" questions accurately.
+        """
+        hit = dict(
+            SAMPLE_HITS[0],
+            design_decisions=[
+                {
+                    "considered": "Stage GUI inside /Applications/.hippo-staging/HippoGUI.app",
+                    "chosen": "Stage GUI in $TMPDIR, mv to /Applications atomically",
+                    "reason": "Launch Services crawls /Applications recursively",
+                }
+            ],
+        )
+        messages = _build_rag_prompt("why $TMPDIR?", [hit])
+        user = messages[1]["content"]
+        assert "Design decisions:" in user
+        assert "Stage GUI inside /Applications/.hippo-staging" in user
+        assert "Stage GUI in $TMPDIR" in user
+        assert "Launch Services crawls /Applications" in user
+
+    def test_design_decisions_omitted_when_empty(self):
+        hit = dict(SAMPLE_HITS[0], design_decisions=[])
+        messages = _build_rag_prompt("test", [hit])
+        assert "Design decisions:" not in messages[1]["content"]
+
+    def test_design_decisions_partial_entry_skipped_in_render(self):
+        hit = dict(
+            SAMPLE_HITS[0],
+            design_decisions=[
+                {"considered": "X", "chosen": "Y", "reason": "Z"},
+                {"considered": "A", "chosen": "B"},  # missing reason — render must skip
+                "garbage",  # wrong type — render must skip
+            ],
+        )
+        messages = _build_rag_prompt("test", [hit])
+        user = messages[1]["content"]
+        assert "considered 'X'" in user
+        assert "considered 'A'" not in user
+
 
 class TestFormatRagResponse:
     def test_formats_answer_and_sources(self):

--- a/brain/tests/test_retrieval.py
+++ b/brain/tests/test_retrieval.py
@@ -154,6 +154,7 @@ def _insert_node(
     node_id: int,
     *,
     summary: str = "",
+    content: dict | None = None,
     embed_text: str = "",
     tags: list[str] | None = None,
     outcome: str | None = None,
@@ -167,7 +168,7 @@ def _insert_node(
         (
             node_id,
             f"uuid-{node_id}",
-            json.dumps({"summary": summary}),
+            json.dumps(content if content is not None else {"summary": summary}),
             embed_text,
             node_type,
             outcome,
@@ -533,7 +534,16 @@ def test_search_result_includes_linked_event_ids_and_metadata(conn):
     _insert_node(
         conn,
         1,
-        summary="hello",
+        content={
+            "summary": "hello",
+            "design_decisions": [
+                {
+                    "considered": "sqlite direct reads",
+                    "chosen": "hybrid retrieval",
+                    "reason": "better recall",
+                }
+            ],
+        },
         embed_text="world",
         tags=["a", "b"],
         outcome="ok",
@@ -554,6 +564,13 @@ def test_search_result_includes_linked_event_ids_and_metadata(conn):
     assert result.cwd == "/proj"
     assert result.git_branch == "main"
     assert result.captured_at == 2000  # latest event timestamp wins
+    assert result.design_decisions == [
+        {
+            "considered": "sqlite direct reads",
+            "chosen": "hybrid retrieval",
+            "reason": "better recall",
+        }
+    ]
     assert sorted(result.linked_event_ids) == [10, 11]
 
 


### PR DESCRIPTION
Closes #98.

## Summary

Four fixes for the four findings in #98 — enrichment-quality issues that undermined MCP recall during dogfooding of v0.13.0.

## What changed

### F1 — Worktree path canonicalization (URGENT)
- New `strip_worktree_prefix()` in [entity_resolver.py](brain/src/hippo_brain/entity_resolver.py) strips `.claude/worktrees/<X>/` segments from path-type entity values.
- **Bug fix vs. issue's proposed regex:** the original regex checked `parts[i+2].startswith("agent-")`, which silently misses `feat-*`, `competent-*`, `gracious-*`, and other naming schemes Claude Code uses for worktrees. The new regex (`\.claude/worktrees/[^/]+/`) is segment-name agnostic.
- Applied at canonicalize time **before** the project-root strip (otherwise the worktree path no longer matches the project-root prefix).
- Same `strip_worktree_prefix()` is applied to `cwd` in all three prompt builders (shell, Claude session, Codex session) so the LLM sees the parent-repo path. The events table itself is **not** mutated — raw cwds are preserved.
- The existing [`dedup-entities.py`](brain/scripts/dedup-entities.py) script now sweeps up worktree pollution automatically because it re-canonicalizes through `canonicalize()`.

**Live-DB validation** (dry-run): 513 worktree-polluted rows, 359 duplicate groups queued for merge.

### F2 — Verbatim preservation
All three SYSTEM_PROMPTs now require exact preservation of identifiers (`[A-Z][A-Z0-9_]{2,}`), versions (`\d+\.\d+\.\d+`), package@version pairs, symbol names, and CLI flags. Explicit instruction: **omit rather than guess** — a hallucinated `HIPPO_FORCE_INSTALL` is worse than admitting `HIPPO_FORCE` was unknown.

### F4 — Identifier-dense embed_text
Same three prompts now describe `embed_text` as a search-friendly tag soup of symbol names, file paths, and command names — not polished prose. Density of search keys beats elegance for semantic retrieval.

### F3 — Structured `design_decisions`
- New optional `design_decisions: list[dict]` on `EnrichmentResult`. Each entry has `considered`, `chosen`, `reason` (all required strings; partial entries dropped during validation).
- Added to all three prompts.
- Persisted in `knowledge_nodes.content` JSON (no schema migration).
- Extracted in [retrieval.py](brain/src/hippo_brain/retrieval.py:642) and surfaced in [rag.py:_hit_lines](brain/src/hippo_brain/rag.py:107) so synthesis can answer "why X over Y" questions accurately.

## Acceptance criteria (from #98)

- [x] Forward fix: new file/event entities created in `.claude/worktrees/agent-*/` paths are stored under their canonical repo path
- [x] Backfill: existing `dedup-entities.py` collapses worktree pollution (live dry-run: 359 merges)
- [x] Enrichment prompt updated for verbatim preservation (all 3 prompts)
- [x] `embed_text` density biased toward identifiers (all 3 prompts)
- [x] `design_decisions` field shipped end-to-end (model → prompt → writer → retrieval → RAG render)

## Test plan

- [x] `uv run --project brain pytest brain/tests` — 746 passed, 1 skipped
- [x] `uv run --project brain ruff check brain/` — clean
- [x] `uv run --project brain ruff format --check brain/` — clean
- [x] `cargo test --workspace` — clean (no Rust changes, sanity check)
- [x] Manual `dedup-entities.py --dry-run` on live DB
- [ ] Operator runs `uv run --project brain python brain/scripts/dedup-entities.py` (no `--dry-run`) post-merge to actually collapse the 359 duplicate groups
- [ ] Probe enrichment quality on a future session (manual: ask the MCP about a recent commit's CVE bumps and verify the version strings come back verbatim)

## Notes / risks

- `design_decisions` is **only populated for new enrichments**. Old knowledge nodes have an empty list. The `_extract_design_decisions` helper handles missing keys gracefully.
- `workflow_enrichment.py` was reviewed but **not** changed: it produces a free-text summary, not a structured `EnrichmentResult`. No design_decisions or verbatim rules apply there.