### PR TITLE
fix(brain): tolerate raw control chars in LLM JSON output

### DIFF
--- a/brain/src/hippo_brain/enrichment.py
+++ b/brain/src/hippo_brain/enrichment.py
@@ -204,7 +204,11 @@ def parse_enrichment_response(raw: str) -> EnrichmentResult:
     text = re.sub(r"\n?```\s*$", "", text)
     text = text.strip()
 
-    data = json.loads(text)
+    # strict=False permits raw control characters (e.g. unescaped \n) inside
+    # string values. JSON spec disallows them, but local LLMs routinely emit
+    # them inside multi-line `summary`/`embed_text` values; rejecting these
+    # responses sends the retry loop into a hot loop of full-model inferences.
+    data = json.loads(text, strict=False)
     return validate_enrichment_data(data)
 
 

--- a/brain/tests/test_enrichment.py
+++ b/brain/tests/test_enrichment.py
@@ -153,6 +153,23 @@ def test_parse_rejects_invalid_json():
         parse_enrichment_response("not json")
 
 
+def test_parse_accepts_raw_control_chars_in_strings():
+    # Local LLMs (e.g. gpt-oss-120b) emit raw \n inside string values when
+    # generating multi-line summaries. JSON spec disallows it, but rejecting
+    # these responses puts the enrichment retry loop into a hot loop of
+    # full-model inferences. parse_enrichment_response must tolerate them.
+    raw = (
+        '{"summary": "line one\nline two\twith tab", '
+        '"intent": "testing", "outcome": "success", '
+        '"entities": {"projects": [], "tools": [], "files": [], '
+        '"services": [], "errors": []}, '
+        '"tags": [], "embed_text": "x"}'
+    )
+    result = parse_enrichment_response(raw)
+    assert "line one" in result.summary
+    assert "line two" in result.summary
+
+
 # ---------------------------------------------------------------------------
 # Issue #98 F3: design_decisions field validation.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `parse_enrichment_response` used the default strict `json.loads`, which rejects raw control characters (U+0000–U+001F) inside string values. Local LLMs — `gpt-oss-120b` in particular — routinely emit unescaped `\n` inside multi-line `summary` / `embed_text` values, so every claude enrichment was failing JSON parsing.
- Each failed batch ran the LLM 3 times (the retry budget), all rejected for the same structural reason, then immediately claimed the next batch and repeated. With a 120B-parameter enrichment model, this kept the GPU pinned even when the queue looked nearly idle.
- One-line fix: pass `strict=False` to `json.loads`. RFC-laxer but matches what LLMs actually produce. All other validation (missing fields, invalid `outcome`, non-dict `entities`, malformed JSON itself) continues to reject.

## Diagnosis

Discovered while dogfooding hippo's MCP. Observed symptoms:

- `enrichment_queue` had 1 pending, `claude_enrichment_queue` had 2 in `processing` — **not empty**, contrary to what surface metrics suggested.
- `brain.stderr.log` contained **1,856 `JSONDecodeError` entries**, all of the form `Invalid control character at: line 44 column 38`.
- LM Studio's `llmworker.js` was at 90% CPU continuously; brain process at 0.1% (so the brain wasn't busy *processing* — it was idling between blocking 120B inferences).

The pattern from the log was unambiguous:

```
WARNING:hippo_brain:claude enrichment attempt 1 failed: Invalid control character at: line 44 column 38
WARNING:hippo_brain:claude enrichment attempt 2 failed: Invalid control character at: line 44 column 38
WARNING:hippo_brain:claude enrichment attempt 3 failed: Invalid control character at: line 44 column 38
ERROR:hippo_brain:enrichment failed ... lm_studio_model='gpt-oss-120b' claim_age_ms=60538
INFO:hippo_brain:claimed 1 claude segments: [1740]    ← immediately reclaim, repeat
```

## Test plan

- [x] New regression test `test_parse_accepts_raw_control_chars_in_strings` — JSON containing literal `\n` and `\t` inside string values now parses successfully.
- [x] All existing `parse_*` tests still pass (12/12), including `test_parse_rejects_invalid_json` (verifies we still reject genuine malformed JSON, not just lax-parse anything).
- [x] Full brain test suite: **755 passed, 1 skipped, 1 xfailed, 1 xpassed**.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Post-merge: confirm `JSONDecodeError` count in `brain.stderr.log` stops growing within one brain polling cycle.
- [ ] Post-merge: confirm `claude_enrichment_queue` `processing` rows drain to zero.

## Out of scope (worth a separate look)

- **Skipped backlog.** `enrichment_queue` has 4,083 rows in `skipped`, `claude_enrichment_queue` has 73. These won't retry, so they're permanent gaps in the knowledge graph until something requeues them. Worth a follow-up to understand whether they were skipped for legit reasons or as collateral damage from this same bug.
- **Model choice.** `[models].enrichment` is currently `gpt-oss-120b` with a comment that says *"MoE, 35B total, 3B active — fast"*. That description is for **Qwen3.5 35B-A3B**, not gpt-oss-120b (120B parameters). The comment was likely copy-pasted from a previous model and not updated. Worth deciding whether 120B is intentional for daily enrichment given the cost-per-retry; the loaded `qwen3.6-35b-a3b-ud-mlx` would be cheaper while keeping similar quality.
- **Issue #98** (worktree pollution + verbatim facts) — already addressed by `80b8ced`. This PR is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)