### PR TITLE
feat(brain): count LM Studio model crashes as a first-class metric

### DIFF
--- a/brain/src/hippo_brain/client.py
+++ b/brain/src/hippo_brain/client.py
@@ -60,9 +60,12 @@ def _raise_with_body(resp: httpx.Response) -> None:
             raise
         # Surface model-worker crashes as a first-class signal — independent of
         # the queue-level retries that absorb them. Substring match against the
-        # LM Studio UI string as of 2026-05-07; if LM Studio changes the wording
-        # this stops counting (re-check on LM Studio upgrades).
-        if _lm_crashes and "model has crashed" in body:
+        # LM Studio UI string as of 2026-05-07 (case-insensitive to survive
+        # capitalization drift across LM Studio versions); if LM Studio changes
+        # the wording itself, this stops counting — re-check on LM Studio upgrades.
+        # Crashes are a subset of _lm_errors (which counts every failed call from
+        # the chat()/embed() except blocks): a single crash increments BOTH.
+        if _lm_crashes and "model has crashed" in body.lower():
             _lm_crashes.add(1)
         raise httpx.HTTPStatusError(
             f"{e.args[0]}\nBody: {body}",

--- a/brain/src/hippo_brain/client.py
+++ b/brain/src/hippo_brain/client.py
@@ -22,6 +22,14 @@ _lm_errors = (
     if _meter
     else None
 )
+_lm_crashes = (
+    _meter.create_counter(
+        "hippo.brain.lmstudio.crashes",
+        description="LM Studio reported model worker crashes (process killed mid-inference)",
+    )
+    if _meter
+    else None
+)
 _prompt_tokens = (
     _meter.create_histogram(
         "hippo.brain.lmstudio.prompt_tokens", description="Prompt size in chars"
@@ -50,6 +58,12 @@ def _raise_with_body(resp: httpx.Response) -> None:
             body = ""
         if not body:
             raise
+        # Surface model-worker crashes as a first-class signal — independent of
+        # the queue-level retries that absorb them. Substring match against the
+        # LM Studio UI string as of 2026-05-07; if LM Studio changes the wording
+        # this stops counting (re-check on LM Studio upgrades).
+        if _lm_crashes and "model has crashed" in body:
+            _lm_crashes.add(1)
         raise httpx.HTTPStatusError(
             f"{e.args[0]}\nBody: {body}",
             request=e.request,

--- a/brain/tests/test_client_real.py
+++ b/brain/tests/test_client_real.py
@@ -123,6 +123,19 @@ async def test_embed_400_with_crash_body_also_increments_crash_counter(client, m
     mock_counter.add.assert_called_once_with(1)
 
 
+async def test_chat_400_crash_match_is_case_insensitive(client, monkeypatch):
+    """Capitalization drift across LM Studio versions (e.g. "Model Has Crashed"
+    or all-caps) must still increment the counter — the substring match is
+    intentionally case-insensitive."""
+    mock_counter = MagicMock()
+    monkeypatch.setattr(client_module, "_lm_crashes", mock_counter)
+    mock_resp = _mock_response(400, {"error": "MODEL HAS CRASHED unexpectedly during inference."})
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.chat(messages=[{"role": "user", "content": "hi"}])
+    mock_counter.add.assert_called_once_with(1)
+
+
 async def test_chat_400_body_extraction_failure_does_not_mask_http_error(client):
     """If reading resp.text itself raises (decode error, body unread, etc.), the
     helper must still raise the original HTTPStatusError — not the body-extraction

--- a/brain/tests/test_client_real.py
+++ b/brain/tests/test_client_real.py
@@ -2,8 +2,9 @@
 
 import httpx
 import pytest
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
+from hippo_brain import client as client_module
 from hippo_brain.client import LMStudioClient
 
 
@@ -77,6 +78,49 @@ async def test_chat_error_with_empty_body_does_not_blow_up(client):
         with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await client.chat(messages=[{"role": "user", "content": "hi"}])
     assert "Body:" not in str(exc_info.value)
+
+
+async def test_chat_400_with_crash_body_increments_crash_counter(client, monkeypatch):
+    """LM Studio's "model has crashed" body must increment the crash counter so
+    diagnostic dashboards can track worker kills independently of which capture
+    path triggered them. The signal is otherwise hidden when queue-level retry
+    absorbs the failure."""
+    mock_counter = MagicMock()
+    monkeypatch.setattr(client_module, "_lm_crashes", mock_counter)
+    mock_resp = _mock_response(
+        400,
+        {"error": "The model has crashed without additional information. (Exit code: null)"},
+    )
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.chat(messages=[{"role": "user", "content": "hi"}])
+    mock_counter.add.assert_called_once_with(1)
+
+
+async def test_chat_400_with_non_crash_body_does_not_increment_crash_counter(client, monkeypatch):
+    """Other 400 reasons (malformed input, context overflow, etc.) must NOT be
+    counted as crashes — false positives would erode the signal."""
+    mock_counter = MagicMock()
+    monkeypatch.setattr(client_module, "_lm_crashes", mock_counter)
+    mock_resp = _mock_response(400, {"error": "Context history must not be empty."})
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.chat(messages=[{"role": "user", "content": "hi"}])
+    mock_counter.add.assert_not_called()
+
+
+async def test_embed_400_with_crash_body_also_increments_crash_counter(client, monkeypatch):
+    """Counter is path-agnostic: embed() crashes are equally diagnostic."""
+    mock_counter = MagicMock()
+    monkeypatch.setattr(client_module, "_lm_crashes", mock_counter)
+    mock_resp = _mock_response(
+        400,
+        {"error": "The model has crashed without additional information."},
+    )
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.embed(texts=["hi"])
+    mock_counter.add.assert_called_once_with(1)
 
 
 async def test_chat_400_body_extraction_failure_does_not_mask_http_error(client):

--- a/docs/brain-watchdog.md
+++ b/docs/brain-watchdog.md
@@ -42,3 +42,27 @@ alert rule needs to diagnose a wedge without tailing the full log.
 Metrics: `hippo.brain.enrichment.reaped{queue_name=...}` and
 `hippo.brain.enrichment.preflight_skipped{reason=...}` — watch these to see
 the watchdog actually firing.
+
+## Tracking LM Studio model worker crashes
+
+LM Studio's qwen-MoE worker process can die mid-inference (JIT eviction when
+another client requests a different model, or Metal allocator failures under
+context-cache pressure). Until the worker reloads, the API returns HTTP 4xx
+with body `{"error": "The model has crashed without additional information.
+(Exit code: null)"}`. The brain's queue-level retry transparently re-runs the
+work against a freshly-restarted model, so end-to-end enrichment succeeds —
+but the underlying instability was previously visible only in the workflow
+path's logs (which lack the in-process retry wrapper that claude/shell/browser
+have).
+
+Metric: `hippo.brain.lmstudio.crashes` — incremented by the LM Studio HTTP
+client's `_raise_with_body` helper whenever a 4xx body matches `"model has
+crashed"` (case-insensitive). Path-agnostic: chat, embed, and list_models
+contribute equally. Crashes are a strict subset of `hippo.brain.lmstudio.errors`,
+so a single crash increments both counters; dashboards graphing `crashes /
+errors` see the LM Studio-specific share of failures over time.
+
+Mitigations live in LM Studio settings, not hippo: set
+`unloadPreviousJITModelOnLoad: false` to stop competing-client evictions, and
+cap `defaultContextLength` to a fixed value (e.g. 32768) instead of `"max"`
+to reduce Metal allocator pressure.


### PR DESCRIPTION
## Summary

- Add counter `hippo.brain.lmstudio.crashes` that increments whenever LM Studio returns a 4xx with body containing `"model has crashed"`.
- Fires inside `_raise_with_body` so it's path-agnostic — chat, embed, list_models, all four enrichment sources contribute equally.
- Three new tests: crash body increments, non-crash body doesn't, embed() crashes also count.

Closes #142.

## Background

PR #141 surfaced LM Studio response bodies on 4xx. Within minutes of deploying it, captured bodies revealed all the transient 400s we'd been chasing are LM Studio worker process crashes:

```
{"error":"The model has crashed without additional information. (Exit code: null)"}
```

Verified in `~/Library/Logs/LM Studio/main.log`: 214 such crashes since the log started. Brain's queue retry was absorbing them silently on three of four paths (claude, shell, browser via `_call_llm_with_retries`); only workflow surfaced them as visible failures because it lacks the retry wrapper.

The original plan in #142 was to wrap workflow with the same retry mechanism for consistency — making logging quieter. **The body capture made clear that's the wrong fix**: the workflow path is currently the only canary signaling these crashes. Hiding it would erase the only production-visible signal of an LM Studio backend that's dying ~1.2 times/hour.

This PR is the right shape of fix: surface crashes as a metric so the signal is preserved no matter which path triggered them, and so any future retry-symmetry change to workflow wouldn't lose visibility.

## Notes

- The substring match (`"model has crashed"`) is intentionally brittle. LM Studio returns plain `{"error": "..."}` strings without structured codes; if their wording changes in a future release, the counter silently stops firing. A comment on the match line flags this for re-check on LM Studio upgrades.
- Counter has no `method` label (unlike `_lm_errors`) — crashes are crashes regardless of which API endpoint triggered them. If we want per-endpoint breakdown later, easy to add.

## Test plan

- [x] `uv run --project brain pytest brain/tests/test_client_real.py -v` — 17 passed (3 new)
- [x] `uv run --project brain pytest brain/tests` — 887 passed, 1 skipped, 1 xfailed, 1 xpassed
- [x] `uv run --project brain ruff check brain/src brain/tests` — clean
- [x] `uv run --project brain ruff format --check brain/src brain/tests` — clean
- [ ] Deploy and confirm `hippo.brain.lmstudio.crashes` shows up in Prometheus / Grafana dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)