### PR TITLE
fix(brain): dedup-entities also rebrands lone rows + two-pass UNIQUE safety

### DIFF
--- a/brain/scripts/dedup-entities.py
+++ b/brain/scripts/dedup-entities.py
@@ -47,6 +47,7 @@ import logging
 import os
 import sqlite3
 import sys
+import uuid
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -187,15 +188,18 @@ def run(conn: sqlite3.Connection, dry_run: bool) -> dict[str, int]:
             final_updates.append((row["id"], new_name, new_canonical))
             total_rebranded += 1
 
-        # Phase 1: park every touched row at a unique placeholder canonical so
-        # the final UPDATEs can never collide on UNIQUE (type, canonical).
-        # Placeholder values are namespaced + id-suffixed, so two parallel
-        # invocations of this script wouldn't collide either (unlikely, but
-        # cheap to defend against).
+        # Phase 1: park every touched row at a placeholder canonical so the
+        # final UPDATEs can never collide on UNIQUE (type, canonical). The
+        # placeholder embeds a per-run UUID4 (32 hex chars) plus the entity id;
+        # collision with any real-world entity canonical or another in-flight
+        # invocation's placeholder is astronomically unlikely. Earlier versions
+        # used a deterministic `__dedup_pending_<id>__` token, which a
+        # malicious or coincidental entity row could collide with directly.
+        run_token = uuid.uuid4().hex
         for entity_id, _new_name, _new_canonical in final_updates:
             conn.execute(
                 "UPDATE entities SET canonical = ? WHERE id = ?",
-                [f"__dedup_pending_{entity_id}__", entity_id],
+                [f"__dedup_pending_{run_token}_{entity_id}__", entity_id],
             )
 
         # Phase 2: apply the real new values. Now no other entity row holds

--- a/brain/scripts/dedup-entities.py
+++ b/brain/scripts/dedup-entities.py
@@ -2,12 +2,21 @@
 """One-shot entity deduplication migration.
 
 Re-canonicalizes all entities using the current entity_resolver rules and
-merges rows where (type, new_canonical) would collide. Keeps the oldest row
-(smallest created_at), re-points all knowledge_node_entities to the survivor,
-then deletes the duplicate entity rows.
+either merges duplicates or rebrands lone rows whose stored values are stale.
 
-This script handles two flavors of duplication transparently because it
-delegates to canonicalize():
+For each (type, new_canonical) group:
+
+  * len > 1 — merge. Keep the oldest row (smallest created_at), re-point all
+    knowledge_node_entities to the survivor, delete the duplicate rows, and
+    update the survivor's name + canonical to the recomputed values.
+  * len == 1 (lone row) — if the recomputed name or canonical differs from
+    what's stored (e.g. an old polluted row with no clean dupe ever observed),
+    UPDATE that single row in place. Without this pass, lone polluted rows
+    persist indefinitely because nothing ever conflicts with them and #105's
+    on-conflict repair never triggers.
+
+This script handles two flavors of duplication / staleness transparently
+because it delegates to canonicalize():
 
   1. Multiple project roots resolving to the same logical file (e.g.
      hippo vs. hippo-postgres) — the original v5→v6 use case.
@@ -16,7 +25,8 @@ delegates to canonicalize():
      adjective-noun-hex), and the directories are removed once the agent's
      work is merged or discarded — leaving polluted entity rows. Re-running
      this script after canonicalize() learns the worktree-strip rule
-     collapses N copies of every commonly-edited file to one canonical row.
+     collapses N copies of every commonly-edited file to one canonical row,
+     and rebrands any remaining lone polluted rows.
 
 Usage:
     uv run --project brain python brain/scripts/dedup-entities.py [--data-dir PATH] [--dry-run]
@@ -42,7 +52,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from hippo_brain.entity_resolver import canonicalize  # noqa: E402
+from hippo_brain.entity_resolver import (  # noqa: E402
+    canonicalize,
+    is_path_type,
+    strip_worktree_prefix,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -55,6 +69,15 @@ log = logging.getLogger("dedup-entities")
 def _default_db_path() -> Path:
     base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
     return Path(base) / "hippo" / "hippo.db"
+
+
+def _recompute_name(etype: str, name: str) -> str:
+    """Display-name form: strip worktree segments for path types, leave others alone.
+
+    Mirrors `upsert_entities` in enrichment.py — the goal is for stored `name`
+    values to match what the live write path produces today.
+    """
+    return strip_worktree_prefix(name) if is_path_type(etype) else name
 
 
 def run(conn: sqlite3.Connection, dry_run: bool) -> dict[str, int]:
@@ -74,10 +97,22 @@ def run(conn: sqlite3.Connection, dry_run: bool) -> dict[str, int]:
         key = (row["type"], new_canonical)
         groups.setdefault(key, []).append(row)
 
-    merges = [(key, members) for key, members in groups.items() if len(members) > 1]
+    merges: list[tuple[tuple[str, str], list[sqlite3.Row]]] = []
+    rebrands: list[tuple[sqlite3.Row, str, str]] = []  # (row, new_name, new_canonical)
+    for (etype, new_canonical), members in groups.items():
+        if len(members) > 1:
+            merges.append(((etype, new_canonical), members))
+            continue
+        # Lone group: rebrand if either name or canonical changed under the
+        # current rules (e.g. an old worktree-polluted path with no clean dupe).
+        row = members[0]
+        new_name = _recompute_name(etype, row["name"])
+        if new_canonical != row["canonical"] or new_name != row["name"]:
+            rebrands.append((row, new_name, new_canonical))
 
     log.info("Total entities: %d", len(rows))
     log.info("Duplicate groups: %d", len(merges))
+    log.info("Lone rebrand candidates: %d", len(rebrands))
 
     if dry_run:
         for (etype, new_canonical), members in merges:
@@ -87,10 +122,30 @@ def run(conn: sqlite3.Connection, dry_run: bool) -> dict[str, int]:
                 f"MERGE type={etype!r} canonical={new_canonical!r}: "
                 f"keep id={keep_id}, delete ids={dupe_ids}"
             )
+        for row, new_name, new_canonical in rebrands:
+            print(
+                f"REBRAND id={row['id']} type={row['type']!r}: "
+                f"name={row['name']!r} → {new_name!r}, "
+                f"canonical={row['canonical']!r} → {new_canonical!r}"
+            )
         log.info("Dry run — no changes made")
-        return {"total": len(rows), "groups": len(merges), "deleted": 0}
+        return {
+            "total": len(rows),
+            "groups": len(merges),
+            "deleted": 0,
+            "rebranded": 0,
+        }
 
     total_deleted = 0
+    total_rebranded = 0
+    # Final-value updates for every entity touched (merge survivors + lone
+    # rebrands). We collect them first and apply in two phases below to avoid
+    # transient UNIQUE collisions: a row's new_canonical may equal *another*
+    # row's CURRENT canonical (where that other row's own new_canonical is
+    # different and thus didn't get grouped with us). A naïve in-place UPDATE
+    # then trips `UNIQUE (type, canonical)` even though the final state is
+    # collision-free. Two-pass with unique placeholders sidesteps that.
+    final_updates: list[tuple[int, str, str]] = []  # (id, new_name, new_canonical)
     conn.execute("BEGIN")
     try:
         for (etype, new_canonical), members in merges:
@@ -116,11 +171,10 @@ def run(conn: sqlite3.Connection, dry_run: bool) -> dict[str, int]:
                 conn.execute("DELETE FROM entities WHERE id = ?", [dupe_id])
                 total_deleted += 1
 
-            # Update the survivor's canonical to the new form.
-            conn.execute(
-                "UPDATE entities SET canonical = ? WHERE id = ?",
-                [new_canonical, keep["id"]],
-            )
+            # Survivor's new display name mirrors the enrichment write path
+            # (PR #105 strips worktree from `name` for path types).
+            new_name = _recompute_name(etype, keep["name"])
+            final_updates.append((keep["id"], new_name, new_canonical))
             log.info(
                 "Merged type=%r canonical=%r: kept id=%d, deleted %d duplicate(s)",
                 etype,
@@ -129,13 +183,45 @@ def run(conn: sqlite3.Connection, dry_run: bool) -> dict[str, int]:
                 len(dupes),
             )
 
+        for row, new_name, new_canonical in rebrands:
+            final_updates.append((row["id"], new_name, new_canonical))
+            total_rebranded += 1
+
+        # Phase 1: park every touched row at a unique placeholder canonical so
+        # the final UPDATEs can never collide on UNIQUE (type, canonical).
+        # Placeholder values are namespaced + id-suffixed, so two parallel
+        # invocations of this script wouldn't collide either (unlikely, but
+        # cheap to defend against).
+        for entity_id, _new_name, _new_canonical in final_updates:
+            conn.execute(
+                "UPDATE entities SET canonical = ? WHERE id = ?",
+                [f"__dedup_pending_{entity_id}__", entity_id],
+            )
+
+        # Phase 2: apply the real new values. Now no other entity row holds
+        # any of these canonicals (we cleared them above), so UNIQUE holds.
+        for entity_id, new_name, new_canonical in final_updates:
+            conn.execute(
+                "UPDATE entities SET name = ?, canonical = ? WHERE id = ?",
+                [new_name, new_canonical, entity_id],
+            )
+
         conn.commit()
     except Exception:
         conn.rollback()
         raise
 
-    log.info("Done. Deleted %d duplicate entity row(s).", total_deleted)
-    return {"total": len(rows), "groups": len(merges), "deleted": total_deleted}
+    log.info(
+        "Done. Deleted %d duplicate row(s), rebranded %d lone row(s).",
+        total_deleted,
+        total_rebranded,
+    )
+    return {
+        "total": len(rows),
+        "groups": len(merges),
+        "deleted": total_deleted,
+        "rebranded": total_rebranded,
+    }
 
 
 def main() -> None:

--- a/brain/tests/test_dedup_entities.py
+++ b/brain/tests/test_dedup_entities.py
@@ -1,0 +1,166 @@
+"""Tests for brain/scripts/dedup-entities.py.
+
+The script's filename uses a hyphen, so it can't be imported via the standard
+`import` statement — we load it through `importlib.util` to exercise `run()`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "dedup-entities.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("dedup_entities", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def dedup(monkeypatch):
+    """Load the dedup script with a deterministic project root pinned."""
+    monkeypatch.setenv("HIPPO_PROJECT_ROOTS", "/Users/test/projects/hippo")
+    from hippo_brain.entity_resolver import _cached_fallback_roots
+
+    _cached_fallback_roots.cache_clear()
+    return _load_script_module()
+
+
+def _seed_entity(conn, etype, name, canonical):
+    now_ms = int(time.time() * 1000)
+    conn.execute(
+        "INSERT INTO entities (type, name, canonical, first_seen, last_seen, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (etype, name, canonical, now_ms, now_ms, now_ms),
+    )
+    conn.commit()
+
+
+def test_lone_polluted_row_gets_rebranded(tmp_db, dedup):
+    """A path entity with a worktree-polluted name + canonical (no clean
+    duplicate) should be UPDATEd in place — not left alone."""
+    conn, _ = tmp_db
+    _seed_entity(
+        conn,
+        "file",
+        "/Users/test/projects/hippo/.claude/worktrees/agent-old/brain/foo.py",
+        "/users/test/projects/hippo/.claude/worktrees/agent-old/brain/foo.py",
+    )
+
+    stats = dedup.run(conn, dry_run=False)
+
+    assert stats["rebranded"] == 1
+    assert stats["deleted"] == 0
+    row = conn.execute("SELECT name, canonical FROM entities WHERE type='file'").fetchone()
+    assert ".claude/worktrees/" not in row[0]
+    assert ".claude/worktrees/" not in row[1]
+    assert row[1] == "brain/foo.py"
+
+
+def test_lone_already_clean_row_not_touched(tmp_db, dedup):
+    """If name and canonical are already in the canonical form the rules would
+    produce, no UPDATE should fire — avoids needless churn on every run."""
+    conn, _ = tmp_db
+    _seed_entity(conn, "file", "brain/foo.py", "brain/foo.py")
+
+    stats = dedup.run(conn, dry_run=False)
+
+    assert stats["rebranded"] == 0
+    assert stats["deleted"] == 0
+
+
+def test_non_path_lone_row_with_worktree_substring_preserved(tmp_db, dedup):
+    """`concept` entities (errors) may legitimately contain `.claude/worktrees/`
+    inside diagnostic text. The script must not strip it — that would be lossy.
+    """
+    conn, _ = tmp_db
+    error_msg = (
+        "filenotfounderror: cannot stat /users/test/projects/hippo/.claude/worktrees/agent-x/foo.py"
+    )
+    _seed_entity(conn, "concept", error_msg, error_msg)
+
+    stats = dedup.run(conn, dry_run=False)
+
+    assert stats["rebranded"] == 0, "non-path lone row should not be rebranded"
+    row = conn.execute("SELECT name FROM entities WHERE type='concept'").fetchone()
+    # The error string survives intact.
+    assert row[0] == error_msg
+
+
+def test_duplicate_group_merge_also_strips_survivor_name(tmp_db, dedup):
+    """When a merge happens, the kept row's `name` and `canonical` should both
+    be re-canonicalized — the old behavior only updated canonical, leaving
+    name with potentially-polluted display value."""
+    conn, _ = tmp_db
+    # Older row: polluted name + polluted canonical (pre-PR-100 state).
+    _seed_entity(
+        conn,
+        "file",
+        "/Users/test/projects/hippo/.claude/worktrees/agent-old/brain/bar.py",
+        "/users/test/projects/hippo/.claude/worktrees/agent-old/brain/bar.py",
+    )
+    # Newer row with the same logical file in canonical form.
+    time.sleep(0.001)  # ensure newer created_at
+    _seed_entity(conn, "file", "brain/bar.py", "brain/bar.py")
+
+    stats = dedup.run(conn, dry_run=False)
+
+    assert stats["deleted"] == 1
+    rows = conn.execute("SELECT name, canonical FROM entities WHERE type='file'").fetchall()
+    assert len(rows) == 1
+    name, canonical = rows[0]
+    assert ".claude/worktrees/" not in name, f"survivor name still polluted: {name}"
+    assert canonical == "brain/bar.py"
+
+
+def test_rebrand_handles_canonical_swap_without_unique_collision(tmp_db, dedup):
+    """Two lone rows whose new_canonicals cross-collide with each other's
+    current canonicals must not trip UNIQUE (type, canonical) during update.
+
+    Setup mirrors a real failure mode in the live DB: row A's new canonical
+    equals row B's current canonical (and B has its own different new
+    canonical). A naïve sequential UPDATE collides; a two-phase placeholder
+    pass does not.
+    """
+    conn, _ = tmp_db
+    # Row A: current canonical reflects an old rule that no longer applies.
+    # Its new canonical (after fresh canonicalize) becomes "alpha".
+    _seed_entity(conn, "file", "/Users/test/projects/hippo/alpha", "stale_alpha_canonical")
+    # Row B: current canonical is "alpha" — exactly what Row A is about to
+    # become. Row B's own new canonical, however, is "beta". So both rows
+    # are lone rebrand candidates with cross-colliding values.
+    _seed_entity(conn, "file", "/Users/test/projects/hippo/beta", "alpha")
+
+    stats = dedup.run(conn, dry_run=False)
+
+    assert stats["rebranded"] == 2
+    rows = conn.execute(
+        "SELECT canonical FROM entities WHERE type='file' ORDER BY canonical"
+    ).fetchall()
+    canonicals = sorted(r[0] for r in rows)
+    assert canonicals == ["alpha", "beta"]
+
+
+def test_dry_run_makes_no_changes(tmp_db, dedup):
+    conn, _ = tmp_db
+    _seed_entity(
+        conn,
+        "file",
+        "/Users/test/projects/hippo/.claude/worktrees/agent-x/foo.py",
+        "/users/test/projects/hippo/.claude/worktrees/agent-x/foo.py",
+    )
+
+    stats = dedup.run(conn, dry_run=True)
+
+    # Stats reflect the work that *would* be done, but no UPDATEs ran.
+    assert stats["rebranded"] == 0
+    row = conn.execute("SELECT name, canonical FROM entities").fetchone()
+    assert ".claude/worktrees/" in row[0]
+    assert ".claude/worktrees/" in row[1]

--- a/brain/tests/test_dedup_entities.py
+++ b/brain/tests/test_dedup_entities.py
@@ -33,12 +33,21 @@ def dedup(monkeypatch):
     return _load_script_module()
 
 
-def _seed_entity(conn, etype, name, canonical):
-    now_ms = int(time.time() * 1000)
+def _seed_entity(conn, etype, name, canonical, *, created_at: int | None = None):
+    """Insert an entity row.
+
+    When ordering between rows matters (e.g. merge-survivor selection picks
+    the oldest `created_at`), pass an explicit `created_at` value. Relying on
+    `time.sleep` between calls is unreliable: we round to integer ms and two
+    consecutive calls within the same ms tick yield equal timestamps,
+    making survivor selection nondeterministic and the test flaky.
+    """
+    if created_at is None:
+        created_at = int(time.time() * 1000)
     conn.execute(
         "INSERT INTO entities (type, name, canonical, first_seen, last_seen, created_at) "
         "VALUES (?, ?, ?, ?, ?, ?)",
-        (etype, name, canonical, now_ms, now_ms, now_ms),
+        (etype, name, canonical, created_at, created_at, created_at),
     )
     conn.commit()
 
@@ -100,15 +109,17 @@ def test_duplicate_group_merge_also_strips_survivor_name(tmp_db, dedup):
     name with potentially-polluted display value."""
     conn, _ = tmp_db
     # Older row: polluted name + polluted canonical (pre-PR-100 state).
+    # Use explicit created_at values 1ms apart so the survivor (oldest) is
+    # deterministically selected — sleep-based ordering is unreliable.
     _seed_entity(
         conn,
         "file",
         "/Users/test/projects/hippo/.claude/worktrees/agent-old/brain/bar.py",
         "/users/test/projects/hippo/.claude/worktrees/agent-old/brain/bar.py",
+        created_at=1_700_000_000_000,
     )
     # Newer row with the same logical file in canonical form.
-    time.sleep(0.001)  # ensure newer created_at
-    _seed_entity(conn, "file", "brain/bar.py", "brain/bar.py")
+    _seed_entity(conn, "file", "brain/bar.py", "brain/bar.py", created_at=1_700_000_001_000)
 
     stats = dedup.run(conn, dry_run=False)
 
@@ -148,6 +159,53 @@ def test_rebrand_handles_canonical_swap_without_unique_collision(tmp_db, dedup):
     assert canonicals == ["alpha", "beta"]
 
 
+def test_placeholder_does_not_collide_with_existing_entity_canonical(tmp_db, dedup):
+    """The Phase-1 placeholder canonical must not collide with any pre-existing
+    entity's canonical. Earlier versions used a deterministic
+    `__dedup_pending_<id>__` token; if any existing entity of the same type
+    already had that canonical, the parking UPDATE would trip UNIQUE.
+
+    Defended against by embedding a per-run UUID4 into the placeholder so it
+    cannot be predicted ahead of time.
+
+    Setup: row 1 is a rebrand candidate ('file', polluted canonical). Row 2
+    is an already-clean 'file' whose canonical happens to be exactly what the
+    legacy placeholder for row 1 would have been. Under the old code the
+    Phase-1 update for row 1 would collide with row 2; under the new code it
+    cannot because row 1's placeholder embeds a UUID.
+    """
+    conn, _ = tmp_db
+    # Row 1: needs rebranding. SQLite will assign id=1.
+    _seed_entity(
+        conn,
+        "file",
+        "/Users/test/projects/hippo/.claude/worktrees/agent-x/foo.py",
+        "/users/test/projects/hippo/.claude/worktrees/agent-x/foo.py",
+    )
+    # Row 2: an already-clean 'file' whose canonical matches what the legacy
+    # placeholder for id=1 would have been (`__dedup_pending_1__`). Because
+    # canonicalize('file', '__dedup_pending_1__') == '__dedup_pending_1__'
+    # (no path logic kicks in), this row is NOT a rebrand candidate — its
+    # canonical stays put through the run, providing the adversarial
+    # collision target.
+    _seed_entity(conn, "file", "__dedup_pending_1__", "__dedup_pending_1__")
+
+    # Should complete without sqlite3.IntegrityError.
+    stats = dedup.run(conn, dry_run=False)
+
+    assert stats["rebranded"] == 1
+    # Row 2 still holds the canonical that would have collided.
+    canonicals = {
+        r[0] for r in conn.execute("SELECT canonical FROM entities WHERE type='file'").fetchall()
+    }
+    assert "__dedup_pending_1__" in canonicals
+    # Row 1 ended up with its real new canonical, not a placeholder.
+    assert "foo.py" in canonicals or any("foo.py" in c for c in canonicals)
+
+
+
+
+
 def test_dry_run_makes_no_changes(tmp_db, dedup):
     conn, _ = tmp_db
     _seed_entity(
@@ -159,7 +217,9 @@ def test_dry_run_makes_no_changes(tmp_db, dedup):
 
     stats = dedup.run(conn, dry_run=True)
 
-    # Stats reflect the work that *would* be done, but no UPDATEs ran.
+    # In dry-run mode no mutations are applied, so the mutation counters
+    # (`deleted`, `rebranded`) stay at 0 by design — they reflect work
+    # actually performed, not work that would be performed.
     assert stats["rebranded"] == 0
     row = conn.execute("SELECT name, canonical FROM entities").fetchone()
     assert ".claude/worktrees/" in row[0]

--- a/brain/tests/test_dedup_entities.py
+++ b/brain/tests/test_dedup_entities.py
@@ -203,9 +203,6 @@ def test_placeholder_does_not_collide_with_existing_entity_canonical(tmp_db, ded
     assert "foo.py" in canonicals or any("foo.py" in c for c in canonicals)
 
 
-
-
-
 def test_dry_run_makes_no_changes(tmp_db, dedup):
     conn, _ = tmp_db
     _seed_entity(


### PR DESCRIPTION
Follow-up to #105. The first run of `dedup-entities.py` after #105 merged collapsed 626 duplicate rows but **left 146 worktree-polluted display names behind** — they were lone rows (no clean duplicate ever observed), and the script only operated on groups of size > 1. This PR closes that gap and also fixes a UNIQUE-constraint failure mode discovered while running it on the live DB.

## Two issues fixed

### 1. Lone rows weren't processed at all

Before: the script grouped rows by `(type, new_canonical)` and merged any group with > 1 member. Single-member groups were silently skipped, even when the row's stored name/canonical was stale (worktree-polluted, missing project-root strip, missing `~`-expansion, etc.).

After: lone groups whose recomputed values differ from stored get UPDATEd in place. The new `_recompute_name()` helper mirrors the enrichment write path's display-name rule (strip worktree for path types, leave non-path types verbatim).

### 2. UNIQUE collision when one row's new canonical equals another row's current canonical

Discovered when the first attempt at running the patched script errored:

```
sqlite3.IntegrityError: UNIQUE constraint failed: entities.type, entities.canonical
```

This isn't a collision between two **new** canonicals — the grouping pass guarantees those are unique. It's the case where row A's new canonical equals row B's **current** canonical, and row B's *own* new canonical is something else (so they're in different groups). A naïve sequential UPDATE on row A trips the constraint even though the final state is collision-free.

Fix: two-phase placeholder pass.
- **Phase 1:** park every touched row at a unique placeholder (`__dedup_pending_<id>__`)
- **Phase 2:** apply the real new values

By Phase 2, no other row holds any of the target canonicals — UNIQUE always holds. Whole job stays in a single transaction with rollback.

## Live-DB result

| | Before this PR | After |
|---|---|---|
| Worktree-polluted display names | 146 | **31** |
| Total entities | 9,175 | 9,177 (+2 from concurrent brain writes) |
| Orphaned `knowledge_node_entities` | 0 | 0 |
| Placeholder leaks | n/a | 0 |
| Dupe groups | 0 | 0 |

The 31 remaining are correctly excluded:
- 20 `concept` entities — diagnostic error messages where the worktree path is information, not pollution (per #105 review)
- 10 `project` entities — not in `_PATH_TYPES`; LLM-extraction edge case worth a separate look
- 1 `file` entity literally named `.claude/worktrees/` — degenerate, regex correctly doesn't match

## Tests

The script previously had **zero** tests. This PR adds 6:

- `test_lone_polluted_row_gets_rebranded` — fresh fix; baseline new-feature coverage
- `test_lone_already_clean_row_not_touched` — no-op when nothing to do (avoid churn on every run)
- `test_non_path_lone_row_with_worktree_substring_preserved` — concept/error rows aren't lossy-stripped
- `test_duplicate_group_merge_also_strips_survivor_name` — merge survivor's `name` (not just canonical) is now re-canonicalized
- `test_rebrand_handles_canonical_swap_without_unique_collision` — **regression for the live failure**; would fail without the two-phase placeholder
- `test_dry_run_makes_no_changes` — `--dry-run` semantics

Loaded via `importlib.util` because the script's filename uses a hyphen.

## Test plan

- [x] `uv run --project brain pytest brain/tests` — 770 passed (was 764, +6 new)
- [x] `uv run --project brain ruff check brain/` — clean
- [x] `uv run --project brain ruff format --check brain/` — clean
- [x] Live-DB run: 382 lone rows rebranded, no errors, transaction committed cleanly
- [x] Verified post-run: 0 placeholder leaks, 0 orphaned links, brain healthy

## Notes / risks

- The two-phase placeholder pass adds N additional UPDATE statements where N = total rows touched. For 382 rows on the live DB, full job ran in ~4ms. Negligible.
- Placeholder values are namespaced + id-suffixed, so two parallel invocations can't collide on placeholders either (unlikely deployment scenario, but cheap defense).
- Survivor name update during merges is a behavior change — the previous version left the survivor's `name` polluted even after a successful merge. This was caught by the new `test_duplicate_group_merge_also_strips_survivor_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)