### PR TITLE
fix(brain): surface LM Studio response body on 4xx/5xx

### DIFF
--- a/brain/src/hippo_brain/client.py
+++ b/brain/src/hippo_brain/client.py
@@ -32,10 +32,15 @@ def _raise_with_body(resp: httpx.Response) -> None:
     # LM Studio returns a JSON body on 4xx (e.g. {"error": "Context history must
     # not be empty."}) that pinpoints the failure. httpx's default raise_for_status
     # discards it, so we re-raise with the body appended to keep diagnoses visible.
+    # If body extraction itself fails (decode error, body unread, etc.), fall back
+    # to the original raise — never let a body-extraction error mask the real HTTP error.
     try:
         resp.raise_for_status()
     except httpx.HTTPStatusError as e:
-        body = resp.text[:500].strip()
+        try:
+            body = resp.text[:500].strip()
+        except Exception:
+            body = ""
         if not body:
             raise
         raise httpx.HTTPStatusError(

--- a/brain/src/hippo_brain/client.py
+++ b/brain/src/hippo_brain/client.py
@@ -28,6 +28,23 @@ _prompt_tokens = (
 )
 
 
+def _raise_with_body(resp: httpx.Response) -> None:
+    # LM Studio returns a JSON body on 4xx (e.g. {"error": "Context history must
+    # not be empty."}) that pinpoints the failure. httpx's default raise_for_status
+    # discards it, so we re-raise with the body appended to keep diagnoses visible.
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        body = resp.text[:500].strip()
+        if not body:
+            raise
+        raise httpx.HTTPStatusError(
+            f"{e.args[0]}\nBody: {body}",
+            request=e.request,
+            response=e.response,
+        ) from e
+
+
 class LMStudioClient:
     def __init__(self, base_url: str = "http://localhost:1234/v1", timeout: float = 300.0):
         self.base_url = base_url.rstrip("/")
@@ -52,7 +69,7 @@ class LMStudioClient:
                         "max_tokens": max_tokens,
                     },
                 )
-                resp.raise_for_status()
+                _raise_with_body(resp)
                 data = resp.json()
                 result = data["choices"][0]["message"]["content"]
             if _request_duration:
@@ -74,7 +91,7 @@ class LMStudioClient:
                     f"{self.base_url}/embeddings",
                     json={"model": model, "input": texts},
                 )
-                resp.raise_for_status()
+                _raise_with_body(resp)
                 data = resp.json()
                 result = [item["embedding"] for item in data["data"]]
             if _request_duration:
@@ -89,7 +106,7 @@ class LMStudioClient:
         """Return IDs of all models currently loaded in LM Studio."""
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             resp = await client.get(f"{self.base_url}/models")
-            resp.raise_for_status()
+            _raise_with_body(resp)
             return [m["id"] for m in resp.json().get("data", [])]
 
     async def is_reachable(self) -> bool:

--- a/brain/src/hippo_brain/client.py
+++ b/brain/src/hippo_brain/client.py
@@ -1,10 +1,13 @@
 import hashlib
+import logging
 import math
 import time
 
 import httpx
 
 from hippo_brain.telemetry import get_meter
+
+logger = logging.getLogger(__name__)
 
 _meter = get_meter()
 _request_duration = (
@@ -39,7 +42,11 @@ def _raise_with_body(resp: httpx.Response) -> None:
     except httpx.HTTPStatusError as e:
         try:
             body = resp.text[:500].strip()
-        except Exception:
+        except Exception as text_err:
+            # Catch broad: any failure to decode (UnicodeDecodeError, ResponseNotRead,
+            # programming bugs in the property accessor) must not mask the real HTTP
+            # error. Log at debug so the loss of body context is greppable in incidents.
+            logger.debug("LM Studio response body extraction failed: %s", text_err)
             body = ""
         if not body:
             raise

--- a/brain/tests/test_client_real.py
+++ b/brain/tests/test_client_real.py
@@ -2,7 +2,7 @@
 
 import httpx
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 from hippo_brain.client import LMStudioClient
 
@@ -76,6 +76,22 @@ async def test_chat_error_with_empty_body_does_not_blow_up(client):
     with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
         with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await client.chat(messages=[{"role": "user", "content": "hi"}])
+    assert "Body:" not in str(exc_info.value)
+
+
+async def test_chat_400_body_extraction_failure_does_not_mask_http_error(client):
+    """If reading resp.text itself raises (decode error, body unread, etc.), the
+    helper must still raise the original HTTPStatusError — not the body-extraction
+    exception. Otherwise a transient extraction failure would silently replace the
+    real LM Studio error in caller view (silent-fallback anti-pattern)."""
+    mock_resp = _mock_response(400, {"error": "real LM Studio reason"})
+    with patch.object(httpx.Response, "text", new_callable=PropertyMock) as mock_text:
+        mock_text.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "bad")
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
+            with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                await client.chat(messages=[{"role": "user", "content": "hi"}])
+    # Original HTTPStatusError surfaced — extraction error did not mask it.
+    assert isinstance(exc_info.value, httpx.HTTPStatusError)
     assert "Body:" not in str(exc_info.value)
 
 

--- a/brain/tests/test_client_real.py
+++ b/brain/tests/test_client_real.py
@@ -44,6 +44,41 @@ async def test_chat_raises_on_http_error(client):
             await client.chat(messages=[{"role": "user", "content": "hi"}])
 
 
+async def test_chat_400_includes_response_body_in_error(client):
+    """4xx responses must surface LM Studio's error body, not just the status string.
+
+    Without the body, the brain logs only `400 Bad Request for url ...`, hiding
+    the actual reason LM Studio rejected the request (e.g. "Context history must
+    not be empty.", "max_tokens exceeds context window", etc.).
+    """
+    mock_resp = _mock_response(400, {"error": "Context history must not be empty."})
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
+        with pytest.raises(httpx.HTTPStatusError, match="Context history must not be empty"):
+            await client.chat(messages=[{"role": "user", "content": "hi"}])
+
+
+async def test_embed_400_includes_response_body_in_error(client):
+    """Same body-capture behavior must apply to embeddings."""
+    mock_resp = _mock_response(400, {"error": "embedding model not loaded"})
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
+        with pytest.raises(httpx.HTTPStatusError, match="embedding model not loaded"):
+            await client.embed(texts=["hi"])
+
+
+async def test_chat_error_with_empty_body_does_not_blow_up(client):
+    """If LM Studio returns a 4xx with no body, behavior matches the original
+    raise_for_status (no synthetic 'Body:' suffix)."""
+    mock_resp = httpx.Response(
+        503,
+        content=b"",
+        request=httpx.Request("POST", "http://localhost:1234/v1/fake"),
+    )
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.chat(messages=[{"role": "user", "content": "hi"}])
+    assert "Body:" not in str(exc_info.value)
+
+
 async def test_embed_returns_embeddings(client):
     """embed() should POST to /embeddings and return list of vectors."""
     mock_resp = _mock_response(

--- a/brain/tests/test_client_real.py
+++ b/brain/tests/test_client_real.py
@@ -66,8 +66,8 @@ async def test_embed_400_includes_response_body_in_error(client):
 
 
 async def test_chat_error_with_empty_body_does_not_blow_up(client):
-    """If LM Studio returns a 4xx with no body, behavior matches the original
-    raise_for_status (no synthetic 'Body:' suffix)."""
+    """If LM Studio returns an HTTP error with no body, behavior matches the
+    original raise_for_status (no synthetic 'Body:' suffix)."""
     mock_resp = httpx.Response(
         503,
         content=b"",

--- a/brain/tests/test_client_real.py
+++ b/brain/tests/test_client_real.py
@@ -93,6 +93,9 @@ async def test_chat_400_body_extraction_failure_does_not_mask_http_error(client)
     # Original HTTPStatusError surfaced — extraction error did not mask it.
     assert isinstance(exc_info.value, httpx.HTTPStatusError)
     assert "Body:" not in str(exc_info.value)
+    # Status code survives — guards against a regression where the synthetic
+    # error is raised but with empty/missing fields.
+    assert exc_info.value.response.status_code == 400
 
 
 async def test_embed_returns_embeddings(client):


### PR DESCRIPTION
## Summary

- LM Studio returns a JSON body on 4xx (e.g. `{"error": "Context history must not be empty."}`) that pinpoints the failure. The previous code discarded it via httpx's default `raise_for_status`, leaving `brain.stderr.log` with only `400 Bad Request for url ...`.
- Add `_raise_with_body()` helper that appends up to 500 chars of the response body to the `HTTPStatusError`, applied to `chat()`, `embed()`, and `list_models()`.
- Keeps the existing exception type so callers (`_call_llm_with_retries`, queue-failure handlers) need no changes.

## Why this matters

While auditing capture health, we found 21 × `400 Bad Request` errors against `/v1/chat/completions` in the last brain session — 10 on `workflow.enrich`, 1 on `shell.chat` (after retries), 1 hidden under `_call_llm_with_retries` retry warnings on the claude path. The same `run_id` 400s once and 200s on a subsequent attempt within seconds, so we know it's transient.

We don't yet know what LM Studio is actually saying because the body was thrown away. This PR is the prerequisite for a properly informed root-cause investigation — once it's deployed, future 400s will include LM Studio's reason in the brain log, and we can decide whether the next fix is (a) bring workflow's chat call under the same retry wrapper as the other paths, (b) tune model preflight, or (c) something the body reveals that we haven't considered.

## Test plan

- [x] `uv run --project brain pytest brain/tests/test_client.py brain/tests/test_client_real.py -v` — 18 passed (3 new)
- [x] `uv run --project brain pytest brain/tests` — 883 passed, 1 skipped, 1 xfailed, 1 xpassed
- [x] `uv run --project brain ruff check brain/src brain/tests` — clean
- [x] `uv run --project brain ruff format --check brain/src brain/tests` — clean
- [ ] Deploy and observe brain.stderr.log next time a 4xx fires — confirm body appears in the log

## New tests added

- `test_chat_400_includes_response_body_in_error` — asserts the LM Studio error reason now appears in `HTTPStatusError`
- `test_embed_400_includes_response_body_in_error` — same for embeddings
- `test_chat_error_with_empty_body_does_not_blow_up` — empty-body 503 still raises cleanly without a synthetic `Body:` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)