### PR TITLE
fix(bench): unblock BT-29 — same-session pgrp, isolated TMPDIR, real brain port

### DIFF
--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -27,6 +27,7 @@ from hippo_brain.bench.corpus import (
     write_corpus,
 )
 from hippo_brain.bench.orchestrate import orchestrate_run
+from hippo_brain.bench.prod_config import default_prod_brain_url
 from hippo_brain.bench.paths import (
     bench_runs_dir,
     corpus_manifest_path,
@@ -343,7 +344,10 @@ def _build_parser() -> argparse.ArgumentParser:
     run.add_argument("--corpus-version", default="corpus-v2")
     run.add_argument("--base-url", default="http://localhost:1234/v1")
     run.add_argument(
-        "--brain-url", default="http://localhost:8000", help="Prod brain base URL (v2)"
+        "--brain-url",
+        default=default_prod_brain_url(),
+        help="Prod brain base URL (v2). Defaults to http://127.0.0.1:<[brain].port> "
+        "from ~/.config/hippo/config.toml, falling back to port 9175.",
     )
     run.add_argument("--embedding-model", default="text-embedding-nomic-embed-text-v2-moe")
     run.add_argument(
@@ -483,8 +487,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     recover.add_argument(
         "--brain-url",
-        default="http://localhost:8000",
-        help="Prod brain base URL to resume if lockfile doesn't carry one",
+        default=default_prod_brain_url(),
+        help="Prod brain base URL to resume if lockfile doesn't carry one. "
+        "Defaults to http://127.0.0.1:<[brain].port> from ~/.config/hippo/config.toml.",
     )
     recover.set_defaults(func=_cmd_recover)
 

--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -347,7 +347,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--brain-url",
         default=default_prod_brain_url(),
         help="Prod brain base URL (v2). Defaults to http://127.0.0.1:<[brain].port> "
-        "from ~/.config/hippo/config.toml, falling back to port 9175.",
+        "read from $XDG_CONFIG_HOME/hippo/config.toml (or $HOME/.config/hippo/config.toml "
+        "if XDG_CONFIG_HOME is unset), falling back to port 9175.",
     )
     run.add_argument("--embedding-model", default="text-embedding-nomic-embed-text-v2-moe")
     run.add_argument(
@@ -489,7 +490,9 @@ def _build_parser() -> argparse.ArgumentParser:
         "--brain-url",
         default=default_prod_brain_url(),
         help="Prod brain base URL to resume if lockfile doesn't carry one. "
-        "Defaults to http://127.0.0.1:<[brain].port> from ~/.config/hippo/config.toml.",
+        "Defaults to http://127.0.0.1:<[brain].port> read from "
+        "$XDG_CONFIG_HOME/hippo/config.toml (or $HOME/.config/hippo/config.toml "
+        "if XDG_CONFIG_HOME is unset).",
     )
     recover.set_defaults(func=_cmd_recover)
 

--- a/brain/src/hippo_brain/bench/corpus_v2.py
+++ b/brain/src/hippo_brain/bench/corpus_v2.py
@@ -235,17 +235,35 @@ _SOURCE_SPECS: dict[str, _SourceSpec] = {
 }
 
 
-# Shadow DB schema. Mirrors the subset of crates/hippo-core/src/schema.sql
-# that the brain enrichment touches. PRAGMA user_version is set separately
-# from EXPECTED_SCHEMA_VERSION at write time. Keep in sync when the live
-# schema changes the columns of these tables.
+# Shadow DB schema for the bench's INPUT tables. Column-for-column compatible
+# with `crates/hippo-core/src/schema.sql` so the daemon's bench-mode
+# `ensure_schema` pass (which runs schema.sql idempotently to create the
+# OUTPUT tables — knowledge_nodes, entities, knowledge_node_*, etc.) can
+# also create the prod indexes on these input tables without hitting
+# "no such column" errors.
+#
+# Output tables (knowledge_nodes, entities, workflow_annotations, lessons, …)
+# are intentionally NOT created here — the daemon owns them via ensure_schema.
+# Adding new prod columns? Keep this constant in sync with schema.sql so the
+# bench DB's table shapes don't drift.
 _SHADOW_SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS sessions (
     id INTEGER PRIMARY KEY,
-    start_time INTEGER NOT NULL DEFAULT 0,
-    shell TEXT NOT NULL DEFAULT '',
-    hostname TEXT NOT NULL DEFAULT '',
-    username TEXT NOT NULL DEFAULT ''
+    start_time INTEGER NOT NULL,
+    end_time INTEGER,
+    terminal TEXT,
+    shell TEXT NOT NULL,
+    hostname TEXT NOT NULL,
+    username TEXT NOT NULL,
+    summary TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
+);
+
+CREATE TABLE IF NOT EXISTS env_snapshots (
+    id INTEGER PRIMARY KEY,
+    content_hash TEXT NOT NULL UNIQUE,
+    env_json TEXT NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS events (
@@ -255,6 +273,8 @@ CREATE TABLE IF NOT EXISTS events (
     command TEXT NOT NULL,
     stdout TEXT,
     stderr TEXT,
+    stdout_truncated INTEGER DEFAULT 0,
+    stderr_truncated INTEGER DEFAULT 0,
     exit_code INTEGER,
     duration_ms INTEGER NOT NULL,
     cwd TEXT NOT NULL,
@@ -264,12 +284,15 @@ CREATE TABLE IF NOT EXISTS events (
     git_branch TEXT,
     git_commit TEXT,
     git_dirty INTEGER,
+    env_snapshot_id INTEGER REFERENCES env_snapshots(id),
+    envelope_id TEXT,
     source_kind TEXT NOT NULL DEFAULT 'shell',
     tool_name TEXT,
     enriched INTEGER NOT NULL DEFAULT 0,
     redaction_count INTEGER NOT NULL DEFAULT 0,
+    archived_at INTEGER,
     probe_tag TEXT,
-    created_at INTEGER NOT NULL DEFAULT 0
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS enrichment_queue (
@@ -283,8 +306,8 @@ CREATE TABLE IF NOT EXISTS enrichment_queue (
     error_message TEXT,
     locked_at INTEGER,
     locked_by TEXT,
-    created_at INTEGER NOT NULL DEFAULT 0,
-    updated_at INTEGER NOT NULL DEFAULT 0
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS claude_sessions (
@@ -321,8 +344,8 @@ CREATE TABLE IF NOT EXISTS claude_enrichment_queue (
     error_message TEXT,
     locked_at INTEGER,
     locked_by TEXT,
-    created_at INTEGER NOT NULL DEFAULT 0,
-    updated_at INTEGER NOT NULL DEFAULT 0
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS browser_events (
@@ -337,8 +360,10 @@ CREATE TABLE IF NOT EXISTS browser_events (
     search_query TEXT,
     referrer TEXT,
     content_hash TEXT,
+    envelope_id TEXT,
     enriched INTEGER NOT NULL DEFAULT 0,
-    probe_tag TEXT
+    probe_tag TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS browser_enrichment_queue (
@@ -352,8 +377,8 @@ CREATE TABLE IF NOT EXISTS browser_enrichment_queue (
     error_message TEXT,
     locked_at INTEGER,
     locked_by TEXT,
-    created_at INTEGER NOT NULL DEFAULT 0,
-    updated_at INTEGER NOT NULL DEFAULT 0
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS workflow_runs (
@@ -384,8 +409,14 @@ CREATE TABLE IF NOT EXISTS workflow_enrichment_queue (
     error_message TEXT,
     locked_at INTEGER,
     locked_by TEXT,
-    enqueued_at INTEGER NOT NULL DEFAULT 0,
-    updated_at INTEGER NOT NULL DEFAULT 0
+    -- Prod schema declares these NOT NULL with no default (the daemon sets
+    -- them explicitly on every insert). The bench's seeded INSERT only
+    -- supplies (run_id, status), so we add a default for the bench's
+    -- convenience. CREATE TABLE IF NOT EXISTS is a no-op for an existing
+    -- table, so ensure_schema in bench mode does NOT downgrade the bench's
+    -- relaxed defaults — it sees the table already exists and skips.
+    enqueued_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS corpus_meta (

--- a/brain/src/hippo_brain/bench/prod_config.py
+++ b/brain/src/hippo_brain/bench/prod_config.py
@@ -55,7 +55,19 @@ def resolve_prod_brain_port(config_path: Path | None = None) -> int:
         _warn(f"malformed TOML in {path}: {e!s}")
         return DEFAULT_BRAIN_PORT
 
-    port = data.get("brain", {}).get("port", DEFAULT_BRAIN_PORT)
+    # Guard against `brain = 1` (or any scalar value at the [brain] key) —
+    # that's valid TOML and would crash `data.get("brain", {}).get("port")`
+    # with AttributeError, blowing up CLI parser construction before any
+    # subcommand can run. Codex review on PR #130.
+    brain_section = data.get("brain", {})
+    if not isinstance(brain_section, dict):
+        _warn(
+            f"[brain] in {path} is not a table "
+            f"(got {type(brain_section).__name__}={brain_section!r})"
+        )
+        return DEFAULT_BRAIN_PORT
+
+    port = brain_section.get("port", DEFAULT_BRAIN_PORT)
     # bool is an int subclass in Python — `port = true` would silently land
     # as port=1 without this guard. Floats and strings are also rejected.
     if not isinstance(port, int) or isinstance(port, bool):

--- a/brain/src/hippo_brain/bench/prod_config.py
+++ b/brain/src/hippo_brain/bench/prod_config.py
@@ -2,13 +2,20 @@
 own port — by reading `[brain].port` from `~/.config/hippo/config.toml`.
 
 The bench used to hardcode `http://localhost:8000`, which never matched the
-actual brain default of 9175. This caused `prod_brain_reachable: warn` in
-every preflight and silently disabled the prod-pause guarantee.
+actual brain default of 9175 (`hippo_brain.__init__._default_settings`).
+Result: `prod_brain_reachable: warn` in every preflight, and the prod-pause
+guarantee silently skipped because preflight only aborts on `pass + fail`,
+not `warn + fail`.
+
+Parse failures here warn to stderr instead of failing silently — a silent
+fallback would re-enable the same prod-pause-skip footgun the bench exists
+to avoid measuring under.
 """
 
 from __future__ import annotations
 
 import os
+import sys
 import tomllib
 from pathlib import Path
 
@@ -16,7 +23,11 @@ DEFAULT_BRAIN_PORT = 9175
 
 
 def _config_path() -> Path:
-    """Same precedence as `hippo-brain` itself: $XDG_CONFIG_HOME, then $HOME."""
+    """Same precedence as `hippo-brain` itself: $XDG_CONFIG_HOME, then $HOME.
+
+    Per the XDG Base Directory spec, an empty XDG_CONFIG_HOME is treated as
+    unset — falling back to $HOME/.config.
+    """
     xdg = os.environ.get("XDG_CONFIG_HOME")
     base = Path(xdg) if xdg else Path.home() / ".config"
     return base / "hippo" / "config.toml"
@@ -25,10 +36,8 @@ def _config_path() -> Path:
 def resolve_prod_brain_port(config_path: Path | None = None) -> int:
     """Return `[brain].port` from prod config.toml, or DEFAULT_BRAIN_PORT.
 
-    Returns the default on any failure (missing file, malformed TOML, missing
-    section). The bench's preflight will catch a mismatch separately — this
-    function's job is only to produce a sensible default so the bench targets
-    the same port the brain actually serves on.
+    Returns the default silently for the normal "no config file" case, and
+    with a stderr warning for unreadable, malformed, or out-of-spec values.
     """
     path = config_path or _config_path()
     if not path.exists():
@@ -36,10 +45,33 @@ def resolve_prod_brain_port(config_path: Path | None = None) -> int:
     try:
         with path.open("rb") as f:
             data = tomllib.load(f)
-    except tomllib.TOMLDecodeError, OSError:
+    except FileNotFoundError:
+        # Race with .exists() above — file disappeared. Treat as missing.
         return DEFAULT_BRAIN_PORT
+    except (PermissionError, IsADirectoryError) as e:
+        _warn(f"cannot read {path}: {e!s}")
+        return DEFAULT_BRAIN_PORT
+    except tomllib.TOMLDecodeError as e:
+        _warn(f"malformed TOML in {path}: {e!s}")
+        return DEFAULT_BRAIN_PORT
+
     port = data.get("brain", {}).get("port", DEFAULT_BRAIN_PORT)
-    return int(port) if isinstance(port, int) else DEFAULT_BRAIN_PORT
+    # bool is an int subclass in Python — `port = true` would silently land
+    # as port=1 without this guard. Floats and strings are also rejected.
+    if not isinstance(port, int) or isinstance(port, bool):
+        _warn(f"[brain].port in {path} is not an integer (got {type(port).__name__}={port!r})")
+        return DEFAULT_BRAIN_PORT
+    if not 1 <= port <= 65535:
+        _warn(f"[brain].port in {path} is out of range (got {port})")
+        return DEFAULT_BRAIN_PORT
+    return port
+
+
+def _warn(msg: str) -> None:
+    print(
+        f"warning: {msg}; defaulting to brain port {DEFAULT_BRAIN_PORT}",
+        file=sys.stderr,
+    )
 
 
 def default_prod_brain_url(config_path: Path | None = None) -> str:

--- a/brain/src/hippo_brain/bench/prod_config.py
+++ b/brain/src/hippo_brain/bench/prod_config.py
@@ -1,0 +1,46 @@
+"""Resolve the prod brain URL the same way `hippo-brain serve` resolves its
+own port — by reading `[brain].port` from `~/.config/hippo/config.toml`.
+
+The bench used to hardcode `http://localhost:8000`, which never matched the
+actual brain default of 9175. This caused `prod_brain_reachable: warn` in
+every preflight and silently disabled the prod-pause guarantee.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+DEFAULT_BRAIN_PORT = 9175
+
+
+def _config_path() -> Path:
+    """Same precedence as `hippo-brain` itself: $XDG_CONFIG_HOME, then $HOME."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "hippo" / "config.toml"
+
+
+def resolve_prod_brain_port(config_path: Path | None = None) -> int:
+    """Return `[brain].port` from prod config.toml, or DEFAULT_BRAIN_PORT.
+
+    Returns the default on any failure (missing file, malformed TOML, missing
+    section). The bench's preflight will catch a mismatch separately — this
+    function's job is only to produce a sensible default so the bench targets
+    the same port the brain actually serves on.
+    """
+    path = config_path or _config_path()
+    if not path.exists():
+        return DEFAULT_BRAIN_PORT
+    try:
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+    except tomllib.TOMLDecodeError, OSError:
+        return DEFAULT_BRAIN_PORT
+    port = data.get("brain", {}).get("port", DEFAULT_BRAIN_PORT)
+    return int(port) if isinstance(port, int) else DEFAULT_BRAIN_PORT
+
+
+def default_prod_brain_url(config_path: Path | None = None) -> str:
+    return f"http://127.0.0.1:{resolve_prod_brain_port(config_path)}"

--- a/brain/src/hippo_brain/bench/shadow_stack.py
+++ b/brain/src/hippo_brain/bench/shadow_stack.py
@@ -20,6 +20,7 @@ import pathlib
 import shutil
 import signal
 import subprocess
+import tempfile
 import time
 
 import httpx
@@ -32,6 +33,12 @@ class ShadowStack:
     run_tree: pathlib.Path
     process_group_id: int
     brain_base_url: str
+    # Per-run tmpdir under the system temp dir. Isolates the daemon's socket
+    # fallback path (`$TMPDIR/hippo-daemon.sock`) from prod's, since the
+    # bench's run_tree path is too long to fit a Unix socket sun_path on
+    # macOS (104 bytes), forcing the daemon to use the $TMPDIR fallback.
+    # Cleaned up by teardown_shadow_stack.
+    tmpdir: pathlib.Path | None = None
 
 
 def _build_env(
@@ -42,6 +49,7 @@ def _build_env(
     corpus_version: str,
     embedding_model: str,
     otel_enabled: bool,
+    tmpdir: pathlib.Path | None = None,
 ) -> dict[str, str]:
     env = os.environ.copy()
     env["HOME"] = str(run_tree)
@@ -50,6 +58,8 @@ def _build_env(
     # Rust (dirs::home_dir) and Python (Path.home) resolve config to
     # <run_tree>/.config/hippo/config.toml without a separate env var.
     env.pop("XDG_CONFIG_HOME", None)
+    if tmpdir is not None:
+        env["TMPDIR"] = str(tmpdir)
     env["OTEL_RESOURCE_ATTRIBUTES"] = (
         f"service.namespace=hippo-bench,"
         f"bench.run_id={run_id},"
@@ -93,6 +103,15 @@ def spawn_shadow_stack(
 
     _write_shadow_config(run_tree, brain_port)
 
+    # Per-run tmpdir under the system temp dir. The daemon falls back to
+    # `$TMPDIR/hippo-daemon.sock` whenever `data_dir/daemon.sock` exceeds the
+    # macOS sun_path limit (104 bytes) — and the bench run_tree path always
+    # blows that. Without overriding TMPDIR, the bench daemon would race the
+    # prod daemon for the same `$TMPDIR/hippo-daemon.sock`. We deliberately
+    # mkdtemp under the *system* tmp dir (not under run_tree) so the resulting
+    # socket path stays short enough to fit sun_path.
+    tmpdir = pathlib.Path(tempfile.mkdtemp(prefix=f"hippo-bench-{run_id}-"))
+
     env = _build_env(
         run_tree=run_tree,
         run_id=run_id,
@@ -100,20 +119,31 @@ def spawn_shadow_stack(
         corpus_version=corpus_version,
         embedding_model=embedding_model,
         otel_enabled=otel_enabled,
+        tmpdir=tmpdir,
     )
 
     hippo_bin = shutil.which("hippo") or "hippo"
     uv_bin = shutil.which("uv") or "uv"
 
-    # Daemon gets its own session (new process group).
-    # The brain joins the daemon's process group so a single os.killpg tears
-    # both down without orphaning either process.
+    # Daemon and brain share a process group inside the parent's session so a
+    # single os.killpg tears both down without orphaning either.
     #
-    # NOTE: Use "daemon run" — there is no `hippo serve` subcommand. PR #127
-    # shipped `[hippo_bin, "serve"]` which silently failed: shadow daemon
-    # crashed on spawn, brain still came up against the pre-copied corpus DB
-    # so JSONL output kept appearing while bench had no daemon-side
-    # telemetry. Caught by panel review (BT-02).
+    # ORIGINAL DESIGN BUG: this used start_new_session=True on the daemon,
+    # which calls setsid() — putting the daemon in a new POSIX session. The
+    # brain (still in the parent's session) then tried setpgid(0, daemon_pgid)
+    # in its preexec_fn, and POSIX rejects that with EPERM because the target
+    # pgrp is in a different session. Surface error: "SubprocessError:
+    # Exception occurred in preexec_fn." Discovered by the first real BT-29
+    # operator run (2026-05-04) — mocked tests in this file always passed
+    # because subprocess.Popen was stubbed and the kernel never enforced the
+    # cross-session check.
+    #
+    # FIX: daemon's preexec_fn does setpgid(0, 0), creating a NEW pgrp inside
+    # the parent's session (pgid == pid). Parent ALSO calls setpgid as belt-
+    # and-suspenders — whichever wins, daemon ends up as its own pgrp leader.
+    # Brain's preexec_fn then joins that pgrp without crossing a session
+    # boundary, so setpgid succeeds.
+    #
     # BT-11: --bench tells the daemon to log bench mode and assert sandbox
     # isolation. Use `serve` (the BT-09 alias) instead of `daemon run` so the
     # flag has somewhere to land — `daemon run` doesn't accept --bench.
@@ -123,10 +153,15 @@ def spawn_shadow_stack(
             env=env,
             stdout=subprocess.DEVNULL,
             stderr=daemon_log,
-            start_new_session=True,
+            preexec_fn=lambda: os.setpgid(0, 0),
         )
-    # With start_new_session=True the child calls setsid(), making its PID the
-    # process-group leader.  pgid == pid is guaranteed.
+    try:
+        os.setpgid(daemon_proc.pid, daemon_proc.pid)
+    except ProcessLookupError, PermissionError:
+        # ProcessLookupError: daemon already exited (preflight will catch it).
+        # PermissionError: daemon already exec'd, in which case its preexec_fn
+        # already did the setpgid. Either way, no action needed.
+        pass
     daemon_pgid = daemon_proc.pid
 
     with open(logs_dir / "brain.log", "ab") as brain_log:
@@ -144,6 +179,7 @@ def spawn_shadow_stack(
         run_tree=run_tree,
         process_group_id=daemon_pgid,
         brain_base_url=f"http://127.0.0.1:{brain_port}",
+        tmpdir=tmpdir,
     )
 
 
@@ -165,11 +201,12 @@ def wait_for_brain_ready(stack: ShadowStack, timeout_sec: float = 60.0) -> float
 
 
 def teardown_shadow_stack(stack: ShadowStack, sigkill_timeout_sec: float = 10.0) -> None:
-    """SIGTERM the process group, wait, SIGKILL if still alive."""
+    """SIGTERM the process group, wait, SIGKILL if still alive, then clean tmpdir."""
     pgid = stack.process_group_id
     try:
         os.killpg(pgid, signal.SIGTERM)
     except ProcessLookupError:
+        _cleanup_tmpdir(stack)
         return
 
     deadline = time.monotonic() + sigkill_timeout_sec
@@ -177,6 +214,7 @@ def teardown_shadow_stack(stack: ShadowStack, sigkill_timeout_sec: float = 10.0)
         daemon_done = stack.daemon_proc.poll() is not None
         brain_done = stack.brain_proc.poll() is not None
         if daemon_done and brain_done:
+            _cleanup_tmpdir(stack)
             return
         time.sleep(0.1)
 
@@ -184,3 +222,9 @@ def teardown_shadow_stack(stack: ShadowStack, sigkill_timeout_sec: float = 10.0)
         os.killpg(pgid, signal.SIGKILL)
     except ProcessLookupError:
         pass
+    _cleanup_tmpdir(stack)
+
+
+def _cleanup_tmpdir(stack: ShadowStack) -> None:
+    if stack.tmpdir is not None:
+        shutil.rmtree(stack.tmpdir, ignore_errors=True)

--- a/brain/src/hippo_brain/bench/shadow_stack.py
+++ b/brain/src/hippo_brain/bench/shadow_stack.py
@@ -180,13 +180,18 @@ def spawn_shadow_stack(
 
     _write_shadow_config(run_tree, brain_port)
 
-    # Per-run tmpdir under the SYSTEM temp dir (not run_tree) — the daemon's
-    # socket fallback is `$TMPDIR/hippo-daemon.sock`, which must fit a Unix
-    # socket sun_path (104 bytes on macOS). The bench run_tree path alone is
-    # too long, so we mkdtemp under the system tmp dir to keep the resulting
-    # socket path short. Without this, bench daemon races prod for the same
-    # `$TMPDIR/hippo-daemon.sock`.
-    tmpdir = pathlib.Path(tempfile.mkdtemp(prefix=f"hippo-bench-{run_id}-"))
+    # Per-run tmpdir for the daemon's socket-fallback (`$TMPDIR/hippo-daemon.sock`).
+    # Two constraints fight here:
+    #   1. Path must fit Unix socket sun_path (104 bytes on macOS).
+    #   2. Must be unique per bench run, so we don't collide with prod's
+    #      $TMPDIR/hippo-daemon.sock.
+    # macOS `$TMPDIR` resolves to `/var/folders/<HASH>/<HASH>/T/` (~51 chars),
+    # leaving only ~36 chars for prefix+suffix+socket name. Our run_id-prefixed
+    # mkdtemp blew that and the daemon failed bind() with "path must be shorter
+    # than SUN_LEN" (BT-29 validation run, 2026-05-04). We use /tmp directly:
+    # POSIX-guaranteed and short, leaving ~85 chars of headroom. Run identity
+    # comes from the daemon log path, not the socket path.
+    tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="hb-", dir="/tmp"))
 
     try:
         env = _build_env(

--- a/brain/src/hippo_brain/bench/shadow_stack.py
+++ b/brain/src/hippo_brain/bench/shadow_stack.py
@@ -155,9 +155,18 @@ def _spawn_pgrp_pair(
     except BaseException:
         # Brain spawn failed — kill the daemon (and its pgrp) so we don't leak
         # a process holding the shadow brain port. Re-raise the original.
+        # Adversarial-review followup: also reap the daemon. Without an explicit
+        # wait(), the Popen object is GC'd at function exit and Python's
+        # __del__ reaper runs whenever the GC decides — leaving a zombie
+        # visible in `ps` until then. wait()-with-timeout makes the reap
+        # deterministic without blocking forever if SIGKILL didn't land.
         try:
             os.killpg(daemon_pgid, signal.SIGKILL)
         except ProcessLookupError:
+            pass
+        try:
+            daemon_proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
             pass
         raise
 

--- a/brain/src/hippo_brain/bench/shadow_stack.py
+++ b/brain/src/hippo_brain/bench/shadow_stack.py
@@ -1,8 +1,9 @@
 """Shadow process-group spawn and teardown for hippo-bench v2.
 
-Spawns hippo-daemon + hippo-brain in their own process group with:
+Spawns hippo-daemon + hippo-brain in a shared process group with:
   XDG_DATA_HOME=<run_tree>
   HOME=<run_tree>  (so both Rust dirs::home_dir and Python Path.home resolve to run_tree)
+  TMPDIR=<per-run dir>  (isolates daemon socket-fallback from prod's)
   OTEL_RESOURCE_ATTRIBUTES=service.namespace=hippo-bench,...
 
 A minimal config.toml is written to <run_tree>/.config/hippo/config.toml before
@@ -20,6 +21,7 @@ import pathlib
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 
@@ -33,11 +35,10 @@ class ShadowStack:
     run_tree: pathlib.Path
     process_group_id: int
     brain_base_url: str
-    # Per-run tmpdir under the system temp dir. Isolates the daemon's socket
-    # fallback path (`$TMPDIR/hippo-daemon.sock`) from prod's, since the
-    # bench's run_tree path is too long to fit a Unix socket sun_path on
-    # macOS (104 bytes), forcing the daemon to use the $TMPDIR fallback.
-    # Cleaned up by teardown_shadow_stack.
+    # Per-run system tmpdir. The macOS sun_path limit (104 bytes) is shorter
+    # than `<run_tree>/daemon.sock`, so the daemon falls back to
+    # `$TMPDIR/hippo-daemon.sock` — without per-run TMPDIR isolation that
+    # collides with prod's socket. Cleaned by teardown_shadow_stack.
     tmpdir: pathlib.Path | None = None
 
 
@@ -87,6 +88,82 @@ def _write_shadow_config(run_tree: pathlib.Path, brain_port: int) -> None:
     )
 
 
+def _spawn_pgrp_pair(
+    *,
+    daemon_cmd: list[str],
+    brain_cmd: list[str],
+    env: dict[str, str],
+    daemon_log: pathlib.Path,
+    brain_log: pathlib.Path,
+) -> tuple[subprocess.Popen, subprocess.Popen, int]:
+    """Spawn two children in a shared process group inside the parent's session.
+
+    Daemon becomes pgrp leader (pgid == pid) via preexec_fn; brain joins it.
+    Returns (daemon_proc, brain_proc, pgid). Raises RuntimeError if the
+    daemon dies before becoming leader (with a pointer to daemon_log). If the
+    brain spawn raises, kills the daemon's pgrp before re-raising — never
+    returns a half-initialized pair.
+
+    POSIX: setpgid into a target pgrp requires the target to be in the same
+    session as the caller. start_new_session=True on the daemon would put it
+    in a new session, breaking brain's join with EPERM.
+    """
+    with open(daemon_log, "ab") as daemon_log_f:
+        daemon_proc = subprocess.Popen(
+            daemon_cmd,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=daemon_log_f,
+            preexec_fn=lambda: os.setpgid(0, 0),
+        )
+
+    # Belt-and-suspenders: parent races child's preexec to install the pgrp.
+    # PermissionError = child exec'd first (its preexec already did setpgid).
+    # ProcessLookupError = daemon already died (next check raises with log path).
+    try:
+        os.setpgid(daemon_proc.pid, daemon_proc.pid)
+    except ProcessLookupError, PermissionError:
+        pass
+
+    # Daemon liveness check (bounded). Without this, a daemon that crashes
+    # on exec (broken binary, sandbox assertion failure, missing flag, port
+    # already bound) leaves the brain to time out on /health 60s later with
+    # a misleading "brain not ready" error — and the real diagnostic stays
+    # buried in daemon_log with no breadcrumb. We poll for up to 200ms to
+    # give a fast-failing child time to exit before we declare it alive;
+    # slower failures are caught by wait_for_brain_ready's parallel daemon
+    # poll. If you raise this window, adjust the spawn budget tests too.
+    liveness_deadline = time.monotonic() + 0.2
+    while time.monotonic() < liveness_deadline:
+        if daemon_proc.poll() is not None:
+            raise RuntimeError(
+                f"daemon exited with code {daemon_proc.returncode} before "
+                f"becoming pgrp leader; see {daemon_log} for stderr"
+            )
+        time.sleep(0.02)
+    daemon_pgid = daemon_proc.pid
+
+    try:
+        with open(brain_log, "ab") as brain_log_f:
+            brain_proc = subprocess.Popen(
+                brain_cmd,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=brain_log_f,
+                preexec_fn=lambda: os.setpgid(0, daemon_pgid),
+            )
+    except BaseException:
+        # Brain spawn failed — kill the daemon (and its pgrp) so we don't leak
+        # a process holding the shadow brain port. Re-raise the original.
+        try:
+            os.killpg(daemon_pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        raise
+
+    return daemon_proc, brain_proc, daemon_pgid
+
+
 def spawn_shadow_stack(
     *,
     run_tree: pathlib.Path,
@@ -103,75 +180,40 @@ def spawn_shadow_stack(
 
     _write_shadow_config(run_tree, brain_port)
 
-    # Per-run tmpdir under the system temp dir. The daemon falls back to
-    # `$TMPDIR/hippo-daemon.sock` whenever `data_dir/daemon.sock` exceeds the
-    # macOS sun_path limit (104 bytes) — and the bench run_tree path always
-    # blows that. Without overriding TMPDIR, the bench daemon would race the
-    # prod daemon for the same `$TMPDIR/hippo-daemon.sock`. We deliberately
-    # mkdtemp under the *system* tmp dir (not under run_tree) so the resulting
-    # socket path stays short enough to fit sun_path.
+    # Per-run tmpdir under the SYSTEM temp dir (not run_tree) — the daemon's
+    # socket fallback is `$TMPDIR/hippo-daemon.sock`, which must fit a Unix
+    # socket sun_path (104 bytes on macOS). The bench run_tree path alone is
+    # too long, so we mkdtemp under the system tmp dir to keep the resulting
+    # socket path short. Without this, bench daemon races prod for the same
+    # `$TMPDIR/hippo-daemon.sock`.
     tmpdir = pathlib.Path(tempfile.mkdtemp(prefix=f"hippo-bench-{run_id}-"))
 
-    env = _build_env(
-        run_tree=run_tree,
-        run_id=run_id,
-        model_id=model_id,
-        corpus_version=corpus_version,
-        embedding_model=embedding_model,
-        otel_enabled=otel_enabled,
-        tmpdir=tmpdir,
-    )
-
-    hippo_bin = shutil.which("hippo") or "hippo"
-    uv_bin = shutil.which("uv") or "uv"
-
-    # Daemon and brain share a process group inside the parent's session so a
-    # single os.killpg tears both down without orphaning either.
-    #
-    # ORIGINAL DESIGN BUG: this used start_new_session=True on the daemon,
-    # which calls setsid() — putting the daemon in a new POSIX session. The
-    # brain (still in the parent's session) then tried setpgid(0, daemon_pgid)
-    # in its preexec_fn, and POSIX rejects that with EPERM because the target
-    # pgrp is in a different session. Surface error: "SubprocessError:
-    # Exception occurred in preexec_fn." Discovered by the first real BT-29
-    # operator run (2026-05-04) — mocked tests in this file always passed
-    # because subprocess.Popen was stubbed and the kernel never enforced the
-    # cross-session check.
-    #
-    # FIX: daemon's preexec_fn does setpgid(0, 0), creating a NEW pgrp inside
-    # the parent's session (pgid == pid). Parent ALSO calls setpgid as belt-
-    # and-suspenders — whichever wins, daemon ends up as its own pgrp leader.
-    # Brain's preexec_fn then joins that pgrp without crossing a session
-    # boundary, so setpgid succeeds.
-    #
-    # BT-11: --bench tells the daemon to log bench mode and assert sandbox
-    # isolation. Use `serve` (the BT-09 alias) instead of `daemon run` so the
-    # flag has somewhere to land — `daemon run` doesn't accept --bench.
-    with open(logs_dir / "daemon.log", "ab") as daemon_log:
-        daemon_proc = subprocess.Popen(
-            [hippo_bin, "serve", "--bench"],
-            env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=daemon_log,
-            preexec_fn=lambda: os.setpgid(0, 0),
-        )
     try:
-        os.setpgid(daemon_proc.pid, daemon_proc.pid)
-    except ProcessLookupError, PermissionError:
-        # ProcessLookupError: daemon already exited (preflight will catch it).
-        # PermissionError: daemon already exec'd, in which case its preexec_fn
-        # already did the setpgid. Either way, no action needed.
-        pass
-    daemon_pgid = daemon_proc.pid
-
-    with open(logs_dir / "brain.log", "ab") as brain_log:
-        brain_proc = subprocess.Popen(
-            [uv_bin, "run", "--project", "brain", "hippo-brain", "serve"],
-            env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=brain_log,
-            preexec_fn=lambda: os.setpgid(0, daemon_pgid),
+        env = _build_env(
+            run_tree=run_tree,
+            run_id=run_id,
+            model_id=model_id,
+            corpus_version=corpus_version,
+            embedding_model=embedding_model,
+            otel_enabled=otel_enabled,
+            tmpdir=tmpdir,
         )
+
+        hippo_bin = shutil.which("hippo") or "hippo"
+        uv_bin = shutil.which("uv") or "uv"
+
+        daemon_proc, brain_proc, daemon_pgid = _spawn_pgrp_pair(
+            daemon_cmd=[hippo_bin, "serve", "--bench"],
+            brain_cmd=[uv_bin, "run", "--project", "brain", "hippo-brain", "serve"],
+            env=env,
+            daemon_log=logs_dir / "daemon.log",
+            brain_log=logs_dir / "brain.log",
+        )
+    except BaseException:
+        # Spawn failed — clean tmpdir before propagating so we don't leak
+        # per-run sockets/files across attempts.
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        raise
 
     return ShadowStack(
         daemon_proc=daemon_proc,
@@ -184,12 +226,24 @@ def spawn_shadow_stack(
 
 
 def wait_for_brain_ready(stack: ShadowStack, timeout_sec: float = 60.0) -> float:
-    """Poll /health until 200. Returns elapsed seconds. Raises TimeoutError."""
+    """Poll /health until 200. Returns elapsed seconds.
+
+    Raises TimeoutError if the brain never responds, OR RuntimeError if the
+    daemon dies during the wait — second-line check beyond _spawn_pgrp_pair's
+    bounded liveness window. The brain doesn't talk to the daemon during
+    startup, so brain `/health` could return 200 while the daemon is dead;
+    this catcher prevents us from declaring readiness in that state.
+    """
     start = time.monotonic()
     deadline = start + timeout_sec
     url = f"{stack.brain_base_url}/health"
     last_err: Exception | None = None
     while time.monotonic() < deadline:
+        if stack.daemon_proc.poll() is not None:
+            raise RuntimeError(
+                f"daemon exited with code {stack.daemon_proc.returncode} "
+                f"during brain readiness wait; see {stack.run_tree}/logs/daemon.log"
+            )
         try:
             resp = httpx.get(url, timeout=2.0)
             if resp.status_code == 200:
@@ -221,10 +275,27 @@ def teardown_shadow_stack(stack: ShadowStack, sigkill_timeout_sec: float = 10.0)
     try:
         os.killpg(pgid, signal.SIGKILL)
     except ProcessLookupError:
-        pass
+        # pgrp gone between SIGTERM and SIGKILL — usually a benign race, but
+        # could indicate a process escaped via setsid. Log so future leak
+        # triage has a breadcrumb.
+        print(
+            f"shadow_stack: pgrp {pgid} disappeared before SIGKILL "
+            f"(likely benign race; investigate {stack.run_tree}/logs if leaks suspected)",
+            file=sys.stderr,
+        )
     _cleanup_tmpdir(stack)
 
 
 def _cleanup_tmpdir(stack: ShadowStack) -> None:
-    if stack.tmpdir is not None:
-        shutil.rmtree(stack.tmpdir, ignore_errors=True)
+    if stack.tmpdir is None:
+        return
+
+    def _on_rmtree_exc(_func, path, exc):
+        # Log instead of swallow — accumulating $TMPDIR/hippo-bench-*/ leaks
+        # are otherwise invisible to the operator.
+        print(
+            f"shadow_stack: tmpdir cleanup leaked {path}: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+
+    shutil.rmtree(stack.tmpdir, onexc=_on_rmtree_exc)

--- a/brain/tests/test_bench_prod_config.py
+++ b/brain/tests/test_bench_prod_config.py
@@ -1,0 +1,63 @@
+"""Tests for hippo_brain.bench.prod_config — prod brain URL/port resolver.
+
+Regression context: bench v2 hardcoded `http://localhost:8000` as the prod
+brain URL, but `hippo-brain serve` defaults to port 9175 (see
+`hippo_brain.__init__._default_settings`). The mismatch silently warned in
+every preflight and skipped the prod-pause guarantee. This module reads
+`[brain].port` from prod config.toml the way the brain itself does.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hippo_brain.bench.prod_config import (
+    DEFAULT_BRAIN_PORT,
+    default_prod_brain_url,
+    resolve_prod_brain_port,
+)
+
+
+def test_default_when_config_missing(tmp_path: Path):
+    missing = tmp_path / "no-such-config.toml"
+    assert resolve_prod_brain_port(missing) == DEFAULT_BRAIN_PORT
+    assert default_prod_brain_url(missing) == f"http://127.0.0.1:{DEFAULT_BRAIN_PORT}"
+
+
+def test_reads_brain_port_from_config(tmp_path: Path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[brain]\nport = 12345\n")
+    assert resolve_prod_brain_port(cfg) == 12345
+    assert default_prod_brain_url(cfg) == "http://127.0.0.1:12345"
+
+
+def test_default_when_section_missing(tmp_path: Path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[storage]\ndata_dir = '/tmp'\n")
+    assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+
+
+def test_default_on_malformed_toml(tmp_path: Path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("this is not :: valid = toml\n[][\n")
+    assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+
+
+def test_default_on_non_int_port(tmp_path: Path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[brain]\nport = 'nine-thousand'\n")
+    assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+
+
+def test_xdg_config_home_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """When XDG_CONFIG_HOME is set, the resolver looks there first — matching
+    `hippo-brain`'s own behavior. We verify by setting XDG_CONFIG_HOME to a
+    dir that contains a brain port override."""
+    xdg = tmp_path / "xdg"
+    (xdg / "hippo").mkdir(parents=True)
+    (xdg / "hippo" / "config.toml").write_text("[brain]\nport = 7777\n")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setenv("HOME", str(tmp_path / "wrong-home"))
+    assert resolve_prod_brain_port() == 7777

--- a/brain/tests/test_bench_prod_config.py
+++ b/brain/tests/test_bench_prod_config.py
@@ -5,6 +5,11 @@ brain URL, but `hippo-brain serve` defaults to port 9175 (see
 `hippo_brain.__init__._default_settings`). The mismatch silently warned in
 every preflight and skipped the prod-pause guarantee. This module reads
 `[brain].port` from prod config.toml the way the brain itself does.
+
+Per the silent-failure audit on PR #130 follow-up: parse failures must NOT
+fall back silently — that re-enables the same prod-pause-skip footgun.
+These tests assert stderr warnings fire on every fall-back path except
+"file legitimately doesn't exist."
 """
 
 from __future__ import annotations
@@ -20,44 +25,109 @@ from hippo_brain.bench.prod_config import (
 )
 
 
-def test_default_when_config_missing(tmp_path: Path):
+def test_default_when_config_missing(tmp_path: Path, capsys: pytest.CaptureFixture):
     missing = tmp_path / "no-such-config.toml"
     assert resolve_prod_brain_port(missing) == DEFAULT_BRAIN_PORT
     assert default_prod_brain_url(missing) == f"http://127.0.0.1:{DEFAULT_BRAIN_PORT}"
+    # Missing config is the normal install state — must NOT warn.
+    captured = capsys.readouterr()
+    assert captured.err == ""
 
 
-def test_reads_brain_port_from_config(tmp_path: Path):
+def test_reads_brain_port_from_config(tmp_path: Path, capsys: pytest.CaptureFixture):
     cfg = tmp_path / "config.toml"
     cfg.write_text("[brain]\nport = 12345\n")
     assert resolve_prod_brain_port(cfg) == 12345
     assert default_prod_brain_url(cfg) == "http://127.0.0.1:12345"
+    assert capsys.readouterr().err == ""
 
 
-def test_default_when_section_missing(tmp_path: Path):
+def test_default_when_section_missing(tmp_path: Path, capsys: pytest.CaptureFixture):
     cfg = tmp_path / "config.toml"
     cfg.write_text("[storage]\ndata_dir = '/tmp'\n")
     assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+    # Missing [brain] section is benign (uses defaults), no warn.
+    assert capsys.readouterr().err == ""
 
 
-def test_default_on_malformed_toml(tmp_path: Path):
+def test_warns_on_malformed_toml(tmp_path: Path, capsys: pytest.CaptureFixture):
     cfg = tmp_path / "config.toml"
     cfg.write_text("this is not :: valid = toml\n[][\n")
     assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+    err = capsys.readouterr().err
+    assert "malformed TOML" in err
+    assert str(cfg) in err
+    assert f"port {DEFAULT_BRAIN_PORT}" in err
 
 
-def test_default_on_non_int_port(tmp_path: Path):
+def test_warns_on_unreadable_config(tmp_path: Path, capsys: pytest.CaptureFixture):
+    """A directory at the config path raises IsADirectoryError on open. We
+    can't reliably create a file we can't read on the test fs (root owns
+    chmod 000), so IsADirectoryError stands in for the broader OSError
+    family this catches."""
+    cfg_dir = tmp_path / "config.toml"  # directory, not a file
+    cfg_dir.mkdir()
+    assert resolve_prod_brain_port(cfg_dir) == DEFAULT_BRAIN_PORT
+    err = capsys.readouterr().err
+    assert "cannot read" in err
+    assert str(cfg_dir) in err
+
+
+def test_warns_on_non_int_port(tmp_path: Path, capsys: pytest.CaptureFixture):
     cfg = tmp_path / "config.toml"
     cfg.write_text("[brain]\nport = 'nine-thousand'\n")
     assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+    err = capsys.readouterr().err
+    assert "not an integer" in err
+    assert "str" in err
+
+
+def test_warns_on_float_port(tmp_path: Path, capsys: pytest.CaptureFixture):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[brain]\nport = 9175.0\n")
+    assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+    err = capsys.readouterr().err
+    assert "not an integer" in err
+    assert "float" in err
+
+
+def test_warns_on_bool_port(tmp_path: Path, capsys: pytest.CaptureFixture):
+    """bool is an int subclass in Python — `port = true` would silently land
+    as port=1 without an isinstance(port, bool) guard."""
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[brain]\nport = true\n")
+    assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+    err = capsys.readouterr().err
+    assert "not an integer" in err
+    assert "bool" in err
+
+
+def test_warns_on_out_of_range_port(tmp_path: Path, capsys: pytest.CaptureFixture):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[brain]\nport = 99999\n")
+    assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+    err = capsys.readouterr().err
+    assert "out of range" in err
+    assert "99999" in err
 
 
 def test_xdg_config_home_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """When XDG_CONFIG_HOME is set, the resolver looks there first — matching
-    `hippo-brain`'s own behavior. We verify by setting XDG_CONFIG_HOME to a
-    dir that contains a brain port override."""
+    `hippo-brain`'s own behavior."""
     xdg = tmp_path / "xdg"
     (xdg / "hippo").mkdir(parents=True)
     (xdg / "hippo" / "config.toml").write_text("[brain]\nport = 7777\n")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
     monkeypatch.setenv("HOME", str(tmp_path / "wrong-home"))
     assert resolve_prod_brain_port() == 7777
+
+
+def test_empty_xdg_config_home_treated_as_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Per XDG Base Directory spec: an empty XDG_CONFIG_HOME is treated as
+    unset, falling back to $HOME/.config."""
+    home = tmp_path / "home"
+    (home / ".config" / "hippo").mkdir(parents=True)
+    (home / ".config" / "hippo" / "config.toml").write_text("[brain]\nport = 4444\n")
+    monkeypatch.setenv("XDG_CONFIG_HOME", "")  # empty, must be ignored
+    monkeypatch.setenv("HOME", str(home))
+    assert resolve_prod_brain_port() == 4444

--- a/brain/tests/test_bench_prod_config.py
+++ b/brain/tests/test_bench_prod_config.py
@@ -111,6 +111,20 @@ def test_warns_on_out_of_range_port(tmp_path: Path, capsys: pytest.CaptureFixtur
     assert "99999" in err
 
 
+def test_warns_when_brain_key_is_scalar_not_table(tmp_path: Path, capsys: pytest.CaptureFixture):
+    """Codex review on PR #130: `brain = 1` (scalar at the [brain] key) is
+    valid TOML but would crash `data.get("brain", {}).get("port")` with
+    AttributeError. Since this resolver runs at argparse-default time, the
+    crash would blow up CLI parser construction — before any subcommand
+    can even be requested. Must defend against the non-dict shape."""
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('brain = "not-a-table"\n')
+    assert resolve_prod_brain_port(cfg) == DEFAULT_BRAIN_PORT
+    err = capsys.readouterr().err
+    assert "[brain]" in err
+    assert "not a table" in err
+
+
 def test_xdg_config_home_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """When XDG_CONFIG_HOME is set, the resolver looks there first — matching
     `hippo-brain`'s own behavior."""

--- a/brain/tests/test_bench_shadow_stack.py
+++ b/brain/tests/test_bench_shadow_stack.py
@@ -1,10 +1,11 @@
-"""Tests for hippo_brain.bench.shadow_stack — env injection, teardown, readiness probe.
+"""Tests for hippo_brain.bench.shadow_stack — env injection, pgrp spawn,
+teardown, readiness probe.
 
-Most tests mock subprocess.Popen and httpx (does NOT spawn real hippo). The
-real-subprocess regression test at the bottom (test_pgrp_join_with_real_subprocesses)
-is the one that would have caught the cross-session setpgid bug discovered
-during the first BT-29 operator run on 2026-05-04 — see comments in
-shadow_stack.spawn_shadow_stack for the full incident.
+Most tests mock subprocess.Popen and httpx (no real hippo binaries spawn).
+The real-subprocess test (test_spawn_pgrp_pair_with_real_subprocesses)
+exercises the actual _spawn_pgrp_pair helper used by spawn_shadow_stack —
+this is what would have caught the cross-session setpgid bug discovered
+during the first BT-29 operator run on 2026-05-04.
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ import pytest
 from hippo_brain.bench import shadow_stack
 from hippo_brain.bench.shadow_stack import (
     ShadowStack,
+    _spawn_pgrp_pair,
     spawn_shadow_stack,
     teardown_shadow_stack,
     wait_for_brain_ready,
@@ -41,15 +43,19 @@ def _spawn_kwargs(tmp_path: pathlib.Path, **overrides):
 
 
 def _capture_popen_calls(monkeypatch, tmp_path: pathlib.Path):
-    """Patch subprocess.Popen, tempfile.mkdtemp, and os.setpgid for tests that
-    only inspect the kwargs/env passed to Popen. Returns the captured calls
-    list. Real subprocess work happens in test_pgrp_join_with_real_subprocesses."""
+    """Patch subprocess.Popen, tempfile.mkdtemp, and pgrp syscalls for tests
+    that only inspect kwargs/env passed to Popen.
+
+    Each fake Popen returns a MagicMock with `poll()` returning None (alive),
+    so the daemon liveness check in _spawn_pgrp_pair doesn't raise."""
     calls: list[tuple[tuple, dict]] = []
 
     def fake_popen(*args, **kwargs):
         calls.append((args, kwargs))
         proc = MagicMock()
-        proc.pid = 99999  # fake pid
+        proc.pid = 99999
+        proc.poll.return_value = None  # alive — important for liveness check
+        proc.returncode = None
         return proc
 
     def fake_mkdtemp(prefix: str = "tmp", **_kwargs) -> str:
@@ -60,7 +66,7 @@ def _capture_popen_calls(monkeypatch, tmp_path: pathlib.Path):
     monkeypatch.setattr(shadow_stack.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(shadow_stack.tempfile, "mkdtemp", fake_mkdtemp)
     monkeypatch.setattr(shadow_stack.os, "getpgid", lambda _pid: 88888)
-    # Belt-and-suspenders parent-side setpgid is benign in tests; swallow it.
+    # Belt-and-suspenders parent-side setpgid is benign in tests; swallow.
     monkeypatch.setattr(shadow_stack.os, "setpgid", lambda _pid, _pgid: None)
     return calls
 
@@ -99,9 +105,8 @@ def test_env_injection_xdg_data_home(tmp_path, monkeypatch):
 
 def test_env_injection_isolates_tmpdir(tmp_path, monkeypatch):
     """TMPDIR is overridden to a per-run path so the daemon's socket-fallback
-    path (`$TMPDIR/hippo-daemon.sock`) does not collide with the prod
-    daemon's. Without this, both daemons race for one socket and the bench
-    silently corrupts capture state. See follow-up #1 in PR #X."""
+    (`$TMPDIR/hippo-daemon.sock`) does not collide with prod's. Without this
+    the bench daemon races prod for the same socket."""
     calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {"TMPDIR": "/var/folders/should-not-leak"}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
@@ -109,7 +114,7 @@ def test_env_injection_isolates_tmpdir(tmp_path, monkeypatch):
     assert len(calls) == 2
     for _args, kwargs in calls:
         env = kwargs["env"]
-        # Must NOT inherit the parent's TMPDIR (that's where prod's socket lives).
+        # Must NOT inherit the parent's TMPDIR (where prod's socket lives).
         assert env["TMPDIR"] != "/var/folders/should-not-leak"
         # Must point at a per-run path containing the run_id, so concurrent
         # bench runs don't collide with each other either.
@@ -120,12 +125,12 @@ def test_pgrp_setup_uses_preexec_fn_in_same_session(tmp_path, monkeypatch):
     """REGRESSION: daemon must NOT use start_new_session=True. That puts it in
     a new POSIX session, and brain's setpgid(0, daemon_pgid) then fails with
     EPERM (cross-session setpgid is forbidden). Daemon must use preexec_fn
-    setpgid(0, 0) so the new pgrp lives inside the parent's session, and
-    brain's preexec setpgid into that pgrp succeeds.
+    setpgid(0, 0) so the new pgrp lives inside the parent's session.
 
-    NB: this test only inspects Popen kwargs — it does NOT exercise the actual
-    POSIX behavior. The test_pgrp_join_with_real_subprocesses test below is
-    what verifies the kernel actually accepts the resulting setpgid pattern."""
+    NB: this is the kwargs-level catcher — it asserts spawn_shadow_stack
+    USES the right Popen pattern. The companion
+    test_spawn_pgrp_pair_with_real_subprocesses verifies the kernel actually
+    accepts that pattern. Both are needed; they catch different regressions."""
     calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
@@ -133,21 +138,16 @@ def test_pgrp_setup_uses_preexec_fn_in_same_session(tmp_path, monkeypatch):
     assert len(calls) == 2
     daemon_kwargs = calls[0][1]
     brain_kwargs = calls[1][1]
-    # Daemon stays in parent's session and creates a new pgrp via preexec_fn.
-    # start_new_session would put it in a NEW session, breaking brain's join.
     assert daemon_kwargs.get("start_new_session") is not True
     assert callable(daemon_kwargs.get("preexec_fn"))
-    # Brain joins daemon's process group via preexec_fn (same session, OK).
     assert brain_kwargs.get("start_new_session") is not True
     assert callable(brain_kwargs.get("preexec_fn"))
 
 
 def test_otel_disabled_by_default(tmp_path, monkeypatch):
     calls = _capture_popen_calls(monkeypatch, tmp_path)
-    # Even if parent env has HIPPO_OTEL_ENABLED=1, an unsolicited otel_enabled=False
-    # call must NOT propagate it to the shadow stack.
     with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}, clear=True):
-        spawn_shadow_stack(**_spawn_kwargs(tmp_path))  # otel_enabled defaults to False
+        spawn_shadow_stack(**_spawn_kwargs(tmp_path))
 
     assert len(calls) == 2
     for _args, kwargs in calls:
@@ -166,10 +166,108 @@ def test_otel_enabled_when_requested(tmp_path, monkeypatch):
         assert env["HIPPO_OTEL_ENABLED"] == "1"
 
 
+def test_daemon_dead_after_spawn_raises_with_log_path(tmp_path, monkeypatch):
+    """If the daemon crashes on exec, spawn_shadow_stack must raise with the
+    daemon log path — NOT silently let the brain spawn and time out 60s
+    later on /health with a misleading 'brain not ready' error."""
+    popen_calls: list = []
+
+    def fake_popen(*args, **kwargs):
+        popen_calls.append((args, kwargs))
+        proc = MagicMock()
+        proc.pid = 99999
+        # First call (daemon): poll() returns 1, simulating immediate exit.
+        # If the brain is ever spawned, return None to keep test honest.
+        proc.poll.return_value = 1 if len(popen_calls) == 1 else None
+        proc.returncode = 1 if len(popen_calls) == 1 else None
+        return proc
+
+    def fake_mkdtemp(prefix: str = "tmp", **_kwargs) -> str:
+        d = tmp_path / f"{prefix}mkdtemp"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(shadow_stack.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_stack.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(shadow_stack.os, "setpgid", lambda _pid, _pgid: None)
+
+    with patch.dict(os.environ, {}, clear=True), pytest.raises(RuntimeError) as exc_info:
+        spawn_shadow_stack(**_spawn_kwargs(tmp_path))
+
+    msg = str(exc_info.value)
+    assert "daemon exited with code 1" in msg
+    assert "daemon.log" in msg
+    # Brain spawn must NOT have been attempted after the daemon was dead.
+    assert len(popen_calls) == 1
+
+
+def test_brain_spawn_failure_kills_daemon_pgrp(tmp_path, monkeypatch):
+    """If the brain Popen raises, the daemon must be SIGKILL'd — otherwise
+    a leaked daemon holds shadow brain port 18923 and breaks the next run."""
+    killpg_calls: list[tuple[int, int]] = []
+    popen_calls: list = []
+
+    def fake_popen(*_args, **_kwargs):
+        if len(popen_calls) == 0:
+            # Daemon: succeeds, alive.
+            popen_calls.append("daemon")
+            proc = MagicMock()
+            proc.pid = 99999
+            proc.poll.return_value = None
+            return proc
+        # Brain: spawn raises.
+        popen_calls.append("brain")
+        raise OSError("ENFILE: too many open files")
+
+    def fake_mkdtemp(prefix: str = "tmp", **_kwargs) -> str:
+        d = tmp_path / f"{prefix}mkdtemp"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(shadow_stack.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_stack.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(shadow_stack.os, "setpgid", lambda _pid, _pgid: None)
+    monkeypatch.setattr(
+        shadow_stack.os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))
+    )
+
+    with patch.dict(os.environ, {}, clear=True), pytest.raises(OSError, match="ENFILE"):
+        spawn_shadow_stack(**_spawn_kwargs(tmp_path))
+
+    # Daemon's pgrp must have been SIGKILL'd before the OSError propagated.
+    assert killpg_calls == [(99999, signal.SIGKILL)]
+    assert popen_calls == ["daemon", "brain"]
+
+
+def test_spawn_failure_cleans_tmpdir(tmp_path, monkeypatch):
+    """tmpdir must be removed when spawn fails — otherwise repeated failed
+    bench attempts accumulate $TMPDIR/hippo-bench-*/ leaks."""
+    captured_tmpdir: list[str] = []
+
+    def fake_mkdtemp(prefix: str = "tmp", **_kwargs) -> str:
+        d = tmp_path / f"{prefix}mkdtemp"
+        d.mkdir(parents=True, exist_ok=True)
+        captured_tmpdir.append(str(d))
+        return str(d)
+
+    def fake_popen(*_args, **_kwargs):
+        # Daemon spawn raises immediately, before the brain is touched.
+        raise OSError("simulated spawn failure")
+
+    monkeypatch.setattr(shadow_stack.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_stack.tempfile, "mkdtemp", fake_mkdtemp)
+
+    with patch.dict(os.environ, {}, clear=True), pytest.raises(OSError):
+        spawn_shadow_stack(**_spawn_kwargs(tmp_path))
+
+    assert len(captured_tmpdir) == 1
+    assert not pathlib.Path(captured_tmpdir[0]).exists(), "tmpdir must be cleaned on spawn failure"
+
+
 def test_teardown_sigterm_then_sigkill(monkeypatch, tmp_path):
     """When processes don't exit after SIGTERM, teardown escalates to SIGKILL."""
     daemon_proc = MagicMock()
-    daemon_proc.poll.return_value = None  # never exits
+    daemon_proc.poll.return_value = None
     brain_proc = MagicMock()
     brain_proc.poll.return_value = None
 
@@ -190,13 +288,11 @@ def test_teardown_sigterm_then_sigkill(monkeypatch, tmp_path):
 
     monkeypatch.setattr(shadow_stack.os, "killpg", fake_killpg)
 
-    # Use a tiny timeout so we don't wait the full 10 seconds.
     teardown_shadow_stack(stack, sigkill_timeout_sec=0.05)
 
     assert len(killpg_calls) == 2
     assert killpg_calls[0] == (12345, signal.SIGTERM)
     assert killpg_calls[1] == (12345, signal.SIGKILL)
-    # tmpdir must be cleaned even on SIGKILL path (no leak across runs).
     assert not (tmp_path / "leftover-tmpdir").exists()
 
 
@@ -223,14 +319,88 @@ def test_teardown_tolerates_process_lookup_error(monkeypatch, tmp_path):
     monkeypatch.setattr(shadow_stack.os, "killpg", fake_killpg)
 
     teardown_shadow_stack(stack, sigkill_timeout_sec=0.05)
-    # Even when the pgrp is gone before SIGTERM lands, the tmpdir still cleans up.
     assert not (tmp_path / "early-exit-tmpdir").exists()
 
 
-def test_wait_for_brain_ready_timeout(monkeypatch):
-    """When /health never responds, wait_for_brain_ready raises TimeoutError."""
+def test_teardown_sigkill_pgrp_disappeared_logs_to_stderr(monkeypatch, tmp_path, capsys):
+    """If the pgrp dies between SIGTERM and SIGKILL, teardown must log the
+    race so future leak triage has a breadcrumb. Today this is silent."""
+    daemon_proc = MagicMock()
+    daemon_proc.poll.return_value = None  # never exits before SIGKILL
+    brain_proc = MagicMock()
+    brain_proc.poll.return_value = None
+
     stack = ShadowStack(
-        daemon_proc=MagicMock(),
+        daemon_proc=daemon_proc,
+        brain_proc=brain_proc,
+        run_tree=tmp_path / "fake-run-tree",
+        process_group_id=99999,
+        brain_base_url="http://127.0.0.1:18923",
+        tmpdir=tmp_path / "tmpdir",
+    )
+    (tmp_path / "tmpdir").mkdir()
+
+    killpg_calls: list[tuple[int, int]] = []
+
+    def fake_killpg(pgid, sig):
+        killpg_calls.append((pgid, sig))
+        if sig == signal.SIGKILL:
+            raise ProcessLookupError("pgrp gone between SIGTERM and SIGKILL")
+
+    monkeypatch.setattr(shadow_stack.os, "killpg", fake_killpg)
+
+    teardown_shadow_stack(stack, sigkill_timeout_sec=0.05)
+
+    assert killpg_calls == [(99999, signal.SIGTERM), (99999, signal.SIGKILL)]
+    err = capsys.readouterr().err
+    assert "pgrp 99999 disappeared before SIGKILL" in err
+
+
+def test_cleanup_tmpdir_logs_leaks_via_onexc(monkeypatch, tmp_path, capsys):
+    """When rmtree can't fully clean tmpdir, the failure must be logged —
+    not silently swallowed via ignore_errors=True."""
+    daemon_proc = MagicMock()
+    daemon_proc.poll.return_value = 0
+    brain_proc = MagicMock()
+    brain_proc.poll.return_value = 0
+
+    stuck_tmpdir = tmp_path / "stuck-tmpdir"
+    stuck_tmpdir.mkdir()
+
+    stack = ShadowStack(
+        daemon_proc=daemon_proc,
+        brain_proc=brain_proc,
+        run_tree=tmp_path / "fake-run-tree",
+        process_group_id=12345,
+        brain_base_url="http://127.0.0.1:18923",
+        tmpdir=stuck_tmpdir,
+    )
+
+    monkeypatch.setattr(shadow_stack.os, "killpg", lambda _pgid, _sig: None)
+
+    def fake_rmtree(_path, **kwargs):
+        # Simulate a child file failing to unlink. shadow_stack's onexc
+        # callback should log the failure to stderr.
+        cb = kwargs.get("onexc")
+        assert cb is not None, "_cleanup_tmpdir must pass onexc, not ignore_errors"
+        cb(os.unlink, str(stuck_tmpdir / "leaked-socket"), PermissionError("EPERM"))
+
+    monkeypatch.setattr(shadow_stack.shutil, "rmtree", fake_rmtree)
+
+    teardown_shadow_stack(stack, sigkill_timeout_sec=0.05)
+
+    err = capsys.readouterr().err
+    assert "tmpdir cleanup leaked" in err
+    assert "leaked-socket" in err
+    assert "PermissionError" in err
+
+
+def test_wait_for_brain_ready_timeout(monkeypatch):
+    """When /health never responds and daemon stays alive, raises TimeoutError."""
+    daemon_proc = MagicMock()
+    daemon_proc.poll.return_value = None  # alive — must NOT trigger RuntimeError
+    stack = ShadowStack(
+        daemon_proc=daemon_proc,
         brain_proc=MagicMock(),
         run_tree=pathlib.Path("/tmp/x"),
         process_group_id=12345,
@@ -247,86 +417,110 @@ def test_wait_for_brain_ready_timeout(monkeypatch):
         wait_for_brain_ready(stack, timeout_sec=0.05)
 
 
+def test_wait_for_brain_ready_raises_when_daemon_dies_during_wait(monkeypatch):
+    """If the daemon dies WHILE brain is starting up, wait_for_brain_ready
+    must surface the daemon's exit (not silently wait the full 60s and then
+    blame the brain). The brain may legitimately come up healthy without the
+    daemon, so brain /health=200 is not sufficient evidence of readiness."""
+    daemon_proc = MagicMock()
+    daemon_proc.poll.return_value = 42  # dead
+    daemon_proc.returncode = 42
+    stack = ShadowStack(
+        daemon_proc=daemon_proc,
+        brain_proc=MagicMock(),
+        run_tree=pathlib.Path("/tmp/x"),
+        process_group_id=12345,
+        brain_base_url="http://127.0.0.1:18923",
+    )
+
+    def fake_get(*_args, **_kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(shadow_stack.httpx, "get", fake_get)
+    monkeypatch.setattr(shadow_stack.time, "sleep", lambda _s: None)
+
+    with pytest.raises(RuntimeError, match="daemon exited with code 42"):
+        wait_for_brain_ready(stack, timeout_sec=10.0)
+
+
 @pytest.mark.skipif(
     sys.platform == "win32" or not hasattr(os, "setpgid"),
     reason="POSIX setpgid required",
 )
-def test_pgrp_join_with_real_subprocesses():
-    """REGRESSION (BT-29 first operator run, 2026-05-04): exercises the EXACT
-    Popen pattern shadow_stack uses, with two real /bin/sh sleep stubs
-    standing in for the daemon and the brain. Verifies that:
+def test_spawn_pgrp_pair_with_real_subprocesses(tmp_path):
+    """REGRESSION (BT-29 first operator run, 2026-05-04): exercises the actual
+    `_spawn_pgrp_pair` helper used by spawn_shadow_stack, with `/bin/sh` sleep
+    stubs standing in for the daemon and brain. Verifies that the kernel
+    actually accepts the setpgid pattern (no EPERM cross-session error) and
+    that both processes end up in the same pgrp.
 
-      1. The daemon ends up as its own process-group leader (pgid == pid).
-      2. The brain successfully joins the daemon's pgrp without raising
-         SubprocessError ('Exception occurred in preexec_fn').
-      3. Daemon and brain end up in the SAME pgrp, so a single os.killpg
-         tears both down.
-
-    Mocked tests cannot catch this bug because subprocess.Popen is stubbed and
-    the kernel never enforces the cross-session setpgid restriction. The
-    original implementation passed start_new_session=True on the daemon, which
-    silently broke this test would surface as EPERM in step 2."""
-    daemon = subprocess.Popen(
-        ["/bin/sh", "-c", "sleep 30"],
-        preexec_fn=lambda: os.setpgid(0, 0),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+    Mocked tests cannot catch this bug because subprocess.Popen is stubbed
+    and the kernel never enforces the cross-session setpgid restriction.
+    Calling the real helper (not duplicating the Popen pattern inline) means
+    a future revert to start_new_session=True inside _spawn_pgrp_pair would
+    break this test."""
+    daemon_proc, brain_proc, daemon_pgid = _spawn_pgrp_pair(
+        daemon_cmd=["/bin/sh", "-c", "sleep 30"],
+        brain_cmd=["/bin/sh", "-c", "sleep 30"],
+        env=os.environ.copy(),
+        daemon_log=tmp_path / "daemon.log",
+        brain_log=tmp_path / "brain.log",
     )
     try:
-        # Belt-and-suspenders parent-side setpgid; matches shadow_stack.
-        try:
-            os.setpgid(daemon.pid, daemon.pid)
-        except ProcessLookupError, PermissionError:
-            pass
-
-        # Wait for daemon to actually be its own pgrp leader (preexec ran).
+        # Wait briefly for both children's preexec_fns to install pgrp.
         deadline = time.monotonic() + 2.0
         while time.monotonic() < deadline:
             try:
-                if os.getpgid(daemon.pid) == daemon.pid:
+                if (
+                    os.getpgid(daemon_proc.pid) == daemon_pgid
+                    and os.getpgid(brain_proc.pid) == daemon_pgid
+                ):
                     break
             except ProcessLookupError:
-                pytest.fail(f"daemon {daemon.pid} exited before becoming pgrp leader")
+                pytest.fail("a child exited before joining pgrp — likely EPERM")
             time.sleep(0.005)
         else:
-            pytest.fail(f"daemon {daemon.pid} never became its own pgrp leader")
+            pytest.fail(
+                f"children never converged on pgrp {daemon_pgid}: "
+                f"daemon={os.getpgid(daemon_proc.pid)}, "
+                f"brain={os.getpgid(brain_proc.pid)}"
+            )
 
-        daemon_pgid = daemon.pid
-
-        brain = subprocess.Popen(
-            ["/bin/sh", "-c", "sleep 30"],
-            preexec_fn=lambda: os.setpgid(0, daemon_pgid),
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        try:
-            # Wait for brain to land in daemon's pgrp.
-            deadline = time.monotonic() + 2.0
-            while time.monotonic() < deadline:
-                try:
-                    if os.getpgid(brain.pid) == daemon_pgid:
-                        break
-                except ProcessLookupError:
-                    pytest.fail(
-                        f"brain {brain.pid} exited before joining pgrp "
-                        f"{daemon_pgid} — likely EPERM in preexec_fn"
-                    )
-                time.sleep(0.005)
-            else:
-                pytest.fail(f"brain {brain.pid} never joined daemon pgrp {daemon_pgid}")
-
-            assert os.getpgid(brain.pid) == os.getpgid(daemon.pid) == daemon_pgid
-        finally:
-            brain.terminate()
-            try:
-                brain.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                brain.kill()
-                brain.wait(timeout=2)
+        assert os.getpgid(daemon_proc.pid) == daemon_pgid
+        assert os.getpgid(brain_proc.pid) == daemon_pgid
+        assert daemon_pgid == daemon_proc.pid
     finally:
-        daemon.terminate()
-        try:
-            daemon.wait(timeout=2)
-        except subprocess.TimeoutExpired:
-            daemon.kill()
-            daemon.wait(timeout=2)
+        for proc in (brain_proc, daemon_proc):
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or not hasattr(os, "setpgid"),
+    reason="POSIX setpgid required",
+)
+def test_spawn_pgrp_pair_raises_with_log_path_when_daemon_dies(tmp_path):
+    """Real-subprocess version of test_daemon_dead_after_spawn_raises — uses a
+    `/bin/sh -c 'exit 17'` daemon that exits immediately, and asserts the
+    helper raises with the daemon log path before attempting brain spawn."""
+    daemon_log = tmp_path / "daemon.log"
+    brain_log = tmp_path / "brain.log"
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _spawn_pgrp_pair(
+            daemon_cmd=["/bin/sh", "-c", "exit 17"],
+            brain_cmd=["/bin/sh", "-c", "sleep 30"],  # never reached
+            env=os.environ.copy(),
+            daemon_log=daemon_log,
+            brain_log=brain_log,
+        )
+
+    msg = str(exc_info.value)
+    assert "daemon exited with code 17" in msg
+    assert str(daemon_log) in msg
+    # Brain log must NOT have been created — we never reached the brain spawn.
+    assert not brain_log.exists()

--- a/brain/tests/test_bench_shadow_stack.py
+++ b/brain/tests/test_bench_shadow_stack.py
@@ -1,6 +1,10 @@
 """Tests for hippo_brain.bench.shadow_stack — env injection, teardown, readiness probe.
 
-Mocks subprocess.Popen and httpx throughout — does NOT spawn real hippo processes.
+Most tests mock subprocess.Popen and httpx (does NOT spawn real hippo). The
+real-subprocess regression test at the bottom (test_pgrp_join_with_real_subprocesses)
+is the one that would have caught the cross-session setpgid bug discovered
+during the first BT-29 operator run on 2026-05-04 — see comments in
+shadow_stack.spawn_shadow_stack for the full incident.
 """
 
 from __future__ import annotations
@@ -8,6 +12,9 @@ from __future__ import annotations
 import os
 import pathlib
 import signal
+import subprocess
+import sys
+import time
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -33,22 +40,33 @@ def _spawn_kwargs(tmp_path: pathlib.Path, **overrides):
     }
 
 
-def _capture_popen_calls(monkeypatch):
+def _capture_popen_calls(monkeypatch, tmp_path: pathlib.Path):
+    """Patch subprocess.Popen, tempfile.mkdtemp, and os.setpgid for tests that
+    only inspect the kwargs/env passed to Popen. Returns the captured calls
+    list. Real subprocess work happens in test_pgrp_join_with_real_subprocesses."""
     calls: list[tuple[tuple, dict]] = []
 
     def fake_popen(*args, **kwargs):
         calls.append((args, kwargs))
         proc = MagicMock()
-        proc.pid = 99999  # fake pid; we patch os.getpgid below
+        proc.pid = 99999  # fake pid
         return proc
 
+    def fake_mkdtemp(prefix: str = "tmp", **_kwargs) -> str:
+        d = tmp_path / f"{prefix}fake-mkdtemp"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
     monkeypatch.setattr(shadow_stack.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_stack.tempfile, "mkdtemp", fake_mkdtemp)
     monkeypatch.setattr(shadow_stack.os, "getpgid", lambda _pid: 88888)
+    # Belt-and-suspenders parent-side setpgid is benign in tests; swallow it.
+    monkeypatch.setattr(shadow_stack.os, "setpgid", lambda _pid, _pgid: None)
     return calls
 
 
 def test_env_injection_otel_resource_attributes(tmp_path, monkeypatch):
-    calls = _capture_popen_calls(monkeypatch)
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
 
@@ -63,7 +81,7 @@ def test_env_injection_otel_resource_attributes(tmp_path, monkeypatch):
 
 
 def test_env_injection_xdg_data_home(tmp_path, monkeypatch):
-    calls = _capture_popen_calls(monkeypatch)
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     run_tree = tmp_path / "run-tree"
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path, run_tree=run_tree))
@@ -79,25 +97,53 @@ def test_env_injection_xdg_data_home(tmp_path, monkeypatch):
         assert "XDG_CONFIG_HOME" not in env
 
 
-def test_start_new_session_flag(tmp_path, monkeypatch):
-    """Daemon owns a new session (process-group leader); brain joins via preexec_fn."""
-    calls = _capture_popen_calls(monkeypatch)
+def test_env_injection_isolates_tmpdir(tmp_path, monkeypatch):
+    """TMPDIR is overridden to a per-run path so the daemon's socket-fallback
+    path (`$TMPDIR/hippo-daemon.sock`) does not collide with the prod
+    daemon's. Without this, both daemons race for one socket and the bench
+    silently corrupts capture state. See follow-up #1 in PR #X."""
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
+    with patch.dict(os.environ, {"TMPDIR": "/var/folders/should-not-leak"}, clear=True):
+        spawn_shadow_stack(**_spawn_kwargs(tmp_path))
+
+    assert len(calls) == 2
+    for _args, kwargs in calls:
+        env = kwargs["env"]
+        # Must NOT inherit the parent's TMPDIR (that's where prod's socket lives).
+        assert env["TMPDIR"] != "/var/folders/should-not-leak"
+        # Must point at a per-run path containing the run_id, so concurrent
+        # bench runs don't collide with each other either.
+        assert "run-2026-04-27-abc" in env["TMPDIR"]
+
+
+def test_pgrp_setup_uses_preexec_fn_in_same_session(tmp_path, monkeypatch):
+    """REGRESSION: daemon must NOT use start_new_session=True. That puts it in
+    a new POSIX session, and brain's setpgid(0, daemon_pgid) then fails with
+    EPERM (cross-session setpgid is forbidden). Daemon must use preexec_fn
+    setpgid(0, 0) so the new pgrp lives inside the parent's session, and
+    brain's preexec setpgid into that pgrp succeeds.
+
+    NB: this test only inspects Popen kwargs — it does NOT exercise the actual
+    POSIX behavior. The test_pgrp_join_with_real_subprocesses test below is
+    what verifies the kernel actually accepts the resulting setpgid pattern."""
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
 
     assert len(calls) == 2
     daemon_kwargs = calls[0][1]
     brain_kwargs = calls[1][1]
-    # Daemon creates a new session so os.killpg targets its group.
-    assert daemon_kwargs.get("start_new_session") is True
-    assert daemon_kwargs.get("preexec_fn") is None
-    # Brain joins the daemon's process group via preexec_fn, not start_new_session.
+    # Daemon stays in parent's session and creates a new pgrp via preexec_fn.
+    # start_new_session would put it in a NEW session, breaking brain's join.
+    assert daemon_kwargs.get("start_new_session") is not True
+    assert callable(daemon_kwargs.get("preexec_fn"))
+    # Brain joins daemon's process group via preexec_fn (same session, OK).
     assert brain_kwargs.get("start_new_session") is not True
     assert callable(brain_kwargs.get("preexec_fn"))
 
 
 def test_otel_disabled_by_default(tmp_path, monkeypatch):
-    calls = _capture_popen_calls(monkeypatch)
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     # Even if parent env has HIPPO_OTEL_ENABLED=1, an unsolicited otel_enabled=False
     # call must NOT propagate it to the shadow stack.
     with patch.dict(os.environ, {"HIPPO_OTEL_ENABLED": "1"}, clear=True):
@@ -110,7 +156,7 @@ def test_otel_disabled_by_default(tmp_path, monkeypatch):
 
 
 def test_otel_enabled_when_requested(tmp_path, monkeypatch):
-    calls = _capture_popen_calls(monkeypatch)
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path, otel_enabled=True))
 
@@ -120,7 +166,7 @@ def test_otel_enabled_when_requested(tmp_path, monkeypatch):
         assert env["HIPPO_OTEL_ENABLED"] == "1"
 
 
-def test_teardown_sigterm_then_sigkill(monkeypatch):
+def test_teardown_sigterm_then_sigkill(monkeypatch, tmp_path):
     """When processes don't exit after SIGTERM, teardown escalates to SIGKILL."""
     daemon_proc = MagicMock()
     daemon_proc.poll.return_value = None  # never exits
@@ -133,7 +179,9 @@ def test_teardown_sigterm_then_sigkill(monkeypatch):
         run_tree=pathlib.Path("/tmp/x"),
         process_group_id=12345,
         brain_base_url="http://127.0.0.1:18923",
+        tmpdir=tmp_path / "leftover-tmpdir",
     )
+    (tmp_path / "leftover-tmpdir").mkdir()
 
     killpg_calls: list[tuple[int, int]] = []
 
@@ -148,9 +196,11 @@ def test_teardown_sigterm_then_sigkill(monkeypatch):
     assert len(killpg_calls) == 2
     assert killpg_calls[0] == (12345, signal.SIGTERM)
     assert killpg_calls[1] == (12345, signal.SIGKILL)
+    # tmpdir must be cleaned even on SIGKILL path (no leak across runs).
+    assert not (tmp_path / "leftover-tmpdir").exists()
 
 
-def test_teardown_tolerates_process_lookup_error(monkeypatch):
+def test_teardown_tolerates_process_lookup_error(monkeypatch, tmp_path):
     """If the process group is already gone, teardown should not raise."""
     daemon_proc = MagicMock()
     daemon_proc.poll.return_value = 0
@@ -163,7 +213,9 @@ def test_teardown_tolerates_process_lookup_error(monkeypatch):
         run_tree=pathlib.Path("/tmp/x"),
         process_group_id=12345,
         brain_base_url="http://127.0.0.1:18923",
+        tmpdir=tmp_path / "early-exit-tmpdir",
     )
+    (tmp_path / "early-exit-tmpdir").mkdir()
 
     def fake_killpg(_pgid, _sig):
         raise ProcessLookupError("no such process group")
@@ -171,6 +223,8 @@ def test_teardown_tolerates_process_lookup_error(monkeypatch):
     monkeypatch.setattr(shadow_stack.os, "killpg", fake_killpg)
 
     teardown_shadow_stack(stack, sigkill_timeout_sec=0.05)
+    # Even when the pgrp is gone before SIGTERM lands, the tmpdir still cleans up.
+    assert not (tmp_path / "early-exit-tmpdir").exists()
 
 
 def test_wait_for_brain_ready_timeout(monkeypatch):
@@ -191,3 +245,88 @@ def test_wait_for_brain_ready_timeout(monkeypatch):
 
     with pytest.raises(TimeoutError):
         wait_for_brain_ready(stack, timeout_sec=0.05)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or not hasattr(os, "setpgid"),
+    reason="POSIX setpgid required",
+)
+def test_pgrp_join_with_real_subprocesses():
+    """REGRESSION (BT-29 first operator run, 2026-05-04): exercises the EXACT
+    Popen pattern shadow_stack uses, with two real /bin/sh sleep stubs
+    standing in for the daemon and the brain. Verifies that:
+
+      1. The daemon ends up as its own process-group leader (pgid == pid).
+      2. The brain successfully joins the daemon's pgrp without raising
+         SubprocessError ('Exception occurred in preexec_fn').
+      3. Daemon and brain end up in the SAME pgrp, so a single os.killpg
+         tears both down.
+
+    Mocked tests cannot catch this bug because subprocess.Popen is stubbed and
+    the kernel never enforces the cross-session setpgid restriction. The
+    original implementation passed start_new_session=True on the daemon, which
+    silently broke this test would surface as EPERM in step 2."""
+    daemon = subprocess.Popen(
+        ["/bin/sh", "-c", "sleep 30"],
+        preexec_fn=lambda: os.setpgid(0, 0),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        # Belt-and-suspenders parent-side setpgid; matches shadow_stack.
+        try:
+            os.setpgid(daemon.pid, daemon.pid)
+        except ProcessLookupError, PermissionError:
+            pass
+
+        # Wait for daemon to actually be its own pgrp leader (preexec ran).
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            try:
+                if os.getpgid(daemon.pid) == daemon.pid:
+                    break
+            except ProcessLookupError:
+                pytest.fail(f"daemon {daemon.pid} exited before becoming pgrp leader")
+            time.sleep(0.005)
+        else:
+            pytest.fail(f"daemon {daemon.pid} never became its own pgrp leader")
+
+        daemon_pgid = daemon.pid
+
+        brain = subprocess.Popen(
+            ["/bin/sh", "-c", "sleep 30"],
+            preexec_fn=lambda: os.setpgid(0, daemon_pgid),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            # Wait for brain to land in daemon's pgrp.
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                try:
+                    if os.getpgid(brain.pid) == daemon_pgid:
+                        break
+                except ProcessLookupError:
+                    pytest.fail(
+                        f"brain {brain.pid} exited before joining pgrp "
+                        f"{daemon_pgid} — likely EPERM in preexec_fn"
+                    )
+                time.sleep(0.005)
+            else:
+                pytest.fail(f"brain {brain.pid} never joined daemon pgrp {daemon_pgid}")
+
+            assert os.getpgid(brain.pid) == os.getpgid(daemon.pid) == daemon_pgid
+        finally:
+            brain.terminate()
+            try:
+                brain.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                brain.kill()
+                brain.wait(timeout=2)
+    finally:
+        daemon.terminate()
+        try:
+            daemon.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+            daemon.wait(timeout=2)

--- a/brain/tests/test_bench_shadow_stack.py
+++ b/brain/tests/test_bench_shadow_stack.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 import os
 import pathlib
+import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from unittest.mock import MagicMock, patch
 
@@ -104,21 +106,60 @@ def test_env_injection_xdg_data_home(tmp_path, monkeypatch):
 
 
 def test_env_injection_isolates_tmpdir(tmp_path, monkeypatch):
-    """TMPDIR is overridden to a per-run path so the daemon's socket-fallback
-    (`$TMPDIR/hippo-daemon.sock`) does not collide with prod's. Without this
-    the bench daemon races prod for the same socket."""
-    calls = _capture_popen_calls(monkeypatch, tmp_path)
+    """TMPDIR override uses a per-run path under /tmp (not parent's $TMPDIR
+    where prod's socket lives, and not under run_tree where path-length blows
+    sun_path). Verifies the mkdtemp call shape; sun_path budget is verified
+    end-to-end by test_tmpdir_socket_path_fits_macos_sun_path."""
+    mkdtemp_calls: list[dict] = []
+
+    def fake_mkdtemp(**kwargs):
+        mkdtemp_calls.append(kwargs)
+        d = tmp_path / "fake-mkdtemp"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    def fake_popen(*_args, **_kwargs):
+        proc = MagicMock()
+        proc.pid = 99999
+        proc.poll.return_value = None
+        return proc
+
+    monkeypatch.setattr(shadow_stack.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_stack.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(shadow_stack.os, "setpgid", lambda _pid, _pgid: None)
+
     with patch.dict(os.environ, {"TMPDIR": "/var/folders/should-not-leak"}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
 
-    assert len(calls) == 2
-    for _args, kwargs in calls:
-        env = kwargs["env"]
-        # Must NOT inherit the parent's TMPDIR (where prod's socket lives).
-        assert env["TMPDIR"] != "/var/folders/should-not-leak"
-        # Must point at a per-run path containing the run_id, so concurrent
-        # bench runs don't collide with each other either.
-        assert "run-2026-04-27-abc" in env["TMPDIR"]
+    assert len(mkdtemp_calls) == 1
+    # /tmp is short and POSIX-guaranteed — leaves room under sun_path for the
+    # mkdtemp suffix + "hippo-daemon.sock". macOS $TMPDIR (~51 chars) does NOT.
+    assert mkdtemp_calls[0].get("dir") == "/tmp"
+    # Short prefix preserves headroom for the random suffix.
+    assert mkdtemp_calls[0].get("prefix") == "hb-"
+
+
+def test_tmpdir_socket_path_fits_macos_sun_path():
+    """REGRESSION (BT-29 validation, 2026-05-04): the daemon's socket-fallback
+    is `$TMPDIR/hippo-daemon.sock`, and bind() enforces sun_path (104 bytes
+    on macOS — the tightest constraint we support). The original mkdtemp
+    call used a long run_id-prefixed path under `$TMPDIR`, producing ~133
+    char socket paths that failed bind() with `path must be shorter than
+    SUN_LEN`. Pin the call shape so a future change reverting to a longer
+    prefix or to the system $TMPDIR breaks here, not in production."""
+    macos_sun_path_max = 104
+    socket_name = "hippo-daemon.sock"
+
+    # Same call shape as shadow_stack.spawn_shadow_stack uses in production.
+    tmpdir = tempfile.mkdtemp(prefix="hb-", dir="/tmp")
+    try:
+        socket_path = f"{tmpdir}/{socket_name}"
+        assert len(socket_path) < macos_sun_path_max, (
+            f"socket path is {len(socket_path)} bytes, exceeds macOS sun_path "
+            f"limit of {macos_sun_path_max}: {socket_path}"
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_pgrp_setup_uses_preexec_fn_in_same_session(tmp_path, monkeypatch):

--- a/brain/tests/test_bench_telemetry_isolation.py
+++ b/brain/tests/test_bench_telemetry_isolation.py
@@ -29,23 +29,37 @@ def _spawn_kwargs(tmp_path, **overrides):
     }
 
 
-def _capture_popen_calls(monkeypatch):
+def _capture_popen_calls(monkeypatch, tmp_path):
+    """Patch subprocess.Popen, tempfile.mkdtemp, and pgrp syscalls so
+    spawn_shadow_stack runs to completion without touching real binaries.
+
+    Each fake Popen returns poll()=None (alive) so the daemon liveness
+    check inside _spawn_pgrp_pair doesn't raise."""
     calls: list[tuple[tuple, dict]] = []
 
     def fake_popen(*args, **kwargs):
         calls.append((args, kwargs))
         proc = MagicMock()
         proc.pid = 99999
+        proc.poll.return_value = None  # alive
+        proc.returncode = None
         return proc
 
+    def fake_mkdtemp(prefix: str = "tmp", **_kwargs) -> str:
+        d = tmp_path / f"{prefix}fake-mkdtemp"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
     monkeypatch.setattr(shadow_stack.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_stack.tempfile, "mkdtemp", fake_mkdtemp)
     monkeypatch.setattr(shadow_stack.os, "getpgid", lambda _pid: 88888)
+    monkeypatch.setattr(shadow_stack.os, "setpgid", lambda _pid, _pgid: None)
     return calls
 
 
 def test_otel_resource_attributes_contains_namespace(tmp_path, monkeypatch):
     """Every Popen call must carry service.namespace=hippo-bench in OTEL_RESOURCE_ATTRIBUTES."""
-    calls = _capture_popen_calls(monkeypatch)
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
 
@@ -58,7 +72,7 @@ def test_otel_resource_attributes_contains_namespace(tmp_path, monkeypatch):
 
 def test_otel_resource_attributes_contains_run_id(tmp_path, monkeypatch):
     """Every Popen call must carry bench.run_id=<run_id> in OTEL_RESOURCE_ATTRIBUTES."""
-    calls = _capture_popen_calls(monkeypatch)
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
 
@@ -71,7 +85,7 @@ def test_otel_resource_attributes_contains_run_id(tmp_path, monkeypatch):
 
 def test_otel_resource_attributes_contains_model_id(tmp_path, monkeypatch):
     """Every Popen call must carry bench.model_id=<model_id> in OTEL_RESOURCE_ATTRIBUTES."""
-    calls = _capture_popen_calls(monkeypatch)
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
 
@@ -108,7 +122,7 @@ def test_python_sdk_picks_up_env_namespace():
 def test_bench_namespace_is_not_empty(tmp_path, monkeypatch):
     """Prod dashboards filter on empty namespace; bench MUST NOT use empty.
     Otherwise bench spans would leak into prod views."""
-    calls = _capture_popen_calls(monkeypatch)
+    calls = _capture_popen_calls(monkeypatch, tmp_path)
     with patch.dict(os.environ, {}, clear=True):
         spawn_shadow_stack(**_spawn_kwargs(tmp_path))
 

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -659,6 +659,28 @@ pub fn open_db(path: &Path) -> Result<Connection> {
     Ok(conn)
 }
 
+/// Idempotently apply the full `schema.sql` to an already-open connection.
+/// Every statement uses `CREATE … IF NOT EXISTS`, so this is a no-op for
+/// objects that already exist.
+///
+/// `open_db` only applies `SCHEMA` when `user_version == 0` (fresh DB),
+/// trusting that any DB with `user_version > 0` is the product of the
+/// migration ladder and thus has every table. The bench's corpus-init in
+/// Python writes a hand-curated subset of tables and then sets
+/// `PRAGMA user_version = EXPECTED_VERSION`, which violates that assumption:
+/// the brain expects the full prod schema (knowledge_nodes, entities,
+/// knowledge_node_*, workflow_annotations, lessons, …) when writing
+/// enrichment results, but the bench DB only has the input tables.
+///
+/// This function lets bench-mode fill the gap without touching prod's
+/// migration semantics. Operator runs should never call it — they go
+/// through `open_db` whose v=0 / migration paths are what guarantees
+/// schema integrity in production.
+pub fn ensure_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(SCHEMA)?;
+    Ok(())
+}
+
 pub fn upsert_session(
     conn: &Connection,
     session_uuid: &str,
@@ -2854,6 +2876,142 @@ mod tests {
                 col_names
             );
         }
+    }
+
+    /// REGRESSION (BT-29 schema gap, 2026-05-04): the bench's corpus init
+    /// writes a column-compatible subset of input tables (sessions, events,
+    /// env_snapshots, …) and stamps `PRAGMA user_version = EXPECTED_VERSION`.
+    /// open_db, seeing v=latest, skips the fresh-DB SCHEMA path and never
+    /// creates the OUTPUT tables the brain writes during enrichment
+    /// (knowledge_nodes, entities, knowledge_node_*, workflow_annotations,
+    /// lessons, …). `ensure_schema` must be safe to apply against this
+    /// state — backfilling the missing tables and indexes without touching
+    /// existing rows. The partial seed below uses prod-compatible columns
+    /// so schema.sql's indexes (e.g. idx_events_envelope_id) succeed.
+    #[test]
+    fn test_ensure_schema_backfills_missing_tables_at_expected_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("partial.db");
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA foreign_keys=ON;
+             CREATE TABLE sessions (
+                 id INTEGER PRIMARY KEY,
+                 start_time INTEGER NOT NULL,
+                 end_time INTEGER,
+                 terminal TEXT,
+                 shell TEXT NOT NULL,
+                 hostname TEXT NOT NULL,
+                 username TEXT NOT NULL,
+                 summary TEXT,
+                 created_at INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE env_snapshots (
+                 id INTEGER PRIMARY KEY,
+                 content_hash TEXT NOT NULL UNIQUE,
+                 env_json TEXT NOT NULL,
+                 created_at INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE events (
+                 id INTEGER PRIMARY KEY,
+                 session_id INTEGER NOT NULL REFERENCES sessions(id),
+                 timestamp INTEGER NOT NULL,
+                 command TEXT NOT NULL,
+                 stdout TEXT,
+                 stderr TEXT,
+                 stdout_truncated INTEGER DEFAULT 0,
+                 stderr_truncated INTEGER DEFAULT 0,
+                 exit_code INTEGER,
+                 duration_ms INTEGER NOT NULL,
+                 cwd TEXT NOT NULL,
+                 hostname TEXT NOT NULL,
+                 shell TEXT NOT NULL,
+                 git_repo TEXT,
+                 git_branch TEXT,
+                 git_commit TEXT,
+                 git_dirty INTEGER,
+                 env_snapshot_id INTEGER REFERENCES env_snapshots(id),
+                 envelope_id TEXT,
+                 source_kind TEXT NOT NULL DEFAULT 'shell',
+                 tool_name TEXT,
+                 enriched INTEGER NOT NULL DEFAULT 0,
+                 redaction_count INTEGER NOT NULL DEFAULT 0,
+                 archived_at INTEGER,
+                 probe_tag TEXT,
+                 created_at INTEGER NOT NULL DEFAULT 0
+             );
+             INSERT INTO sessions (id, start_time, shell, hostname, username)
+                 VALUES (1, 1000, 'zsh', 'h', 'u');
+             INSERT INTO events
+                 (id, session_id, timestamp, command, duration_ms, cwd, hostname, shell)
+                 VALUES (1, 1, 2000, 'echo hi', 5, '/tmp', 'h', 'zsh');",
+        )
+        .unwrap();
+        // Stamp at latest, mirroring corpus_v2.write_corpus_v2_sqlite.
+        conn.execute_batch(&format!("PRAGMA user_version = {};", EXPECTED_VERSION))
+            .unwrap();
+
+        // open_db must NOT bail and must NOT clobber existing rows.
+        drop(conn);
+        let conn = open_db(&db).unwrap();
+        let v: i64 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, EXPECTED_VERSION);
+
+        // Pre-condition: knowledge_nodes is missing (hand-curated subset).
+        let kn_exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='knowledge_nodes')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            !kn_exists,
+            "test setup: knowledge_nodes should be absent before ensure_schema"
+        );
+
+        // Apply ensure_schema (the bench-mode backfill).
+        ensure_schema(&conn).unwrap();
+
+        // Post-condition: every output table the brain writes to now exists.
+        for table in [
+            "knowledge_nodes",
+            "entities",
+            "knowledge_node_events",
+            "knowledge_node_claude_sessions",
+            "knowledge_node_workflow_runs",
+            "workflow_annotations",
+            "lessons",
+        ] {
+            let exists: bool = conn
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1)",
+                    [table],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert!(
+                exists,
+                "ensure_schema should have created table '{}'",
+                table
+            );
+        }
+
+        // Pre-existing rows must be intact (CREATE … IF NOT EXISTS preserves data).
+        let event_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(event_count, 1, "ensure_schema must not touch existing rows");
+
+        // Idempotent: second application is a no-op.
+        ensure_schema(&conn).unwrap();
+        let event_count_after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(event_count_after, 1);
     }
 }
 

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -724,6 +724,19 @@ pub async fn run_with_mode(config: HippoConfig, bench_mode: bool) -> Result<()> 
     let write_conn = storage::open_db(&db_path)?;
     let read_conn = storage::open_db(&db_path)?;
 
+    // Bench-mode: backfill any missing tables from schema.sql. The bench's
+    // corpus init writes a hand-curated subset of input tables and sets
+    // user_version=EXPECTED_VERSION, which causes open_db to skip the
+    // fresh-DB SCHEMA path. The brain expects the FULL schema (knowledge_nodes,
+    // entities, knowledge_node_*, workflow_annotations, lessons, …) when
+    // writing enrichment results — without this backfill, every brain write
+    // raises `OperationalError: no such table`. ensure_schema is idempotent
+    // (CREATE … IF NOT EXISTS throughout) so it's safe to apply against a
+    // partially-populated bench DB. Production runs do not enter this branch.
+    if bench_mode {
+        storage::ensure_schema(&write_conn)?;
+    }
+
     // Recover fallback files
     let mut session_map = HashMap::new();
     let fallback_dir = config.fallback_dir();


### PR DESCRIPTION
## Summary

Unblocks the bench's spawn-through-measurement path so a model can actually run end-to-end. The first real BT-29 operator run on 2026-05-04 surfaced four blockers; this PR fixes all four and validates the full path with a real bench against `qwen3.6-35b-a3b-ud-mlx` (`tier0_passed: true`, 25/25 events, zero errors, clean teardown, prod-pause/resume cycle honored).

> **⚠️ BT-29 still has further blockers downstream.** See "What this does NOT fix" at the bottom — `downstream_proxy` is `{}` in the run output because `embedding_fn` is never wired through and `eval-qa-v1` golden IDs were never labeled. **Issue #133** documents both gaps and proposes two paths forward (Tier 1 labeling vs harness re-spec). Don't run BT-29 against this PR alone expecting MRR/Hit@1 signal.

## Four spawn-through-measurement layers, all fixed

| # | Layer | Symptom before | Fix | Commit |
|---|---|---|---|---|
| 1 | Cross-session `setpgid` | `SubprocessError: Exception occurred in preexec_fn` (immediate) | Daemon `preexec_fn=lambda: setpgid(0,0)` keeps it in parent's session; brain's `setpgid(0, daemon_pgid)` then succeeds | `c26c31e` |
| 2 | TMPDIR collision with prod | Bench raced prod for `$TMPDIR/hippo-daemon.sock` | Per-run `tempfile.mkdtemp(prefix="hb-", dir="/tmp")` isolates the bench socket | `c26c31e`, `9b7f769` (sun_path budget) |
| 3 | Stale `--brain-url` default | Preflight `prod_brain_reachable: warn`; prod-pause silently skipped | New `bench/prod_config.py` reads `[brain].port` from prod config.toml the way `hippo-brain` does | `c26c31e` |
| 4 | Bench corpus lacks brain's output tables (closes #132) | Brain crashed every write with `OperationalError: no such table: knowledge_nodes` | Hybrid: `storage::ensure_schema(conn)` + daemon calls it in `--bench` mode (option C); `corpus_v2._SHADOW_SCHEMA_SQL` aligned to prod columns so daemon's indexes succeed (option B-min) | `2b55cd5` |

Plus diagnostic and hardening passes:
- Daemon liveness check (200ms post-spawn poll + continuous poll inside `wait_for_brain_ready`) — surfaces dead-daemon failures with the exact log path instead of misleading 60s "brain not ready" timeouts
- Brain-spawn failure cleans up daemon pgrp (no leaked process holding port 18923)
- `tempfile.mkdtemp` failure cleans up tmpdir
- `_cleanup_tmpdir` uses `onexc` callback (logs leaked paths to stderr instead of swallowing via `ignore_errors=True`)
- SIGKILL `ProcessLookupError` race in teardown logs a stderr breadcrumb
- `prod_config` warns to stderr on malformed TOML / unreadable config / non-int / float / bool / out-of-range port (no silent re-introduction of the prod-pause-skip footgun)
- Tightened the 18-line incident-narrative comment to a 4-line POSIX constraint note

## End-to-end validation result

Real bench against `qwen3.6-35b-a3b-ud-mlx`:
- `models_completed: ["qwen3.6-35b-a3b-ud-mlx"]`
- `models_errored: []`
- `tier0_passed: true`
- `failed_gates: []`, `skipped_gates: []`, `notes: []`
- `attempts_total: 25, events_attempted: 25, errors_count: 0`
- `prod_brain_resumed_ok: true`
- Shadow tmpdir cleaned (no leak)
- Brain wrote 8 `knowledge_nodes` rows + 44 `entities` rows during the run

Final brain log entries:
```
INFO:hippo_brain:enriched 1 events -> node N
INFO:hippo_brain:enriched workflow run X -> knowledge node
```
Zero `OperationalError`. All four sources (events / claude / browser / workflow) processed cleanly.

## Test coverage

- Rust: workspace passes; new `test_ensure_schema_backfills_missing_tables_at_expected_version` pins the contract that `ensure_schema` is safe against a partial bench-shaped DB at `user_version = EXPECTED_VERSION`
- Python: 229 bench tests pass after `corpus_v2` column alignment
- New regression tests this PR added: 16 (across `test_bench_shadow_stack.py`, `test_bench_prod_config.py`, `test_ensure_schema_backfills_missing_tables_at_expected_version`)
- The real-subprocess regression test (`test_spawn_pgrp_pair_with_real_subprocesses`) calls the actual `_spawn_pgrp_pair` helper — a future revert to `start_new_session=True` would break it
- ruff + cargo fmt + cargo clippy: clean

## What this does NOT fix

The validation bench produced `downstream_proxy: {}` because of two pre-existing structural gaps that BT-29 will hit:

1. **`embedding_fn` is never constructed for CLI flow.** `coordinator_v2.run_one_model_v2` accepts an `embedding_fn` callable, but the CLI just plumbs the model name as a string. The downstream proxy pass at `coordinator_v2.py:332` is gated on `if embedding_fn:` and is therefore always skipped.

2. **`eval-qa-v1.jsonl` golden_event_ids are all `null`.** The committed `qa_template.jsonl` has 100 questions but no labeled answers — Tier 1 labeling was explicitly listed as out-of-scope in PR #61 ("Tier 1 labeled eval + hand-labeling TUI ... explicitly out of scope, roadmap").

**BT-29's determinism harness compares `downstream_proxy.modes[mode].mrr` and `hit_at_1` across 3 runs. Without #1 fixed, those are absent. With #1 fixed but not #2, they're computed against null golden IDs and produce noise.**

**Issue #133** documents both gaps and proposes two paths forward (Tier 1 labeling vs BT-29 re-spec). It deserves a design decision before BT-29 work continues — fixing only #1 would let an operator run BT-29 and get garbage metrics.

## Test plan

- [x] `uv run --project brain pytest brain/tests/ -q` — all pass
- [x] `cargo test --workspace` — all pass; clippy clean; fmt clean
- [x] `uv run --project brain ruff check brain/` — clean
- [x] End-to-end: validation bench produces `tier0_passed: true` with prod-compatible schema + daemon-side `ensure_schema`
- [x] **Reviewer:** confirm hybrid C+B approach is the right ownership split (daemon owns full schema in `--bench` mode; corpus stays minimal but column-compatible)
- [ ] **Operator (post-merge):** **Do NOT run BT-29 yet** — see #133 for the remaining blockers and proposed paths forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)