### PR TITLE
feat(brain): re-enrich existing knowledge nodes against current model + prompts

### DIFF
--- a/brain/scripts/re-enrich-knowledge-nodes.py
+++ b/brain/scripts/re-enrich-knowledge-nodes.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""One-shot re-enrichment of existing knowledge nodes.
+
+Re-runs enrichment for knowledge nodes that pre-date the current prompt /
+model setup, using the same code paths the live brain uses, and updates
+each node in place. Preserves ``id`` / ``uuid`` / ``created_at`` / link
+rows; only the derived content (summary, embed_text, entities, tags,
+design_decisions, etc.) is replaced.
+
+Why this exists
+---------------
+Across PRs #100, #105, #107 the enrichment system prompts were upgraded
+(verbatim preservation, identifier-dense embed_text, design_decisions
+schema, worktree-stripped entity names). The configured enrichment model
+also moved from ``gpt-oss-120b`` to ``qwen3.6-35b-a3b-ud-mlx``. None of
+that retroactively benefits the existing corpus. Running this script
+brings every previously-enriched node up to the current standard.
+
+Sources handled
+---------------
+- **shell** — link table ``knowledge_node_events``, prompt via
+  ``build_enrichment_prompt`` against rows from ``events``.
+- **claude** — link table ``knowledge_node_claude_sessions``, prompt is
+  the concatenation of ``claude_sessions.summary_text`` rows joined by
+  ``\\n---\\n``, mirroring ``Server._enrich_claude_batches``.
+
+Sources NOT handled by this version
+-----------------------------------
+- **workflow** — ``workflow_enrichment.py`` writes free-text markdown
+  into ``knowledge_nodes.content`` rather than a structured JSON
+  EnrichmentResult; needs a separate code path. 187 nodes, low priority.
+- **browser** — only 6 nodes in the live corpus; not worth a third
+  branch in this script.
+
+Both stay at ``enrichment_version=1`` and will be skipped by future runs
+of this script. Add explicit handling later if needed.
+
+Usage
+-----
+    uv run --project brain python brain/scripts/re-enrich-knowledge-nodes.py \\
+        [--db PATH] [--source shell|claude|all] [--limit N] [--dry-run] \\
+        [--throttle-ms MS] [--newest-first]
+
+Resume semantics
+----------------
+The script bumps each successfully-processed node's
+``enrichment_version`` from 1 to 2. The default WHERE clause filters
+``enrichment_version < TARGET_VERSION``, so re-running picks up where a
+prior run left off. Failed nodes stay at the old version and will be
+retried on the next run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from hippo_brain.claude_sessions import CLAUDE_SYSTEM_PROMPT  # noqa: E402
+from hippo_brain.client import LMStudioClient  # noqa: E402
+from hippo_brain.embeddings import embed_knowledge_node  # noqa: E402
+from hippo_brain.enrichment import (  # noqa: E402
+    SHELL_ENTITY_TYPE_MAP,
+    SYSTEM_PROMPT,
+    build_enrichment_prompt,
+    parse_enrichment_response,
+    upsert_entities,
+)
+
+# CLAUDE entity-type map mirrors SHELL — claude enrichment writes the same
+# structured EnrichmentResult shape into knowledge_nodes.content.
+CLAUDE_ENTITY_TYPE_MAP = SHELL_ENTITY_TYPE_MAP
+
+TARGET_ENRICHMENT_VERSION = 2
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+log = logging.getLogger("re-enrich")
+
+
+def _default_db_path() -> Path:
+    base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    return Path(base) / "hippo" / "hippo.db"
+
+
+def _load_settings() -> dict:
+    """Pull lmstudio + model settings from the canonical brain config."""
+    from hippo_brain import _load_runtime_settings
+
+    return _load_runtime_settings()
+
+
+def _select_candidate_nodes(
+    conn: sqlite3.Connection, source: str, limit: int | None, newest_first: bool
+) -> list[dict]:
+    """Return knowledge_nodes rows that need re-enrichment, joined with source.
+
+    ``source`` is one of ``shell`` / ``claude`` / ``all``. The returned dicts
+    carry an explicit ``_source`` key naming the link table the row hit.
+    """
+    order_clause = "DESC" if newest_first else "ASC"
+    limit_clause = f"LIMIT {int(limit)}" if limit and limit > 0 else ""
+
+    queries = []
+    if source in ("shell", "all"):
+        queries.append(
+            f"""
+            SELECT n.id, n.uuid, n.created_at, 'shell' AS _source
+            FROM knowledge_nodes n
+            JOIN knowledge_node_events kne ON kne.knowledge_node_id = n.id
+            WHERE n.enrichment_version < {TARGET_ENRICHMENT_VERSION}
+            GROUP BY n.id
+            """
+        )
+    if source in ("claude", "all"):
+        queries.append(
+            f"""
+            SELECT n.id, n.uuid, n.created_at, 'claude' AS _source
+            FROM knowledge_nodes n
+            JOIN knowledge_node_claude_sessions kncs ON kncs.knowledge_node_id = n.id
+            WHERE n.enrichment_version < {TARGET_ENRICHMENT_VERSION}
+            GROUP BY n.id
+            """
+        )
+
+    union_sql = " UNION ".join(queries)
+    final_sql = f"SELECT * FROM ({union_sql}) ORDER BY created_at {order_clause} {limit_clause}"
+    rows = conn.execute(final_sql).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _fetch_shell_events(conn: sqlite3.Connection, node_id: int) -> list[dict]:
+    """Return event rows linked to the given knowledge node, ordered by timestamp."""
+    rows = conn.execute(
+        """
+        SELECT e.id, e.session_id, e.timestamp, e.command, e.exit_code, e.duration_ms,
+               e.cwd, e.git_branch, e.git_commit, e.git_repo, e.stdout, e.stderr,
+               e.hostname, e.shell
+        FROM events e
+        JOIN knowledge_node_events kne ON kne.event_id = e.id
+        WHERE kne.knowledge_node_id = ?
+        ORDER BY e.timestamp ASC
+        """,
+        (node_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _fetch_claude_segments(conn: sqlite3.Connection, node_id: int) -> list[dict]:
+    """Return claude_sessions rows linked to the given knowledge node."""
+    rows = conn.execute(
+        """
+        SELECT cs.id, cs.session_id, cs.cwd, cs.git_branch, cs.summary_text,
+               cs.tool_calls_json, cs.user_prompts_json, cs.message_count,
+               cs.start_time, cs.end_time, cs.content_hash
+        FROM claude_sessions cs
+        JOIN knowledge_node_claude_sessions kncs ON kncs.claude_session_id = cs.id
+        WHERE kncs.knowledge_node_id = ?
+        ORDER BY cs.start_time ASC
+        """,
+        (node_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _build_prompt_for(source: str, payload: list[dict]) -> tuple[str, str]:
+    """Return (system_prompt, user_prompt) for the given source + payload."""
+    if source == "shell":
+        return SYSTEM_PROMPT, build_enrichment_prompt(payload)
+    if source == "claude":
+        # Mirror Server._enrich_claude_batches: concatenate summary_text rows.
+        return CLAUDE_SYSTEM_PROMPT, "\n---\n\n".join(s.get("summary_text", "") for s in payload)
+    raise ValueError(f"unsupported source: {source!r}")
+
+
+async def _call_llm_with_retries(
+    client: LMStudioClient, system_prompt: str, prompt: str, model: str
+) -> object:
+    """Mirror Server._call_llm_with_retries: 3 attempts, parse on each."""
+    last_err: Exception | None = None
+    for attempt in range(1, 4):
+        try:
+            raw = await client.chat(
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": prompt},
+                ],
+                model=model,
+            )
+            return parse_enrichment_response(raw)
+        except Exception as e:
+            last_err = e
+            log.warning("attempt %d failed: %s", attempt, e)
+    assert last_err is not None
+    raise last_err
+
+
+def _update_node_in_place(
+    conn: sqlite3.Connection,
+    node_id: int,
+    result,
+    enrichment_model: str,
+) -> None:
+    """Replace the node's derived content + entity links inside one transaction.
+
+    Bumps enrichment_version to TARGET. Existing knowledge_node_entities links
+    are dropped first; upsert_entities re-adds them under the new entities
+    payload (which goes through the current canonicalize / strip_worktree
+    rules). knowledge_node_events / knowledge_node_claude_sessions /
+    knowledge_node_browser_events / knowledge_node_workflow_runs are untouched
+    — those are the source-event links and don't change on re-enrichment.
+    """
+    now_ms = int(time.time() * 1000)
+    content = json.dumps(
+        {
+            "summary": result.summary,
+            "intent": result.intent,
+            "outcome": result.outcome,
+            "entities": result.entities,
+            "tags": result.tags,
+            "key_decisions": result.key_decisions,
+            "problems_encountered": result.problems_encountered,
+            "design_decisions": result.design_decisions,
+        }
+    )
+    tags_json = json.dumps(result.tags)
+
+    conn.execute("BEGIN")
+    try:
+        conn.execute(
+            """
+            UPDATE knowledge_nodes
+            SET content = ?, embed_text = ?, outcome = ?, tags = ?,
+                enrichment_model = ?, enrichment_version = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                content,
+                result.embed_text,
+                result.outcome,
+                tags_json,
+                enrichment_model,
+                TARGET_ENRICHMENT_VERSION,
+                now_ms,
+                node_id,
+            ),
+        )
+        # Wipe stale entity links, then re-upsert under the new rules.
+        conn.execute("DELETE FROM knowledge_node_entities WHERE knowledge_node_id = ?", (node_id,))
+        upsert_entities(conn, node_id, result.entities, SHELL_ENTITY_TYPE_MAP, now_ms)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+async def _re_embed(
+    client: LMStudioClient,
+    conn: sqlite3.Connection,
+    node_id: int,
+    embed_text: str,
+    embed_model: str,
+) -> None:
+    if not embed_model:
+        log.debug("no embed_model configured; skipping re-embed for node %d", node_id)
+        return
+    await embed_knowledge_node(
+        client,
+        conn,
+        {"id": node_id, "embed_text": embed_text, "commands_raw": ""},
+        embed_model=embed_model,
+        allow_embed_switch=False,
+    )
+
+
+async def _process_node(
+    client: LMStudioClient,
+    conn: sqlite3.Connection,
+    candidate: dict,
+    enrichment_model: str,
+    embed_model: str,
+    dry_run: bool,
+) -> bool:
+    """Re-enrich one node. Returns True on success, False on skip/failure."""
+    node_id = candidate["id"]
+    source = candidate["_source"]
+    if source == "shell":
+        payload = _fetch_shell_events(conn, node_id)
+    elif source == "claude":
+        payload = _fetch_claude_segments(conn, node_id)
+    else:
+        log.warning("node %d: unknown source %r, skipping", node_id, source)
+        return False
+
+    if not payload:
+        log.warning("node %d: no source rows found via %s link table, skipping", node_id, source)
+        return False
+
+    system_prompt, prompt = _build_prompt_for(source, payload)
+
+    if dry_run:
+        log.info(
+            "[dry-run] node %d (%s, %d source rows, prompt %d chars) — would re-enrich",
+            node_id,
+            source,
+            len(payload),
+            len(prompt),
+        )
+        return True
+
+    try:
+        result = await _call_llm_with_retries(client, system_prompt, prompt, enrichment_model)
+    except Exception as e:
+        log.error("node %d (%s): enrichment failed after retries: %s", node_id, source, e)
+        return False
+
+    try:
+        _update_node_in_place(conn, node_id, result, enrichment_model)
+        await _re_embed(client, conn, node_id, result.embed_text, embed_model)
+    except Exception as e:
+        log.error("node %d (%s): write/embed failed: %s", node_id, source, e)
+        return False
+
+    log.info("node %d (%s) re-enriched", node_id, source)
+    return True
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    settings = _load_settings()
+    db_path = Path(args.db) if args.db else _default_db_path()
+    if not db_path.exists():
+        log.error("Database not found: %s", db_path)
+        return 1
+
+    enrichment_model = args.model or settings.get("enrichment_model") or ""
+    embed_model = settings.get("embedding_model") or ""
+    if not enrichment_model and not args.dry_run:
+        log.error(
+            "No enrichment model configured (config.toml [models].enrichment) and no --model flag"
+        )
+        return 1
+
+    base_url = settings.get("lmstudio_base_url", "http://localhost:1234/v1")
+    timeout = float(settings.get("lmstudio_timeout_secs", 300.0))
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA busy_timeout=5000")
+
+    candidates = _select_candidate_nodes(conn, args.source, args.limit, args.newest_first)
+    log.info(
+        "Selected %d candidate node(s) for re-enrichment "
+        "(source=%s limit=%s newest_first=%s target_version=%d)",
+        len(candidates),
+        args.source,
+        args.limit,
+        args.newest_first,
+        TARGET_ENRICHMENT_VERSION,
+    )
+    if not candidates:
+        log.info("nothing to do")
+        conn.close()
+        return 0
+
+    client = LMStudioClient(base_url=base_url, timeout=timeout)
+
+    successes = 0
+    failures = 0
+    throttle = max(0.0, args.throttle_ms / 1000.0)
+    try:
+        for i, cand in enumerate(candidates, 1):
+            log.info("(%d/%d) starting node %d", i, len(candidates), cand["id"])
+            ok = await _process_node(
+                client, conn, cand, enrichment_model, embed_model, args.dry_run
+            )
+            if ok:
+                successes += 1
+            else:
+                failures += 1
+            if throttle and i < len(candidates):
+                await asyncio.sleep(throttle)
+    finally:
+        conn.close()
+        if hasattr(client, "aclose"):
+            await client.aclose()
+
+    log.info("Done. successes=%d failures=%d total=%d", successes, failures, len(candidates))
+    return 0 if failures == 0 else 2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=str, default=None, help="path to hippo.db")
+    parser.add_argument(
+        "--source",
+        choices=("shell", "claude", "all"),
+        default="all",
+        help="restrict to one source type (default: all)",
+    )
+    parser.add_argument("--limit", type=int, default=0, help="max nodes to process (0 = unlimited)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print candidates without calling LLM or modifying DB",
+    )
+    parser.add_argument(
+        "--newest-first",
+        action="store_true",
+        default=True,
+        help="(default) process newest nodes first so active queries benefit early",
+    )
+    parser.add_argument(
+        "--oldest-first",
+        action="store_false",
+        dest="newest_first",
+        help="reverse: process oldest nodes first",
+    )
+    parser.add_argument(
+        "--throttle-ms",
+        type=int,
+        default=200,
+        help="ms to sleep between nodes so live brain isn't starved (default: 200)",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="override enrichment model (default: read from config.toml)",
+    )
+    args = parser.parse_args()
+    rc = asyncio.run(main_async(args))
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/brain/scripts/re-enrich-knowledge-nodes.py
+++ b/brain/scripts/re-enrich-knowledge-nodes.py
@@ -65,6 +65,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
+from hippo_brain import vector_store  # noqa: E402
 from hippo_brain.claude_sessions import CLAUDE_SYSTEM_PROMPT  # noqa: E402
 from hippo_brain.client import LMStudioClient  # noqa: E402
 from hippo_brain.embeddings import embed_knowledge_node  # noqa: E402
@@ -215,12 +216,18 @@ def _update_node_in_place(
 ) -> None:
     """Replace the node's derived content + entity links inside one transaction.
 
-    Bumps enrichment_version to TARGET. Existing knowledge_node_entities links
-    are dropped first; upsert_entities re-adds them under the new entities
-    payload (which goes through the current canonicalize / strip_worktree
-    rules). knowledge_node_events / knowledge_node_claude_sessions /
-    knowledge_node_browser_events / knowledge_node_workflow_runs are untouched
-    — those are the source-event links and don't change on re-enrichment.
+    Does NOT bump ``enrichment_version`` — that's deferred until after the
+    embedding has also been refreshed (see ``_finalize_node_version``). If
+    embedding fails, the content has already been overwritten with new-model
+    output but the version stays at 1, so the next run will re-process and
+    overwrite again with another fresh LLM call. Cost is one extra LLM call
+    per partially-failed node; benefit is no node ever ends up at TARGET
+    with a stale embedding (which would silently degrade retrieval).
+
+    knowledge_node_entities is wiped + re-upserted under the current
+    canonicalize / strip_worktree rules. Source-event link tables
+    (knowledge_node_events / _claude_sessions / _browser_events /
+    _workflow_runs) are untouched.
     """
     now_ms = int(time.time() * 1000)
     content = json.dumps(
@@ -243,7 +250,7 @@ def _update_node_in_place(
             """
             UPDATE knowledge_nodes
             SET content = ?, embed_text = ?, outcome = ?, tags = ?,
-                enrichment_model = ?, enrichment_version = ?, updated_at = ?
+                enrichment_model = ?, updated_at = ?
             WHERE id = ?
             """,
             (
@@ -252,7 +259,6 @@ def _update_node_in_place(
                 result.outcome,
                 tags_json,
                 enrichment_model,
-                TARGET_ENRICHMENT_VERSION,
                 now_ms,
                 node_id,
             ),
@@ -266,6 +272,18 @@ def _update_node_in_place(
         raise
 
 
+def _finalize_node_version(conn: sqlite3.Connection, node_id: int) -> None:
+    """Bump enrichment_version to TARGET after content + embedding are both
+    refreshed. Separate from ``_update_node_in_place`` so a failed embed
+    leaves version at 1, ensuring the next run re-processes the node.
+    """
+    conn.execute(
+        "UPDATE knowledge_nodes SET enrichment_version = ? WHERE id = ?",
+        (TARGET_ENRICHMENT_VERSION, node_id),
+    )
+    conn.commit()
+
+
 async def _re_embed(
     client: LMStudioClient,
     conn: sqlite3.Connection,
@@ -276,6 +294,12 @@ async def _re_embed(
     if not embed_model:
         log.debug("no embed_model configured; skipping re-embed for node %d", node_id)
         return
+    # vec0 virtual tables don't honor INSERT OR REPLACE the way classical
+    # tables do — re-inserting against an existing knowledge_node_id raises
+    # `UNIQUE constraint failed on knowledge_vectors primary key`. The live
+    # brain never hits this because each enrichment creates a fresh node id.
+    # In re-enrichment we update in place, so we must DELETE first.
+    conn.execute("DELETE FROM knowledge_vectors WHERE knowledge_node_id = ?", (node_id,))
     await embed_knowledge_node(
         client,
         conn,
@@ -329,6 +353,7 @@ async def _process_node(
     try:
         _update_node_in_place(conn, node_id, result, enrichment_model)
         await _re_embed(client, conn, node_id, result.embed_text, embed_model)
+        _finalize_node_version(conn, node_id)
     except Exception as e:
         log.error("node %d (%s): write/embed failed: %s", node_id, source, e)
         return False
@@ -355,10 +380,20 @@ async def main_async(args: argparse.Namespace) -> int:
     base_url = settings.get("lmstudio_base_url", "http://localhost:1234/v1")
     timeout = float(settings.get("lmstudio_timeout_secs", 300.0))
 
-    conn = sqlite3.connect(str(db_path))
+    # vector_store.open_conn loads the sqlite-vec extension (vec0) and
+    # applies the standard PRAGMAs. Plain sqlite3.connect cannot write to
+    # the knowledge_vectors virtual table — embed_knowledge_node would
+    # error with "no such module: vec0".
+    conn = vector_store.open_conn(db_path)
     conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys=ON")
-    conn.execute("PRAGMA busy_timeout=5000")
+    # Autocommit mode: the script juggles its own explicit BEGIN/COMMIT
+    # blocks plus calls into embed_knowledge_node which manages its own
+    # transactions. Python's default DML auto-transaction would leave the
+    # connection mid-transaction after a failed INSERT (vec0 UNIQUE), so
+    # the next explicit BEGIN trips "cannot start a transaction within a
+    # transaction" and every subsequent node fails. Setting isolation_level
+    # to None disables the auto-transaction.
+    conn.isolation_level = None
 
     candidates = _select_candidate_nodes(conn, args.source, args.limit, args.newest_first)
     log.info(

--- a/brain/scripts/re-enrich-knowledge-nodes.py
+++ b/brain/scripts/re-enrich-knowledge-nodes.py
@@ -77,10 +77,6 @@ from hippo_brain.enrichment import (  # noqa: E402
     upsert_entities,
 )
 
-# CLAUDE entity-type map mirrors SHELL — claude enrichment writes the same
-# structured EnrichmentResult shape into knowledge_nodes.content.
-CLAUDE_ENTITY_TYPE_MAP = SHELL_ENTITY_TYPE_MAP
-
 TARGET_ENRICHMENT_VERSION = 2
 
 logging.basicConfig(
@@ -189,17 +185,32 @@ def _build_prompt_for(source: str, payload: list[dict]) -> tuple[str, str]:
 async def _call_llm_with_retries(
     client: LMStudioClient, system_prompt: str, prompt: str, model: str
 ) -> object:
-    """Mirror Server._call_llm_with_retries: 3 attempts, parse on each."""
+    """Mirror Server._call_llm_with_retries: 3 attempts, parse on each.
+
+    On retry attempts (≥2), appends a follow-up user message instructing the
+    model to output ONLY valid JSON. The live brain does this and it
+    materially reduces re-failure rate when a model emits prose around a
+    JSON object — without the hint we'd burn 3 full inferences before
+    giving up. Behavior matches ``Server._call_llm_with_retries`` exactly.
+    """
     last_err: Exception | None = None
     for attempt in range(1, 4):
-        try:
-            raw = await client.chat(
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": prompt},
-                ],
-                model=model,
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ]
+        if attempt > 1:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "Your previous response was not valid JSON. "
+                        "Output ONLY a JSON object, no explanation or markdown."
+                    ),
+                }
             )
+        try:
+            raw = await client.chat(messages=messages, model=model)
             return parse_enrichment_response(raw)
         except Exception as e:
             last_err = e

--- a/brain/tests/test_re_enrich.py
+++ b/brain/tests/test_re_enrich.py
@@ -1,0 +1,232 @@
+"""Smoke tests for brain/scripts/re-enrich-knowledge-nodes.py.
+
+Hyphenated filename → load via importlib. Tests focus on:
+- candidate selection respects enrichment_version filter + source flag
+- single-node round-trip (shell + claude) updates content / entities /
+  enrichment_version inside one transaction
+- already-target-version nodes are NOT re-processed
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from hippo_brain.client import MockLMStudioClient
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "re-enrich-knowledge-nodes.py"
+
+
+@pytest.fixture
+def conn(tmp_db):
+    """tmp_db with Row factory enabled — the script expects dict-able rows."""
+    c, _ = tmp_db
+    c.row_factory = sqlite3.Row
+    return c
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("re_enrich_knowledge_nodes", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def re_enrich(monkeypatch):
+    """Load the script with deterministic project roots pinned."""
+    monkeypatch.setenv("HIPPO_PROJECT_ROOTS", "/Users/test/projects/hippo")
+    from hippo_brain.entity_resolver import _cached_fallback_roots
+
+    _cached_fallback_roots.cache_clear()
+    return _load_script_module()
+
+
+def _seed_shell_node(conn, node_id: int, version: int = 1, created_at: int = 1_700_000_000_000):
+    """Insert a knowledge node + a linked shell event."""
+    node_uuid = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome,
+                                     tags, enrichment_model, enrichment_version,
+                                     created_at, updated_at)
+        VALUES (?, ?, ?, 'old summary', 'observation', 'success',
+                '["old"]', 'old-model', ?, ?, ?)
+        """,
+        (
+            node_id,
+            node_uuid,
+            json.dumps({"summary": "old summary", "entities": {}}),
+            version,
+            created_at,
+            created_at,
+        ),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO sessions (id, start_time, shell, hostname, username) "
+        "VALUES (1, ?, 'zsh', 'host', 'user')",
+        (created_at,),
+    )
+    conn.execute(
+        """
+        INSERT INTO events (session_id, timestamp, command, exit_code, duration_ms,
+                            cwd, hostname, shell)
+        VALUES (1, ?, 'cargo test', 0, 1000, '/project', 'host', 'zsh')
+        """,
+        (created_at,),
+    )
+    event_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        "INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (?, ?)",
+        (node_id, event_id),
+    )
+    conn.commit()
+
+
+def _seed_claude_node(conn, node_id: int, version: int = 1, created_at: int = 1_700_000_000_000):
+    """Insert a knowledge node + a linked claude_session segment."""
+    node_uuid = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome,
+                                     tags, enrichment_model, enrichment_version,
+                                     created_at, updated_at)
+        VALUES (?, ?, ?, 'old', 'observation', 'success',
+                '["old"]', 'old-model', ?, ?, ?)
+        """,
+        (
+            node_id,
+            node_uuid,
+            json.dumps({"summary": "old", "entities": {}}),
+            version,
+            created_at,
+            created_at,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO claude_sessions (session_id, project_dir, cwd, segment_index,
+                                     start_time, end_time, summary_text,
+                                     tool_calls_json, user_prompts_json,
+                                     message_count, source_file, is_subagent)
+        VALUES ('sess-x', '/project', '/project', 0, ?, ?,
+                'fake summary text', '[]', '[]', 5, '/sess.jsonl', 0)
+        """,
+        (created_at, created_at + 1000),
+    )
+    seg_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        "INSERT INTO knowledge_node_claude_sessions (knowledge_node_id, claude_session_id) "
+        "VALUES (?, ?)",
+        (node_id, seg_id),
+    )
+    conn.commit()
+
+
+def test_candidate_selection_respects_version_filter(conn, re_enrich):
+    """Nodes already at TARGET_ENRICHMENT_VERSION must be excluded."""
+
+    _seed_shell_node(conn, node_id=1, version=1)
+    _seed_shell_node(conn, node_id=2, version=re_enrich.TARGET_ENRICHMENT_VERSION)
+
+    candidates = re_enrich._select_candidate_nodes(
+        conn, source="all", limit=None, newest_first=True
+    )
+    ids = [c["id"] for c in candidates]
+    assert ids == [1], f"only node 1 should need re-enrichment; got {ids}"
+
+
+def test_candidate_selection_source_filter(conn, re_enrich):
+
+    _seed_shell_node(conn, node_id=1)
+    _seed_claude_node(conn, node_id=2)
+
+    shell_only = re_enrich._select_candidate_nodes(
+        conn, source="shell", limit=None, newest_first=True
+    )
+    assert [c["_source"] for c in shell_only] == ["shell"]
+
+    claude_only = re_enrich._select_candidate_nodes(
+        conn, source="claude", limit=None, newest_first=True
+    )
+    assert [c["_source"] for c in claude_only] == ["claude"]
+
+
+def test_process_node_updates_in_place(conn, re_enrich):
+    """Round-trip: re-enriching a shell node updates content + bumps version
+    while preserving id / uuid / created_at."""
+
+    _seed_shell_node(conn, node_id=42, created_at=1_700_000_000_000)
+    before = conn.execute("SELECT uuid, created_at FROM knowledge_nodes WHERE id = 42").fetchone()
+    original_uuid, original_created_at = before["uuid"], before["created_at"]
+
+    candidate = {"id": 42, "uuid": original_uuid, "_source": "shell"}
+    client = MockLMStudioClient()
+
+    ok = asyncio.run(
+        re_enrich._process_node(
+            client, conn, candidate, enrichment_model="m", embed_model="", dry_run=False
+        )
+    )
+    assert ok is True
+
+    after = conn.execute(
+        "SELECT uuid, created_at, enrichment_version, content FROM knowledge_nodes WHERE id = 42"
+    ).fetchone()
+    assert after["uuid"] == original_uuid, "uuid must be preserved"
+    assert after["created_at"] == original_created_at, "created_at must be preserved"
+    assert after["enrichment_version"] == re_enrich.TARGET_ENRICHMENT_VERSION
+    new_content = json.loads(after["content"])
+    assert new_content["summary"] == "test command"  # from MockLMStudioClient.CANNED_RESPONSE
+
+
+def test_dry_run_makes_no_changes(conn, re_enrich):
+
+    _seed_shell_node(conn, node_id=7)
+    candidate = {"id": 7, "uuid": "x", "_source": "shell"}
+    client = MockLMStudioClient()
+
+    ok = asyncio.run(
+        re_enrich._process_node(
+            client, conn, candidate, enrichment_model="m", embed_model="", dry_run=True
+        )
+    )
+    assert ok is True
+
+    row = conn.execute(
+        "SELECT enrichment_version, content FROM knowledge_nodes WHERE id = 7"
+    ).fetchone()
+    assert row["enrichment_version"] == 1, "dry-run must not bump version"
+    assert json.loads(row["content"])["summary"] == "old summary"
+    assert client.chat_calls == [], "dry-run must not call the LLM"
+
+
+def test_failed_node_keeps_old_version_for_retry(conn, re_enrich, monkeypatch):
+    """If the LLM call raises after retries, the node stays at v1 so a
+    subsequent run picks it up again."""
+
+    _seed_shell_node(conn, node_id=99)
+
+    class FailingClient(MockLMStudioClient):
+        async def chat(self, *args, **kwargs):
+            raise RuntimeError("simulated lm-studio outage")
+
+    candidate = {"id": 99, "uuid": "x", "_source": "shell"}
+    client = FailingClient()
+
+    ok = asyncio.run(
+        re_enrich._process_node(
+            client, conn, candidate, enrichment_model="m", embed_model="", dry_run=False
+        )
+    )
+    assert ok is False
+
+    row = conn.execute("SELECT enrichment_version FROM knowledge_nodes WHERE id = 99").fetchone()
+    assert row["enrichment_version"] == 1, "failures must NOT bump version"

--- a/brain/tests/test_re_enrich.py
+++ b/brain/tests/test_re_enrich.py
@@ -187,6 +187,45 @@ def test_process_node_updates_in_place(conn, re_enrich):
     assert new_content["summary"] == "test command"  # from MockLMStudioClient.CANNED_RESPONSE
 
 
+def test_process_claude_node_updates_in_place(conn, re_enrich):
+    """Round-trip: re-enriching a claude node uses the joined-summary_text
+    prompt path and bumps version while preserving id / uuid / created_at.
+
+    Mirrors test_process_node_updates_in_place but exercises the claude
+    branch (`_fetch_claude_segments`, summary_text concatenation).
+    """
+    _seed_claude_node(conn, node_id=55, created_at=1_700_000_000_000)
+    before = conn.execute("SELECT uuid, created_at FROM knowledge_nodes WHERE id = 55").fetchone()
+    original_uuid, original_created_at = before["uuid"], before["created_at"]
+
+    candidate = {"id": 55, "uuid": original_uuid, "_source": "claude"}
+    client = MockLMStudioClient()
+
+    ok = asyncio.run(
+        re_enrich._process_node(
+            client, conn, candidate, enrichment_model="m", embed_model="", dry_run=False
+        )
+    )
+    assert ok is True
+
+    after = conn.execute(
+        "SELECT uuid, created_at, enrichment_version, content FROM knowledge_nodes WHERE id = 55"
+    ).fetchone()
+    assert after["uuid"] == original_uuid
+    assert after["created_at"] == original_created_at
+    assert after["enrichment_version"] == re_enrich.TARGET_ENRICHMENT_VERSION
+    assert json.loads(after["content"])["summary"] == "test command"
+
+    # Verify the claude prompt branch was hit (not the shell branch): the
+    # user message should contain the seeded segment's summary_text.
+    user_messages = [
+        m["content"] for call in client.chat_calls for m in call["messages"] if m["role"] == "user"
+    ]
+    assert any("fake summary text" in m for m in user_messages), (
+        "claude prompt should be the joined summary_text"
+    )
+
+
 def test_dry_run_makes_no_changes(conn, re_enrich):
 
     _seed_shell_node(conn, node_id=7)


### PR DESCRIPTION
Closes #110.

One-shot script that re-runs enrichment for nodes that pre-date the prompt + model upgrades shipped in v0.19.1. **Update-in-place** semantics — preserves `id` / `uuid` / `created_at` / link rows, bumps `enrichment_version` from 1 → 2 so re-runs resume cleanly.

## Sources handled

- **shell** (~2,447 nodes) — events looked up via `knowledge_node_events`, prompt via `build_enrichment_prompt`.
- **claude** (~3,895 nodes) — segments via `knowledge_node_claude_sessions`; prompt = `\n---\n`-joined `claude_sessions.summary_text`, mirroring `Server._enrich_claude_batches`.

Together ~99% of the corpus. **Browser (6) and workflow (187) stay at v1** — workflow needs a separate path because its `content` is free-text markdown, not a JSON `EnrichmentResult`; browser is too small to justify the third branch in this script.

## CLI

```
re-enrich-knowledge-nodes.py [--db PATH] [--source shell|claude|all]
                             [--limit N] [--dry-run] [--throttle-ms MS]
                             [--newest-first | --oldest-first]
                             [--model MODEL]
```

Default behavior: process newest first (active queries benefit early), 200ms throttle between nodes (so the live brain's real-time enrichment isn't starved), all sources.

## Design choices (from #110)

- **Reuses brain functions.** Prompt builders, `parse_enrichment_response`, `upsert_entities`, `embed_knowledge_node` are imported directly. The script is a wrapper, not a re-implementation.
- **UPDATE in place.** Inside one transaction: UPDATE `knowledge_nodes`, DELETE `knowledge_node_entities` for this node, re-call `upsert_entities` (which routes through current `canonicalize` + `strip_worktree_prefix`).
- **Bump version only on success.** Failures stay at v1, retried on next run.
- **Resume.** Default WHERE filters `enrichment_version < TARGET`; running twice in a row is a no-op on the second run.

## Tests (5)

- `test_candidate_selection_respects_version_filter` — v2 nodes excluded.
- `test_candidate_selection_source_filter` — `--source` flag isolates.
- `test_process_node_updates_in_place` — uuid/created_at preserved, version bumps, content replaced.
- `test_dry_run_makes_no_changes` — no LLM call, no DB mutation.
- `test_failed_node_keeps_old_version_for_retry` — failure path keeps v1.

Hyphenated filename → loaded via `importlib.util` (same pattern as `test_dedup_entities.py`).

## Test plan

- [x] `uv run --project brain pytest brain/tests` — 776 passed, 1 skipped, 1 xfailed, 1 xpassed
- [x] `uv run --project brain ruff check brain/` — clean
- [x] `uv run --project brain ruff format --check brain/` — clean
- [x] Live-DB dry-run with `--limit 5` — selected mix of claude/shell candidates with reasonable prompt sizes; no errors.
- [ ] Live-DB real run with `--limit 5` to spot-check end-to-end output quality before kicking off the full corpus pass.
- [ ] Operator runs full pass overnight after merge.

## Operator playbook

```bash
# Verify the model + LM Studio are happy
hippo doctor

# Spot-check on a small batch first
HIPPO_PROJECT_ROOTS=\$HOME/projects/hippo \\
  uv run --project brain python brain/scripts/re-enrich-knowledge-nodes.py \\
    --limit 5

# Inspect the result
sqlite3 ~/.local/share/hippo/hippo.db "
  SELECT id, length(embed_text), substr(embed_text, 1, 200)
  FROM knowledge_nodes WHERE enrichment_version = 2
  ORDER BY updated_at DESC LIMIT 5;
"

# If output looks right, run the full pass
HIPPO_PROJECT_ROOTS=\$HOME/projects/hippo \\
  uv run --project brain python brain/scripts/re-enrich-knowledge-nodes.py
```

Throughput on `qwen3.6-35b-a3b-ud-mlx`: ~tens of nodes/min. Full corpus (~6,300 nodes) ≈ a few hours background. Throttle defaults to 200ms; bump higher if real-time enrichment appears starved.

## Acceptance criteria (from #110)

- [x] All processed nodes have `enrichment_version` ≥ TARGET (= 2).
- [x] No orphaned `knowledge_node_*` link rows after the run (the script never deletes anything but `knowledge_node_entities`, which is re-populated via `upsert_entities`).
- [x] Idempotent: second run is a no-op (verified via the version-filter test).
- [ ] Random sample of pre-existing nodes have populated `design_decisions` after re-enrichment (operator verification).
- [ ] `hippo ask` returns verbatim version strings for v0.13.0 dep-bump probe (operator verification).

## Risks (from #110)

- **Cost.** Several GPU-hours. One-shot operation; not a per-edit hook.
- **Bad new enrichment.** If a specific event class produces worse output under qwen3.6 than under the original model, re-enrichment makes things worse. Mitigation: spot-check `--limit 5` before kicking off full corpus.
- **Live brain interference.** Re-enrichment + steady-state enrichment contend for the same LM Studio. Mitigation: 200ms throttle; bump if needed; or stop the brain (`mise run stop`) for fully-offline run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)