### PR TITLE
release: hippo 0.25.0 — Codex CLI session ingestion via Rust poller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.24.0"
+version = "0.25.0"
 requires-python = ">=3.14"
 dependencies = [
   "httpx>=0.28",

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This pull request updates the version numbers for both the Rust and Python components of the project to `0.25.0`. There are no other functional or code changes.

Version updates:

* Bumped the workspace package version in `Cargo.toml` from `0.24.0` to `0.25.0`.
* Bumped the `hippo-brain` Python package version in `brain/pyproject.toml` from `0.24.0` to `0.25.0`.