### PR TITLE
fix(brain): strip worktree prefix from entity display name (#98 follow-up)

### DIFF
--- a/brain/src/hippo_brain/enrichment.py
+++ b/brain/src/hippo_brain/enrichment.py
@@ -3,7 +3,7 @@ import re
 import time
 import uuid
 
-from hippo_brain.entity_resolver import canonicalize, strip_worktree_prefix
+from hippo_brain.entity_resolver import canonicalize, is_path_type, strip_worktree_prefix
 from hippo_brain.models import EnrichmentResult, validate_enrichment_data
 from hippo_brain.watchdog import DEFAULT_LOCK_TIMEOUT_MS
 
@@ -97,14 +97,19 @@ def upsert_entities(conn, node_id: int, entities_dict, entity_type_map: dict, no
     entity_ids = []
     for key, entity_type in entity_type_map.items():
         for name in all_entities.get(key, []):
-            # Strip worktree prefix from the display name too — not just the
-            # canonical key. `canonical` deduplicates correctly, but `name` is
-            # what `mcp__hippo__get_entities` and the UI surface, and an
-            # ephemeral `.claude/worktrees/<X>/` prefix here means the first
-            # write from inside a worktree poisons the display name forever.
+            # For path-type entities, strip worktree prefix from the display
+            # name too — not just the canonical key. `canonical` deduplicates
+            # correctly, but `name` is what `mcp__hippo__get_entities` and the
+            # UI surface, and an ephemeral `.claude/worktrees/<X>/` prefix
+            # here means the first write from inside a worktree poisons the
+            # display name forever. Non-path entity types (errors stored as
+            # `concept`, etc.) are left verbatim — their values may legitimately
+            # contain `.claude/worktrees/...` substrings inside stack traces or
+            # diagnostic messages, and rewriting those would lose information
+            # while creating a name/canonical divergence.
             # On conflict, repair an existing polluted name with the new clean
             # one; otherwise leave it alone (avoid churn for stable rows).
-            display_name = strip_worktree_prefix(name)
+            display_name = strip_worktree_prefix(name) if is_path_type(entity_type) else name
             canonical = canonicalize(entity_type, name)
             cursor = conn.execute(
                 """

--- a/brain/src/hippo_brain/enrichment.py
+++ b/brain/src/hippo_brain/enrichment.py
@@ -97,15 +97,28 @@ def upsert_entities(conn, node_id: int, entities_dict, entity_type_map: dict, no
     entity_ids = []
     for key, entity_type in entity_type_map.items():
         for name in all_entities.get(key, []):
+            # Strip worktree prefix from the display name too — not just the
+            # canonical key. `canonical` deduplicates correctly, but `name` is
+            # what `mcp__hippo__get_entities` and the UI surface, and an
+            # ephemeral `.claude/worktrees/<X>/` prefix here means the first
+            # write from inside a worktree poisons the display name forever.
+            # On conflict, repair an existing polluted name with the new clean
+            # one; otherwise leave it alone (avoid churn for stable rows).
+            display_name = strip_worktree_prefix(name)
             canonical = canonicalize(entity_type, name)
             cursor = conn.execute(
                 """
                 INSERT INTO entities (type, name, canonical, first_seen, last_seen, created_at)
                 VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT (type, canonical) DO
-                UPDATE SET last_seen = excluded.last_seen
+                UPDATE SET last_seen = excluded.last_seen,
+                           name = CASE
+                               WHEN name LIKE '%.claude/worktrees/%'
+                                   THEN excluded.name
+                               ELSE name
+                           END
                 RETURNING id
                 """,
-                (entity_type, name, canonical, now_ms, now_ms, now_ms),
+                (entity_type, display_name, canonical, now_ms, now_ms, now_ms),
             )
             entity_ids.append(cursor.fetchone()[0])
     if entity_ids:

--- a/brain/src/hippo_brain/entity_resolver.py
+++ b/brain/src/hippo_brain/entity_resolver.py
@@ -111,6 +111,17 @@ def _resolve_project_roots(override: list[str] | None) -> list[str]:
     return list(_cached_fallback_roots())
 
 
+def is_path_type(entity_type: str) -> bool:
+    """Return True for entity types whose values are filesystem paths.
+
+    Used by callers that want to apply path-only transforms (e.g.
+    `strip_worktree_prefix`) without rewriting non-path values like error
+    messages or concept strings, which may legitimately embed path-like
+    substrings inside diagnostic text.
+    """
+    return entity_type in _PATH_TYPES
+
+
 def strip_worktree_prefix(path: str) -> str:
     """Strip every `.claude/worktrees/<X>/` segment from `path`.
 

--- a/brain/tests/test_enrichment.py
+++ b/brain/tests/test_enrichment.py
@@ -639,7 +639,17 @@ def _file_entity(conn, path: str) -> tuple[str, str]:
     return row[0], row[1]
 
 
-def test_upsert_entities_strips_worktree_from_display_name(tmp_db):
+def test_upsert_entities_strips_worktree_from_display_name(tmp_db, monkeypatch):
+    # Pin canonicalization roots so this test is deterministic — without it,
+    # canonicalize() falls back to ~/projects/*/.git auto-detection and the
+    # test outcome depends on the host filesystem (CI may or may not have a
+    # `~/projects/hippo` checkout). Also clear the cached fallback so a prior
+    # test in the same process doesn't poison this run.
+    monkeypatch.setenv("HIPPO_PROJECT_ROOTS", "/Users/test/projects/hippo")
+    from hippo_brain.entity_resolver import _cached_fallback_roots
+
+    _cached_fallback_roots.cache_clear()
+
     conn, _ = tmp_db
     _seed_event_with_queue(conn, event_id=1)
 
@@ -668,9 +678,14 @@ def test_upsert_entities_strips_worktree_from_display_name(tmp_db):
     assert name.endswith("brain/src/hippo_brain/enrichment.py")
 
 
-def test_upsert_entities_repairs_existing_polluted_name(tmp_db):
+def test_upsert_entities_repairs_existing_polluted_name(tmp_db, monkeypatch):
     """A clean write must heal a row whose `name` was polluted by an earlier
     pre-fix write (same canonical, polluted display name)."""
+    monkeypatch.setenv("HIPPO_PROJECT_ROOTS", "/Users/test/projects/hippo")
+    from hippo_brain.entity_resolver import _cached_fallback_roots
+
+    _cached_fallback_roots.cache_clear()
+
     conn, _ = tmp_db
     _seed_event_with_queue(conn, event_id=1)
     _seed_event_with_queue(conn, event_id=2, session_id=2)
@@ -712,9 +727,14 @@ def test_upsert_entities_repairs_existing_polluted_name(tmp_db):
     assert ".claude/worktrees/" not in name
 
 
-def test_upsert_entities_does_not_churn_clean_existing_name(tmp_db):
+def test_upsert_entities_does_not_churn_clean_existing_name(tmp_db, monkeypatch):
     """If the existing display name is already clean, a subsequent write with a
     different (but still clean) name shouldn't overwrite it — avoids churn."""
+    monkeypatch.setenv("HIPPO_PROJECT_ROOTS", "/Users/test/projects/hippo")
+    from hippo_brain.entity_resolver import _cached_fallback_roots
+
+    _cached_fallback_roots.cache_clear()
+
     conn, _ = tmp_db
     _seed_event_with_queue(conn, event_id=1)
     _seed_event_with_queue(conn, event_id=2, session_id=2)
@@ -744,6 +764,46 @@ def test_upsert_entities_does_not_churn_clean_existing_name(tmp_db):
     name, _ = _file_entity(conn, "bar.py")
     # The first write's name is preserved; the second clean write didn't churn it.
     assert name == "/Users/test/projects/hippo/brain/bar.py"
+
+
+def test_upsert_entities_does_not_strip_non_path_types(tmp_db):
+    """Non-path entity types (errors stored as `concept`) may legitimately
+    contain `.claude/worktrees/...` substrings inside diagnostic messages.
+    Stripping them would lose information and create a name/canonical
+    divergence (canonicalize doesn't strip for non-path types either).
+    """
+    conn, _ = tmp_db
+    _seed_event_with_queue(conn, event_id=1)
+
+    # An error message that happens to mention a worktree path inline. The
+    # error string is stored as a 'concept' entity per SHELL_ENTITY_TYPE_MAP.
+    error_msg = (
+        "FileNotFoundError: cannot stat "
+        "/Users/test/projects/hippo/.claude/worktrees/agent-XX/foo.py"
+    )
+    result = EnrichmentResult(
+        summary="...",
+        intent="debugging",
+        outcome="failure",
+        entities={
+            "projects": [],
+            "tools": [],
+            "files": [],
+            "services": [],
+            "errors": [error_msg],
+        },
+        tags=[],
+        embed_text="x",
+    )
+    write_knowledge_node(conn, result, [1], "test-model")
+
+    row = conn.execute(
+        "SELECT name FROM entities WHERE type = 'concept' AND name LIKE 'filenotfounderror%'"
+    ).fetchone()
+    assert row is not None, "concept entity for the error was not created"
+    # The .claude/worktrees/... substring inside the error message must
+    # survive verbatim — this is diagnostic context, not a path entity.
+    assert ".claude/worktrees/agent-XX/foo.py" in row[0]
 
 
 # ---------------------------------------------------------------------------

--- a/brain/tests/test_enrichment.py
+++ b/brain/tests/test_enrichment.py
@@ -606,6 +606,130 @@ def test_write_knowledge_node_persists_design_decisions(tmp_db):
 
 
 # ---------------------------------------------------------------------------
+# Issue #98 F1 follow-up: entity *display name* must also be worktree-stripped.
+# PR #100 fixed the `canonical` column so dedup works, but the `name` column
+# (what `mcp__hippo__get_entities` returns) still stored the raw worktree path.
+# ---------------------------------------------------------------------------
+
+
+def _file_entity(conn, path: str) -> tuple[str, str]:
+    """Return (name, canonical) for a single 'file' entity matching `path`."""
+    row = conn.execute(
+        "SELECT name, canonical FROM entities WHERE type = 'file' AND name LIKE ?",
+        (f"%{path.rsplit('/', 1)[-1]}%",),
+    ).fetchone()
+    assert row is not None, f"no file entity matching {path}"
+    return row[0], row[1]
+
+
+def test_upsert_entities_strips_worktree_from_display_name(tmp_db):
+    conn, _ = tmp_db
+    _seed_event_with_queue(conn, event_id=1)
+
+    polluted = (
+        "/Users/test/projects/hippo/.claude/worktrees/youthful-kirch-7d3b27/"
+        "brain/src/hippo_brain/enrichment.py"
+    )
+    result = EnrichmentResult(
+        summary="Edited enrichment",
+        intent="coding",
+        outcome="success",
+        entities={
+            "projects": ["hippo"],
+            "tools": [],
+            "files": [polluted],
+            "services": [],
+            "errors": [],
+        },
+        tags=[],
+        embed_text="enrichment.py",
+    )
+    write_knowledge_node(conn, result, [1], "test-model")
+
+    name, _canonical = _file_entity(conn, "enrichment.py")
+    assert ".claude/worktrees/" not in name, f"display name still polluted: {name}"
+    assert name.endswith("brain/src/hippo_brain/enrichment.py")
+
+
+def test_upsert_entities_repairs_existing_polluted_name(tmp_db):
+    """A clean write must heal a row whose `name` was polluted by an earlier
+    pre-fix write (same canonical, polluted display name)."""
+    conn, _ = tmp_db
+    _seed_event_with_queue(conn, event_id=1)
+    _seed_event_with_queue(conn, event_id=2, session_id=2)
+
+    # Simulate a pre-fix row: polluted name, but canonical is already correct
+    # (since canonicalize() in PR #100 already strips worktree segments).
+    now_ms = int(time.time() * 1000)
+    conn.execute(
+        "INSERT INTO entities (type, name, canonical, first_seen, last_seen, created_at) "
+        "VALUES ('file', ?, ?, ?, ?, ?)",
+        (
+            "/users/test/projects/hippo/.claude/worktrees/agent-old/brain/foo.py",
+            "brain/foo.py",
+            now_ms,
+            now_ms,
+            now_ms,
+        ),
+    )
+    conn.commit()
+
+    # Fresh write with a clean path — should heal the existing polluted name.
+    result = EnrichmentResult(
+        summary="...",
+        intent="coding",
+        outcome="success",
+        entities={
+            "projects": [],
+            "tools": [],
+            "files": ["/Users/test/projects/hippo/brain/foo.py"],
+            "services": [],
+            "errors": [],
+        },
+        tags=[],
+        embed_text="x",
+    )
+    write_knowledge_node(conn, result, [1], "test-model")
+
+    name, _ = _file_entity(conn, "foo.py")
+    assert ".claude/worktrees/" not in name
+
+
+def test_upsert_entities_does_not_churn_clean_existing_name(tmp_db):
+    """If the existing display name is already clean, a subsequent write with a
+    different (but still clean) name shouldn't overwrite it — avoids churn."""
+    conn, _ = tmp_db
+    _seed_event_with_queue(conn, event_id=1)
+    _seed_event_with_queue(conn, event_id=2, session_id=2)
+
+    # Both writes carry clean names; only the canonical matches.
+    for source_path in (
+        "/Users/test/projects/hippo/brain/bar.py",
+        "brain/bar.py",  # second write: shorter, but canonical is the same
+    ):
+        result = EnrichmentResult(
+            summary="...",
+            intent="coding",
+            outcome="success",
+            entities={
+                "projects": [],
+                "tools": [],
+                "files": [source_path],
+                "services": [],
+                "errors": [],
+            },
+            tags=[],
+            embed_text="x",
+        )
+        evid = 1 if source_path.startswith("/") else 2
+        write_knowledge_node(conn, result, [evid], "test-model")
+
+    name, _ = _file_entity(conn, "bar.py")
+    # The first write's name is preserved; the second clean write didn't churn it.
+    assert name == "/Users/test/projects/hippo/brain/bar.py"
+
+
+# ---------------------------------------------------------------------------
 # Enrichment eligibility
 # ---------------------------------------------------------------------------
 from hippo_brain.enrichment import is_enrichment_eligible  # noqa: E402


### PR DESCRIPTION
Follow-up to PR #100. Reopens #98.

## Summary

PR #100 fixed the `canonical` column in `entities` so worktree-path entities dedup correctly at the unique-key level. **The `name` column was still storing the raw LLM-emitted path**, including `.claude/worktrees/<X>/...` prefixes. Since `mcp__hippo__get_entities` and any UI surface read the `name` column, the user-visible representation of files remained polluted, and the existing `ON CONFLICT` clause only updated `last_seen` — never `name` — so any file whose first-ever sighting came from inside a worktree was stuck with a worktree-display-name forever.

## Live-DB evidence (before this PR)

```
F1: worktree-polluted entity rows         | 558
F1: post-PR-100 first_seen (NEW pollution!) | 38
```

The 38 newly-polluted rows were created **after** PR #100 merged at `2026-04-27 09:35Z` — newest sighting `2026-04-27 14:39` from Ralph Loop runs `youthful-kirch-7d3b27`, `upbeat-wilson-1aeb94`, `agent-ade96bc9611939e0d`.

## What changed

`brain/src/hippo_brain/enrichment.py` — `upsert_entities` now:

1. Strips the worktree prefix from the **display name** before insert (`strip_worktree_prefix(name)`), not just the canonical.
2. On conflict, **repairs** an existing polluted name (`name LIKE '%.claude/worktrees/%'`) by overwriting it with the new clean value.
3. **Preserves** clean existing names — the `CASE WHEN` avoids churning stable rows when both writes are clean (just dedup on canonical).

```sql
ON CONFLICT (type, canonical) DO
UPDATE SET last_seen = excluded.last_seen,
           name = CASE
               WHEN name LIKE '%.claude/worktrees/%'
                   THEN excluded.name
               ELSE name
           END
```

## Tests (3 new, all passing)

- `test_upsert_entities_strips_worktree_from_display_name` — fresh write with worktree path stores the stripped form.
- `test_upsert_entities_repairs_existing_polluted_name` — clean write heals a pre-fix polluted row.
- `test_upsert_entities_does_not_churn_clean_existing_name` — first write with absolute path, second write with relative path, original wins.

## Test plan

- [x] `uv run --project brain pytest brain/tests` — **757 passed**, 1 skipped, 1 xfailed, 1 xpassed
- [x] `uv run --project brain ruff check brain/` — clean
- [x] `uv run --project brain ruff format --check brain/` — clean
- [ ] Operator runs `uv run --project brain python brain/scripts/dedup-entities.py` post-merge to collapse the 558 existing polluted rows (script was ready since PR #100 but never executed).
- [ ] Post-merge verification probe: `mcp__hippo__get_entities(type='file', query='enrichment.py')` should return clean paths only.

## What this PR does NOT fix

- **F2 (verbatim facts)** — empirically still broken; MCP probe returns *"version not specified"* for the canonical CVE-bump test case despite PR #100's prompt change. The model (`gpt-oss-120b`) is paraphrasing past the prompt instruction. Detailed in the reopened-#98 comment with three options for follow-up.
- **58 malformed-JSON `content` rows** — separate issue, possibly related to PR #104's `strict=False` fix.

## Notes / risks

- The `CASE WHEN` clause means existing **clean** rows that happen to share a canonical with a new write keep their original display name. This is intentional (avoids churn) but means we won't, e.g., normalize `/Users/foo/...` → `~/foo/...` over time. Acceptable tradeoff.
- The fix is forward-only — existing 558 polluted rows still need the dedup-entities.py backfill to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)