### PR TITLE
fix(otel): move Grafana to host port 3030

### DIFF
--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -178,7 +178,7 @@ notify_macos             = false
 #   4. Reinstall: mise run install
 #   5. Verify: hippo doctor
 #
-# Access Grafana: http://localhost:3000 (admin/hippo)
+# Access Grafana: http://localhost:3030 (admin/hippo)
 # OTel Collector health: http://localhost:13133
 enabled = false
 endpoint = "http://localhost:4317"

--- a/extension/claude-skill/monitoring-hippo/SKILL.md
+++ b/extension/claude-skill/monitoring-hippo/SKILL.md
@@ -98,7 +98,7 @@ curl -s http://localhost:13133/
 - Hippo Daemon: http://localhost:3030/d/hippo-daemon
 - Hippo Enrichment Pipeline: http://localhost:3030/d/hippo-enrichment
 
-Login: admin/admin
+Login: admin/hippo
 
 ### Check OTEL Logs
 ```bash
@@ -166,4 +166,4 @@ Run these to confirm hippo is fully operational:
 3. LM Studio: `curl -s http://localhost:1234/v1/models | jq '.data[].id'`
 4. Recent enrichment: `tail -10 ~/.local/share/hippo/brain.stderr.log | grep enriched`
 5. OTEL collector: `curl -s http://localhost:13133/`
-6. Grafana: `curl -s -u admin:admin 'http://localhost:3030/api/search' | jq '.[] | .title'`
+6. Grafana: `curl -s -u admin:hippo 'http://localhost:3030/api/search' | jq '.[] | .title'`

--- a/extension/claude-skill/monitoring-hippo/SKILL.md
+++ b/extension/claude-skill/monitoring-hippo/SKILL.md
@@ -94,9 +94,9 @@ curl -s http://localhost:13133/
 ```
 
 ### Check Grafana Dashboards
-- Hippo Overview: http://localhost:3000/d/hippo-overview
-- Hippo Daemon: http://localhost:3000/d/hippo-daemon
-- Hippo Enrichment Pipeline: http://localhost:3000/d/hippo-enrichment
+- Hippo Overview: http://localhost:3030/d/hippo-overview
+- Hippo Daemon: http://localhost:3030/d/hippo-daemon
+- Hippo Enrichment Pipeline: http://localhost:3030/d/hippo-enrichment
 
 Login: admin/admin
 
@@ -166,4 +166,4 @@ Run these to confirm hippo is fully operational:
 3. LM Studio: `curl -s http://localhost:1234/v1/models | jq '.data[].id'`
 4. Recent enrichment: `tail -10 ~/.local/share/hippo/brain.stderr.log | grep enriched`
 5. OTEL collector: `curl -s http://localhost:13133/`
-6. Grafana: `curl -s -u admin:admin 'http://localhost:3000/api/search' | jq '.[] | .title'`
+6. Grafana: `curl -s -u admin:admin 'http://localhost:3030/api/search' | jq '.[] | .title'`

--- a/mise.toml
+++ b/mise.toml
@@ -743,7 +743,7 @@ if [ "$OTEL_ENABLED" = "0" ] && [ "$OTEL_COLLECTOR_UP" = "1" ]; then
     echo "      To enable observability:"
     echo "        1. Edit ~/.config/hippo/config.toml and set [telemetry] enabled = true"
     echo "        2. Run: mise run restart"
-    echo "        3. Access Grafana: http://localhost:3000 (admin/hippo)"
+    echo "        3. Access Grafana: http://localhost:3030 (admin/hippo)"
 elif [ "$OTEL_ENABLED" = "0" ] && [ "$OTEL_COLLECTOR_UP" = "0" ]; then
     echo "NOTE: OpenTelemetry observability is disabled."
     echo "      To enable it:"
@@ -1042,7 +1042,7 @@ fi
 docker compose up -d --remove-orphans
 echo ""
 echo "=== OTel stack running ==="
-echo "  Grafana:        http://localhost:3000 (admin/hippo)"
+echo "  Grafana:        http://localhost:3030 (admin/hippo)"
 echo "  OTel Collector: localhost:4317 (gRPC) / localhost:4318 (HTTP)"
 echo "  Collector health: http://localhost:13133"
 echo "  Data dir:       $OTEL_DATA_DIR"

--- a/otel/README.md
+++ b/otel/README.md
@@ -22,7 +22,7 @@ export HIPPO_OTEL_ENABLED=1
 mise run restart
 
 # Open Grafana
-open http://localhost:3000
+open http://localhost:3030
 ```
 
 Hippo persists OTEL data on the host under `~/.local/share/hippo/otel/`, so restarting or recreating
@@ -44,7 +44,7 @@ hippo-mcp   ──┘
 | Service | Port | Purpose |
 |---------|------|---------|
 | OTel Collector | 4317 (gRPC), 4318 (HTTP) | Receives OTLP telemetry |
-| Grafana | 3000 | Dashboards and exploration |
+| Grafana | 3030 | Dashboards and exploration |
 | Tempo | 3200 | Trace storage |
 | Loki | 3100 | Log aggregation |
 | Prometheus | 9090 | Metrics storage |

--- a/otel/docker-compose.yml
+++ b/otel/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ${HOME}/.local/share/hippo/otel/grafana:/var/lib/grafana
     ports:
-      - "3000:3000"
+      - "3030:3000"
     depends_on:
       - tempo
       - loki


### PR DESCRIPTION
## Summary
- Re-do of the Grafana port change that was lost when #123 was closed (its branch got force-updated mid-review).
- Host-side mapping `3030:3000` in `otel/docker-compose.yml`; the container port stays 3000, so Grafana's internal config and provisioned datasources are untouched.
- Updates every live reference to `localhost:3000` for Grafana: `config/config.default.toml` comment, `mise.toml` setup-banner + `otel:up` summary, `otel/README.md` quick-start + service table, and the `monitoring-hippo` skill's dashboard URLs and curl smoke test.
- Archived design docs under `docs/archive/` are intentionally untouched — they are historical and should reflect what the system looked like at the time.

## Why
The conventional :3000 dev-server slot was a recurring conflict against local app work. Grafana doesn't need to live there.

## Test plan
- [x] `mise run otel:down && mise run otel:up` — confirm Grafana reachable at http://localhost:3030 and not at :3000
- [x] `hippo doctor` — no regressions (the doctor doesn't probe Grafana directly, so this is mostly a sanity check that nothing on the daemon side hardcoded :3000)
- [x] Spot-check the three dashboards in the monitoring skill load at the new port

🤖 Generated with [Claude Code](https://claude.com/claude-code)