### PR TITLE
fix(brain): embed workflow knowledge nodes into the vector store

### DIFF
--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -1466,6 +1466,7 @@ class BrainServer:
         if not run_ids:
             return
         query_model = self.query_model or self.enrichment_model
+        embed_tasks = []
         for run_id in run_ids:
             logger.info("enriching workflow run %d", run_id)
             _add(_events_claimed, 1, source="workflow")
@@ -1485,7 +1486,7 @@ class BrainServer:
             batch_start_ms = int(time.time() * 1000)
             with span:
                 try:
-                    await enrich_one_async(
+                    result = await enrich_one_async(
                         self.db_path,
                         run_id=run_id,
                         inference=self.client,
@@ -1494,6 +1495,11 @@ class BrainServer:
                     _add(_nodes_created, source="workflow")
                     self._record_success()
                     logger.info("enriched workflow run %d -> knowledge node", run_id)
+                    if result is not None and self.embedding_model:
+                        node_id, node_dict = result
+                        embed_tasks.append(
+                            asyncio.create_task(self._embed_node(node_id, node_dict, "workflow"))
+                        )
                 except Exception as e:
                     _add(_enrichment_failures, source="workflow")
                     err_msg = self._record_error(e)
@@ -1510,6 +1516,9 @@ class BrainServer:
                         mark_workflow_queue_failed(retry_conn, run_id, err_msg)
                     finally:
                         retry_conn.close()
+
+        if embed_tasks:
+            await asyncio.gather(*embed_tasks, return_exceptions=True)
 
     async def _enrich_opencode_batches(self, batches):
         """Process opencode session segment batches via the agentic queue."""

--- a/brain/src/hippo_brain/workflow_enrichment.py
+++ b/brain/src/hippo_brain/workflow_enrichment.py
@@ -9,6 +9,7 @@ For each completed workflow run in the enrichment queue:
 6. For each failing annotation, call lessons.upsert_cluster
 """
 
+import logging
 import sqlite3
 import time
 import uuid
@@ -17,6 +18,8 @@ from pathlib import Path
 from hippo_brain.client import InferenceClient
 from hippo_brain.lessons import ClusterKey, upsert_cluster
 from hippo_brain.watchdog import DEFAULT_LOCK_TIMEOUT_MS
+
+logger = logging.getLogger("hippo_brain")
 
 CORRELATION_WINDOW_MS = 15 * 60 * 1000  # ±15 minutes
 
@@ -294,20 +297,30 @@ async def enrich_one_async(
         )
         conn.commit()
 
-        # Lesson clustering for each failing annotation (sync — opens its own connection)
-        for a in ann_rows:
-            path_prefix = _path_prefix(a["path"], path_prefix_segments)
-            upsert_cluster(
-                db_path,
-                ClusterKey(
-                    repo=repo_name,
-                    tool=a["tool"] or "",
-                    rule_id=a["rule_id"] or "",
-                    path_prefix=path_prefix or "",
-                ),
-                min_occurrences=min_occurrences,
-                summary_fn=lambda k: f"{k.tool}:{k.rule_id} in {k.path_prefix}",
-                now_ms=now,
+        # Lesson clustering for each failing annotation (sync — opens its own
+        # connection). Best-effort: the node and queue 'done' status are already
+        # committed above, so a clustering failure must not propagate — that would
+        # mark the run failed and re-enrich it into a duplicate node.
+        try:
+            for a in ann_rows:
+                path_prefix = _path_prefix(a["path"], path_prefix_segments)
+                upsert_cluster(
+                    db_path,
+                    ClusterKey(
+                        repo=repo_name,
+                        tool=a["tool"] or "",
+                        rule_id=a["rule_id"] or "",
+                        path_prefix=path_prefix or "",
+                    ),
+                    min_occurrences=min_occurrences,
+                    summary_fn=lambda k: f"{k.tool}:{k.rule_id} in {k.path_prefix}",
+                    now_ms=now,
+                )
+        except Exception:
+            logger.warning(
+                "lesson clustering failed for workflow run %d; node already persisted",
+                run_id,
+                exc_info=True,
             )
 
         assert node_id is not None  # INSERT always populates lastrowid

--- a/brain/src/hippo_brain/workflow_enrichment.py
+++ b/brain/src/hippo_brain/workflow_enrichment.py
@@ -169,8 +169,12 @@ async def enrich_one_async(
     *,
     path_prefix_segments: int = 2,
     min_occurrences: int = 2,
-) -> None:
-    """Async wrapper around enrich_one for use in the enrichment scheduler."""
+) -> tuple[int, dict] | None:
+    """Async wrapper around enrich_one for use in the enrichment scheduler.
+
+    Returns ``(node_id, node_dict)`` for the created knowledge node so the
+    caller can schedule embedding, or ``None`` when ``run_id`` does not exist.
+    """
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
@@ -306,6 +310,8 @@ async def enrich_one_async(
                 now_ms=now,
             )
 
+        assert node_id is not None  # INSERT always populates lastrowid
+        return node_id, {"id": node_id, "embed_text": title, "commands_raw": ""}
     finally:
         conn.close()
 

--- a/brain/tests/test_server_extended.py
+++ b/brain/tests/test_server_extended.py
@@ -465,6 +465,50 @@ async def test_workflow_enrichment_calls_enrich_one_async(tmp_db):
     assert 42 in enrich_calls
 
 
+@pytest.mark.asyncio
+async def test_workflow_enrichment_schedules_embedding(tmp_db):
+    """Workflow enrichment must schedule _embed_node, like every other source.
+
+    Regression target: workflow/CI knowledge nodes were written to SQLite but
+    never embedded, silently falling out of semantic search.
+    """
+    conn, db_path = tmp_db
+    now_ms = int(time.time() * 1000)
+    conn.execute(
+        "INSERT INTO workflow_runs (id, repo, head_sha, event, status, conclusion, "
+        "html_url, raw_json, first_seen_at, last_seen_at) "
+        "VALUES (42, 'org/repo', 'abc123', 'push', 'completed', 'success', "
+        "'https://x', '{}', ?, ?)",
+        (now_ms, now_ms),
+    )
+    conn.execute(
+        "INSERT INTO workflow_enrichment_queue (run_id, enqueued_at, updated_at) VALUES (42, ?, ?)",
+        (now_ms, now_ms),
+    )
+    conn.commit()
+
+    server = _make_server(str(db_path), embedding_model="fake-embed")
+    server.poll_interval_secs = 0
+    server.client.chat = AsyncMock(return_value="CI run completed successfully")
+
+    embed_calls: list[tuple[int, str]] = []
+
+    async def _rec(node_id, node_dict, source_label):
+        embed_calls.append((node_id, source_label))
+
+    server._embed_node = _rec  # type: ignore[method-assign]
+
+    ok = PreflightDecision(proceed=True, reason="ok", loaded_models=["test-model"])
+    with patch("hippo_brain.server.preflight_inference", new_callable=AsyncMock, return_value=ok):
+        task = asyncio.create_task(server._enrichment_loop())
+        await asyncio.sleep(0.2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert any(src == "workflow" for _, src in embed_calls)
+
+
 # ---- stop_enrichment with no tasks ----
 
 

--- a/brain/tests/test_workflow_enrichment.py
+++ b/brain/tests/test_workflow_enrichment.py
@@ -3,7 +3,7 @@
 import asyncio
 import sqlite3
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -292,6 +292,36 @@ def test_enrich_one_async_skips_missing_run(enrichment_db):
     )
 
     fake_lm.chat.assert_not_called()
+
+
+def test_enrich_one_async_survives_clustering_failure(enrichment_db):
+    """A lesson-clustering failure must not fail the run.
+
+    The knowledge node and queue 'done' status are committed before lesson
+    clustering runs; if clustering raises, the run must NOT propagate the
+    error (which would mark it failed, re-enrich, and duplicate the node).
+    """
+    fake_lm = MagicMock()
+    fake_lm.chat = AsyncMock(return_value="Async enrichment summary")
+
+    with patch(
+        "hippo_brain.workflow_enrichment.upsert_cluster",
+        side_effect=RuntimeError("clustering boom"),
+    ):
+        result = asyncio.run(
+            enrich_one_async(enrichment_db, run_id=1, inference=fake_lm, query_model="test-model")
+        )
+
+    assert result is not None  # completed despite the clustering failure
+
+    conn = sqlite3.connect(enrichment_db)
+    node = conn.execute("SELECT id FROM knowledge_nodes").fetchone()
+    assert node is not None
+    status = conn.execute("SELECT status FROM workflow_enrichment_queue WHERE run_id=1").fetchone()[
+        0
+    ]
+    assert status == "done"
+    conn.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related fixes to workflow/CI knowledge-node enrichment.

**1. Workflow nodes were never embedded.** Workflow/CI enrichment created knowledge nodes but never embedded them — the only one of five enrichment sources missing the embed step. CI-run `change_outcome` nodes were written to SQLite and FTS-indexed but left invisible to semantic search (~3.3% of the corpus, 344 orphaned nodes observed in production).

- `enrich_one_async` now returns `(node_id, node_dict)` instead of `None`.
- `_enrich_workflow_runs` collects `embed_tasks`, schedules `_embed_node(..., "workflow")`, and `gather`s them — structurally identical to the shell/claude/browser/opencode paths.
- Adds a regression test that runs the **real** `enrich_one_async` and asserts the embed task fires. The prior test stubbed the function out and only checked it was *called* — which is why this bug shipped unnoticed.

**2. Lesson-clustering failures could orphan a node.** `enrich_one_async` runs best-effort lesson clustering *after* committing the knowledge node and the queue `done` status. A clustering failure propagated out of the function, so the caller marked the run failed and would re-enrich it into a duplicate node. The clustering loop is now wrapped — failures are logged and the already-persisted run stays `done`.

## Test plan

- [x] `test_workflow_enrichment_schedules_embedding` — fails before fix 1, passes after
- [x] `test_enrich_one_async_survives_clustering_failure` — fails before fix 2, passes after
- [x] Full brain suite: 883 passed, 1 skipped, 1 xfailed — zero regressions
- [x] `ruff check` + `ruff format --check` clean

## Config / security impact

None. No schema, secret, or shell-startup changes.

## Follow-up (PR2)

A separate PR will add a periodic orphan-reaper (backfills the 344 existing un-embedded nodes + provides embed retry) and a watchdog invariant to catch this class of bug — a source that forgets to embed.