### PR TITLE
feat(reaper): embedding orphan-reaper + watchdog invariant I-14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.25.1"
+version = "0.26.0"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.25.1"
+version = "0.26.0"
 requires-python = ">=3.14"
 dependencies = [
   "httpx>=0.28",

--- a/brain/src/hippo_brain/__init__.py
+++ b/brain/src/hippo_brain/__init__.py
@@ -28,6 +28,9 @@ def _default_settings() -> dict:
         "max_claim_batch": 10,
         "lock_timeout_secs": 600,
         "long_dwell_bypass_ms": 120_000,
+        "embed_reaper_interval_secs": 300,
+        "embed_reaper_batch_size": 50,
+        "embed_orphan_stale_secs": 900,
     }
 
 
@@ -61,6 +64,7 @@ def _load_runtime_settings() -> dict:
     brain = config.get("brain", {})
     telemetry = config.get("telemetry", {})
     browser = config.get("browser", {})
+    reaper = config.get("reaper", {})
 
     return {
         "db_path": str(data_dir / "hippo.db"),
@@ -81,6 +85,9 @@ def _load_runtime_settings() -> dict:
         "max_claim_batch": brain.get("max_claim_batch", 10),
         "lock_timeout_secs": brain.get("lock_timeout_secs", 600),
         "long_dwell_bypass_ms": browser.get("long_dwell_bypass_ms", 120_000),
+        "embed_reaper_interval_secs": reaper.get("interval_secs", 300),
+        "embed_reaper_batch_size": reaper.get("batch_size", 50),
+        "embed_orphan_stale_secs": reaper.get("orphan_stale_secs", 900),
     }
 
 
@@ -136,6 +143,9 @@ def main() -> None:
             max_claim_batch=settings["max_claim_batch"],
             lock_timeout_ms=int(settings["lock_timeout_secs"]) * 1000,
             long_dwell_bypass_ms=settings["long_dwell_bypass_ms"],
+            embed_reaper_interval_secs=settings["embed_reaper_interval_secs"],
+            embed_reaper_batch_size=settings["embed_reaper_batch_size"],
+            embed_orphan_stale_secs=settings["embed_orphan_stale_secs"],
         )
         try:
             uvicorn.run(app, host="127.0.0.1", port=settings["port"])

--- a/brain/src/hippo_brain/models.py
+++ b/brain/src/hippo_brain/models.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass, field
 
 
@@ -77,6 +78,83 @@ class Lesson:
 
 _VALID_OUTCOMES = {"success", "partial", "failure", "unknown"}
 _ENTITY_KEYS = ("projects", "tools", "files", "services", "errors", "env_vars", "domains")
+_ENV_VAR_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,}$")
+_DOMAIN_RE = re.compile(r"^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$", re.IGNORECASE)
+_FILE_SUFFIX_RE = re.compile(r"\.[A-Za-z0-9]{1,12}(?::\d+)?$")
+
+
+def _empty_entities() -> dict[str, list[str]]:
+    return {key: [] for key in _ENTITY_KEYS}
+
+
+def _append_unique(entities: dict[str, list[str]], key: str, value: str) -> None:
+    value = value.strip()
+    if value and value not in entities[key]:
+        entities[key].append(value)
+
+
+def _entity_key_from_type(raw_type) -> str | None:
+    if not isinstance(raw_type, str):
+        return None
+    normalized = raw_type.strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "project": "projects",
+        "projects": "projects",
+        "tool": "tools",
+        "tools": "tools",
+        "cli": "tools",
+        "file": "files",
+        "files": "files",
+        "path": "files",
+        "paths": "files",
+        "service": "services",
+        "services": "services",
+        "api": "services",
+        "database": "services",
+        "error": "errors",
+        "errors": "errors",
+        "exception": "errors",
+        "env_var": "env_vars",
+        "env_vars": "env_vars",
+        "environment_variable": "env_vars",
+        "domain": "domains",
+        "domains": "domains",
+        "hostname": "domains",
+    }
+    return aliases.get(normalized)
+
+
+def _infer_entity_key(value: str) -> str:
+    lower = value.lower()
+    if _ENV_VAR_RE.match(value):
+        return "env_vars"
+    if "/" in value or value.startswith(".") or _FILE_SUFFIX_RE.search(value):
+        return "files"
+    if "error" in lower or "exception" in lower or "failed" in lower or "traceback" in lower:
+        return "errors"
+    if "://" not in value and " " not in value and _DOMAIN_RE.match(value):
+        return "domains"
+    return "tools"
+
+
+def _coerce_entity_list(raw_entities: list) -> dict[str, list[str]]:
+    """Recover common local-LLM output: `entities` as a flat list."""
+    entities = _empty_entities()
+    for item in raw_entities:
+        if isinstance(item, str):
+            value = item.strip()
+            if value:
+                _append_unique(entities, _infer_entity_key(value), value)
+            continue
+        if isinstance(item, dict):
+            name = item.get("name") or item.get("value") or item.get("entity") or item.get("text")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            key = _entity_key_from_type(
+                item.get("type") or item.get("category") or item.get("kind")
+            )
+            _append_unique(entities, key or _infer_entity_key(name), name)
+    return entities
 
 
 def validate_enrichment_data(data: dict) -> EnrichmentResult:
@@ -96,10 +174,12 @@ def validate_enrichment_data(data: dict) -> EnrichmentResult:
     if outcome not in _VALID_OUTCOMES:
         raise ValueError(f"outcome must be one of {sorted(_VALID_OUTCOMES)}, got {outcome!r}")
 
-    # Entities must be a dict (default to empty dict if missing)
+    # Entities should be a dict, but local LLMs sometimes return a flat list.
     raw_entities = data.get("entities", {})
-    if not isinstance(raw_entities, dict):
-        raise ValueError(f"entities must be a dict, got {type(raw_entities).__name__}")
+    if isinstance(raw_entities, list):
+        raw_entities = _coerce_entity_list(raw_entities)
+    elif not isinstance(raw_entities, dict):
+        raise ValueError(f"entities must be a dict or list, got {type(raw_entities).__name__}")
 
     # Filter each entity list to contain only strings
     entities: dict[str, list[str]] = {}

--- a/brain/src/hippo_brain/opencode_sessions.py
+++ b/brain/src/hippo_brain/opencode_sessions.py
@@ -35,7 +35,14 @@ Output a JSON object with these fields:
 - outcome: One of "success", "partial", "failure", "unknown"
 - key_decisions: List of decisions made and why
 - problems_encountered: List of errors/failures and how they were resolved
-- entities: Tool/file/service identifiers extracted
+- entities: An object with lists of extracted entities:
+  - projects: Project names mentioned or inferred
+  - tools: CLI tools, editor tools, package managers, or agent tools used
+  - files: Specific files or paths referenced
+  - services: Services, databases, APIs, or inference backends interacted with
+  - errors: Actual error messages encountered
+  - env_vars: Environment variable names referenced
+  - domains: Hostnames or domains referenced
 - tags: Descriptive, specific tags
 - embed_text: A detailed, identifier-dense paragraph optimized for keyword retrieval
 

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -196,6 +196,9 @@ class BrainServer:
         max_claim_batch: int = DEFAULT_MAX_CLAIM_BATCH,
         lock_timeout_ms: int = DEFAULT_LOCK_TIMEOUT_MS,
         long_dwell_bypass_ms: int = 120_000,
+        embed_reaper_interval_secs: int = 300,
+        embed_reaper_batch_size: int = 50,
+        embed_orphan_stale_secs: int = 900,
     ):
         if not db_path:
             db_path = str(Path.home() / ".local" / "share" / "hippo" / "hippo.db")
@@ -214,6 +217,9 @@ class BrainServer:
         self.max_claim_batch = max_claim_batch
         self.lock_timeout_ms = lock_timeout_ms
         self.long_dwell_bypass_ms = long_dwell_bypass_ms
+        self.embed_reaper_interval_secs = embed_reaper_interval_secs
+        self.embed_reaper_batch_size = embed_reaper_batch_size
+        self.embed_orphan_stale_secs = embed_orphan_stale_secs
         self.enrichment_running = False
         self._paused: bool = False
         self._paused_at_iso: str | None = None
@@ -1687,6 +1693,9 @@ def create_app(
     max_claim_batch: int = DEFAULT_MAX_CLAIM_BATCH,
     lock_timeout_ms: int = DEFAULT_LOCK_TIMEOUT_MS,
     long_dwell_bypass_ms: int = 120_000,
+    embed_reaper_interval_secs: int = 300,
+    embed_reaper_batch_size: int = 50,
+    embed_orphan_stale_secs: int = 900,
 ) -> Starlette:
     server = BrainServer(
         db_path=db_path,
@@ -1702,6 +1711,9 @@ def create_app(
         max_claim_batch=max_claim_batch,
         lock_timeout_ms=lock_timeout_ms,
         long_dwell_bypass_ms=long_dwell_bypass_ms,
+        embed_reaper_interval_secs=embed_reaper_interval_secs,
+        embed_reaper_batch_size=embed_reaper_batch_size,
+        embed_orphan_stale_secs=embed_orphan_stale_secs,
     )
 
     if _meter:

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -237,6 +237,7 @@ class BrainServer:
         self._resume_event = asyncio.Event()
         self._enrichment_task = None
         self._reaper_task = None
+        self._embed_reaper_task = None
         self._vector_db = None
         self._vector_table = None
         if self.embedding_model:
@@ -1649,12 +1650,59 @@ class BrainServer:
             except Exception as e:
                 logger.warning("reaper loop error: %s", e, exc_info=True)
 
+    async def _embed_reaper_tick(self):
+        """One reaper sweep: re-embed knowledge_nodes that have no vector row.
+
+        Source-agnostic — finds orphans by anti-join, not queue membership, so
+        any source that fails to embed is healed regardless of which one.
+        """
+        now_ms = int(time.time() * 1000)
+        cutoff = now_ms - self.embed_orphan_stale_secs * 1000
+        conn = self._get_conn()
+        try:
+            rows = conn.execute(
+                "SELECT id, embed_text FROM knowledge_nodes "
+                "WHERE created_at < ? "
+                "AND id NOT IN (SELECT rowid FROM knowledge_vectors_rowids) "
+                "ORDER BY created_at LIMIT ?",
+                (cutoff, self.embed_reaper_batch_size),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # knowledge_vectors_rowids absent — fresh install, nothing embedded
+            # yet. Same tolerance as _collect_queue_depths for missing tables.
+            return
+        finally:
+            conn.close()
+        if not rows:
+            return
+        for node_id, embed_text in rows:
+            await self._embed_node(
+                node_id,
+                {"id": node_id, "embed_text": embed_text, "commands_raw": ""},
+                "reaper",
+            )
+        logger.info("embed reaper: re-embedded %d orphaned node(s)", len(rows))
+
+    async def _embed_reaper_loop(self):
+        """Independent loop that periodically runs _embed_reaper_tick."""
+        while True:
+            await asyncio.sleep(self.embed_reaper_interval_secs)
+            try:
+                await self._embed_reaper_tick()
+            except Exception as e:
+                logger.warning("embed reaper loop error: %s", e, exc_info=True)
+
     def start_enrichment(self):
         self._enrichment_task = asyncio.create_task(self._enrichment_loop())
         self._reaper_task = asyncio.create_task(self._reaper_loop())
+        self._embed_reaper_task = asyncio.create_task(self._embed_reaper_loop())
 
     async def stop_enrichment(self):
-        tasks = [t for t in (self._enrichment_task, self._reaper_task) if t is not None]
+        tasks = [
+            t
+            for t in (self._enrichment_task, self._reaper_task, self._embed_reaper_task)
+            if t is not None
+        ]
         if not tasks:
             return
         for t in tasks:
@@ -1664,6 +1712,7 @@ class BrainServer:
                 await t
         self._enrichment_task = None
         self._reaper_task = None
+        self._embed_reaper_task = None
 
     def get_routes(self) -> list[Route]:
         return [

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -1676,12 +1676,17 @@ class BrainServer:
         if not rows:
             return
         for node_id, embed_text in rows:
-            await self._embed_node(
-                node_id,
-                {"id": node_id, "embed_text": embed_text, "commands_raw": ""},
-                "reaper",
-            )
-        logger.info("embed reaper: re-embedded %d orphaned node(s)", len(rows))
+            try:
+                await self._embed_node(
+                    node_id,
+                    {"id": node_id, "embed_text": embed_text, "commands_raw": ""},
+                    "reaper",
+                )
+            except Exception:
+                # One bad node must not abandon the rest of the batch; it stays
+                # an orphan and is retried next tick.
+                logger.warning("embed reaper: re-embed failed for node %d", node_id, exc_info=True)
+        logger.info("embed reaper: swept %d orphaned node(s)", len(rows))
 
     async def _embed_reaper_loop(self):
         """Independent loop that periodically runs _embed_reaper_tick."""

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -1656,6 +1656,10 @@ class BrainServer:
         Source-agnostic — finds orphans by anti-join, not queue membership, so
         any source that fails to embed is healed regardless of which one.
         """
+        if self._paused:
+            # Quiescent during a /control/pause window (hippo-bench isolation);
+            # firing embeds would issue inference calls and corrupt the run.
+            return
         now_ms = int(time.time() * 1000)
         cutoff = now_ms - self.embed_orphan_stale_secs * 1000
         conn = self._get_conn()
@@ -1667,9 +1671,13 @@ class BrainServer:
                 "ORDER BY created_at LIMIT ?",
                 (cutoff, self.embed_reaper_batch_size),
             ).fetchall()
-        except sqlite3.OperationalError:
-            # knowledge_vectors_rowids absent — fresh install, nothing embedded
-            # yet. Same tolerance as _collect_queue_depths for missing tables.
+        except sqlite3.OperationalError as e:
+            # Tolerate only the missing knowledge_vectors_rowids shadow table
+            # (fresh install, nothing embedded yet). Any other operational
+            # error — locked DB, I/O failure, bad SQL — must surface via the
+            # loop's logging rather than masquerade as a healthy idle reaper.
+            if "no such table" not in str(e):
+                raise
             return
         finally:
             conn.close()

--- a/brain/src/hippo_brain/watchdog.py
+++ b/brain/src/hippo_brain/watchdog.py
@@ -75,6 +75,7 @@ QUEUES: tuple[QueueSpec, ...] = (
     QueueSpec("claude", "claude_enrichment_queue", "id"),
     QueueSpec("browser", "browser_enrichment_queue", "id"),
     QueueSpec("workflow", "workflow_enrichment_queue", "run_id"),
+    QueueSpec("agentic", "agentic_enrichment_queue", "id"),
 )
 
 

--- a/brain/tests/test_enrichment.py
+++ b/brain/tests/test_enrichment.py
@@ -142,9 +142,18 @@ def test_parse_skips_non_string_entity_items():
     assert result.entities["tools"] == ["cargo"]
 
 
-def test_parse_rejects_entities_not_dict():
-    data = _valid_enrichment_dict(entities=["not", "a", "dict"])
-    with pytest.raises(ValueError, match="entities must be a dict"):
+def test_parse_normalizes_flat_entity_list():
+    data = _valid_enrichment_dict(entities=["cargo", "brain/src/server.py", "HIPPO_DB"])
+    result = parse_enrichment_response(json.dumps(data))
+
+    assert result.entities["tools"] == ["cargo"]
+    assert result.entities["files"] == ["brain/src/server.py"]
+    assert result.entities["env_vars"] == ["HIPPO_DB"]
+
+
+def test_parse_rejects_entities_not_dict_or_list():
+    data = _valid_enrichment_dict(entities="cargo")
+    with pytest.raises(ValueError, match="entities must be a dict or list"):
         parse_enrichment_response(json.dumps(data))
 
 

--- a/brain/tests/test_init.py
+++ b/brain/tests/test_init.py
@@ -60,6 +60,9 @@ def test_main_serve_dispatches(monkeypatch):
                     "max_claim_batch": 10,
                     "lock_timeout_secs": 600,
                     "long_dwell_bypass_ms": 120_000,
+                    "embed_reaper_interval_secs": 300,
+                    "embed_reaper_batch_size": 50,
+                    "embed_orphan_stale_secs": 900,
                 },
             ):
                 hippo_brain.main()
@@ -78,6 +81,9 @@ def test_main_serve_dispatches(monkeypatch):
         max_claim_batch=10,
         lock_timeout_ms=600_000,
         long_dwell_bypass_ms=120_000,
+        embed_reaper_interval_secs=300,
+        embed_reaper_batch_size=50,
+        embed_orphan_stale_secs=900,
     )
     mock_uvicorn.run.assert_called_once_with("fake-app", host="127.0.0.1", port=9175)
 
@@ -105,6 +111,9 @@ def test_main_serve_uses_config_runtime_settings(monkeypatch):
         "max_claim_batch": 7,
         "lock_timeout_secs": 900,
         "long_dwell_bypass_ms": 240_000,
+        "embed_reaper_interval_secs": 120,
+        "embed_reaper_batch_size": 25,
+        "embed_orphan_stale_secs": 600,
     }
 
     with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
@@ -126,6 +135,9 @@ def test_main_serve_uses_config_runtime_settings(monkeypatch):
         max_claim_batch=7,
         lock_timeout_ms=900_000,
         long_dwell_bypass_ms=240_000,
+        embed_reaper_interval_secs=120,
+        embed_reaper_batch_size=25,
+        embed_orphan_stale_secs=600,
     )
     mock_uvicorn.run.assert_called_once_with("fake-app", host="127.0.0.1", port=9444)
 

--- a/brain/tests/test_opencode_sessions.py
+++ b/brain/tests/test_opencode_sessions.py
@@ -11,6 +11,7 @@ Acts as the regression bed for F-26..F-28 in `docs/capture/test-matrix.md`.
 from hippo_brain.enrichment import is_enrichment_eligible
 from hippo_brain.models import EnrichmentResult
 from hippo_brain.opencode_sessions import (
+    OPENCODE_ENRICHMENT_PROMPT,
     build_opencode_enrichment_prompt,
     claim_pending_opencode_segments,
     mark_opencode_queue_failed,
@@ -186,6 +187,10 @@ class TestPromptFormatting:
 
         assert "Capture opencode message parts" in prompt
         assert "bash: rg opencode brain/src/hippo_brain" in prompt
+
+    def test_system_prompt_requires_structured_entities_object(self):
+        assert "entities: An object with lists of extracted entities" in OPENCODE_ENRICHMENT_PROMPT
+        assert "env_vars" in OPENCODE_ENRICHMENT_PROMPT
 
 
 class TestWriteKnowledgeNode:

--- a/brain/tests/test_server_extended.py
+++ b/brain/tests/test_server_extended.py
@@ -483,3 +483,19 @@ async def test_stop_enrichment_is_noop_with_no_tasks(tmp_db):
 
     # Should not raise
     await server.stop_enrichment()
+
+
+# ---- Task 3: [reaper] config threading ----
+
+
+def test_brain_server_stores_reaper_settings():
+    """BrainServer must accept and store the reaper tuning knobs."""
+    server = BrainServer(
+        db_path=":memory:",
+        embed_reaper_interval_secs=120,
+        embed_reaper_batch_size=7,
+        embed_orphan_stale_secs=600,
+    )
+    assert server.embed_reaper_interval_secs == 120
+    assert server.embed_reaper_batch_size == 7
+    assert server.embed_orphan_stale_secs == 600

--- a/brain/tests/test_server_extended.py
+++ b/brain/tests/test_server_extended.py
@@ -571,3 +571,56 @@ async def test_embed_reaper_tick_survives_single_embed_failure(tmp_db):
     # the tick itself does not propagate the failure.
     await server._embed_reaper_tick()
     assert seen == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_embed_reaper_tick_skips_when_paused(tmp_db):
+    """A paused brain (hippo-bench isolation) must not run reaper embeds —
+    they would issue inference calls and corrupt benchmark isolation."""
+    conn, db_path = tmp_db
+    now_ms = int(time.time() * 1000)
+    old = now_ms - 3_600_000
+    conn.executescript(
+        "CREATE TABLE IF NOT EXISTS knowledge_vectors_rowids "
+        "(rowid INTEGER PRIMARY KEY, id, chunk_id, chunk_offset);"
+    )
+    conn.execute(
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, "
+        "created_at, updated_at) VALUES (1, 'u1', 'c', 'et', 'observation', ?, ?)",
+        (old, old),
+    )
+    conn.commit()
+
+    server = _make_server(str(db_path), embed_orphan_stale_secs=900)
+    server._paused = True
+    embedded: list[int] = []
+
+    async def _rec(node_id, node_dict, source_label):
+        embedded.append(node_id)
+
+    server._embed_node = _rec  # type: ignore[method-assign]
+
+    await server._embed_reaper_tick()
+    assert embedded == []  # paused — no embeds issued
+
+
+@pytest.mark.asyncio
+async def test_embed_reaper_tick_propagates_non_missing_table_errors(tmp_db):
+    """Only a missing shadow table is tolerated; a real operational error
+    (locked DB, bad SQL) must surface, not be masked as a healthy idle reaper."""
+    import sqlite3
+
+    _, db_path = tmp_db
+    server = _make_server(str(db_path), embed_orphan_stale_secs=900)
+
+    class _LockedConn:
+        def execute(self, *args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        def close(self):
+            pass
+
+    server._get_conn = lambda: _LockedConn()  # type: ignore[method-assign]
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        await server._embed_reaper_tick()

--- a/brain/tests/test_server_extended.py
+++ b/brain/tests/test_server_extended.py
@@ -541,7 +541,7 @@ async def test_embed_reaper_tick_reembeds_only_old_orphans(tmp_db):
 
 @pytest.mark.asyncio
 async def test_embed_reaper_tick_survives_single_embed_failure(tmp_db):
-    """One orphan's embed failure must not abort the sweep."""
+    """One orphan's embed failure must not abort the rest of the sweep."""
     conn, db_path = tmp_db
     now_ms = int(time.time() * 1000)
     old = now_ms - 3_600_000
@@ -561,10 +561,13 @@ async def test_embed_reaper_tick_survives_single_embed_failure(tmp_db):
     seen: list[int] = []
 
     async def _rec(node_id, node_dict, source_label):
-        seen.append(node_id)  # real _embed_node never raises
+        seen.append(node_id)
+        if node_id == 1:
+            raise RuntimeError("embed boom")
 
     server._embed_node = _rec  # type: ignore[method-assign]
 
-    # Must not raise — both orphans are attempted in one sweep.
+    # Node 1 raising must not abort the sweep — node 2 is still attempted, and
+    # the tick itself does not propagate the failure.
     await server._embed_reaper_tick()
     assert seen == [1, 2]

--- a/brain/tests/test_server_extended.py
+++ b/brain/tests/test_server_extended.py
@@ -499,3 +499,72 @@ def test_brain_server_stores_reaper_settings():
     assert server.embed_reaper_interval_secs == 120
     assert server.embed_reaper_batch_size == 7
     assert server.embed_orphan_stale_secs == 600
+
+
+# ---- Task 4: _embed_reaper_tick + _embed_reaper_loop ----
+
+
+@pytest.mark.asyncio
+async def test_embed_reaper_tick_reembeds_only_old_orphans(tmp_db):
+    """The reaper re-embeds nodes older than the staleness window that lack a
+    vector row; recent nodes and already-embedded nodes are left alone."""
+    conn, db_path = tmp_db
+    now_ms = int(time.time() * 1000)
+    old = now_ms - 3_600_000  # 1h old
+    recent = now_ms - 60_000  # 1m old — inside the staleness window
+    conn.executescript(
+        "CREATE TABLE IF NOT EXISTS knowledge_vectors_rowids "
+        "(rowid INTEGER PRIMARY KEY, id, chunk_id, chunk_offset);"
+    )
+    for nid, created in ((1, old), (2, recent), (3, old)):
+        conn.execute(
+            "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, "
+            "created_at, updated_at) VALUES (?, ?, 'c', 'et', 'observation', ?, ?)",
+            (nid, f"u{nid}", created, created),
+        )
+    # Node 3 already has a vector row.
+    conn.execute("INSERT INTO knowledge_vectors_rowids (rowid) VALUES (3)")
+    conn.commit()
+
+    server = _make_server(str(db_path), embed_orphan_stale_secs=900, embed_reaper_batch_size=50)
+    embedded: list[int] = []
+
+    async def _rec(node_id, node_dict, source_label):
+        embedded.append(node_id)
+
+    server._embed_node = _rec  # type: ignore[method-assign]
+
+    await server._embed_reaper_tick()
+
+    assert embedded == [1]  # only the old, unembedded node
+
+
+@pytest.mark.asyncio
+async def test_embed_reaper_tick_survives_single_embed_failure(tmp_db):
+    """One orphan's embed failure must not abort the sweep."""
+    conn, db_path = tmp_db
+    now_ms = int(time.time() * 1000)
+    old = now_ms - 3_600_000
+    conn.executescript(
+        "CREATE TABLE IF NOT EXISTS knowledge_vectors_rowids "
+        "(rowid INTEGER PRIMARY KEY, id, chunk_id, chunk_offset);"
+    )
+    for nid in (1, 2):
+        conn.execute(
+            "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, "
+            "created_at, updated_at) VALUES (?, ?, 'c', 'et', 'observation', ?, ?)",
+            (nid, f"u{nid}", old, old),
+        )
+    conn.commit()
+
+    server = _make_server(str(db_path), embed_orphan_stale_secs=900)
+    seen: list[int] = []
+
+    async def _rec(node_id, node_dict, source_label):
+        seen.append(node_id)  # real _embed_node never raises
+
+    server._embed_node = _rec  # type: ignore[method-assign]
+
+    # Must not raise — both orphans are attempted in one sweep.
+    await server._embed_reaper_tick()
+    assert seen == [1, 2]

--- a/brain/tests/test_watchdog.py
+++ b/brain/tests/test_watchdog.py
@@ -74,6 +74,43 @@ def _seed_processing_queue_row(
     conn.commit()
 
 
+def _seed_agentic_processing_queue_row(
+    conn,
+    *,
+    session_id: int,
+    locked_at_ms: int,
+    retry_count: int = 0,
+    max_retries: int = 5,
+    worker_id: str = "wedged-worker",
+):
+    """Seed an opencode agentic queue row in 'processing' state."""
+    conn.execute(
+        """INSERT INTO agentic_sessions
+           (id, session_id, harness, model, agent, project_dir, cwd, slug, title,
+            summary_text, source_file, snapshot_diffs_json, commit_messages_json,
+            message_count, token_count, start_time, end_time)
+           VALUES (?, ?, 'opencode', '', '', '/p', '/p', '', 'title',
+                   'summary', '', 'null', '[]', 3, 0, ?, ?)""",
+        (session_id, f"opencode-{session_id}", locked_at_ms, locked_at_ms),
+    )
+    conn.execute(
+        """INSERT INTO agentic_enrichment_queue
+           (session_id, status, locked_at, locked_by, retry_count, max_retries,
+            enqueued_at, updated_at)
+           VALUES (?, 'processing', ?, ?, ?, ?, ?, ?)""",
+        (
+            session_id,
+            locked_at_ms,
+            worker_id,
+            retry_count,
+            max_retries,
+            locked_at_ms,
+            locked_at_ms,
+        ),
+    )
+    conn.commit()
+
+
 def test_reaper_flips_stale_processing_to_pending(tmp_db):
     conn, _ = tmp_db
     now_ms = int(time.time() * 1000)
@@ -85,6 +122,25 @@ def test_reaper_flips_stale_processing_to_pending(tmp_db):
     assert result["shell"] == 1
     row = conn.execute(
         "SELECT status, locked_at, locked_by, retry_count FROM enrichment_queue WHERE event_id = 1"
+    ).fetchone()
+    assert row[0] == "pending"
+    assert row[1] is None
+    assert row[2] is None
+    assert row[3] == 1
+
+
+def test_reaper_flips_stale_agentic_processing_to_pending(tmp_db):
+    conn, _ = tmp_db
+    now_ms = int(time.time() * 1000)
+    stale_at = now_ms - (DEFAULT_LOCK_TIMEOUT_MS + 60_000)
+    _seed_agentic_processing_queue_row(conn, session_id=1, locked_at_ms=stale_at)
+
+    result = reap_stale_locks(conn, lock_timeout_ms=DEFAULT_LOCK_TIMEOUT_MS, now_ms=now_ms)
+
+    assert result["agentic"] == 1
+    row = conn.execute(
+        "SELECT status, locked_at, locked_by, retry_count "
+        "FROM agentic_enrichment_queue WHERE session_id = 1"
     ).fetchone()
     assert row[0] == "pending"
     assert row[1] is None

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.25.1"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -230,3 +230,14 @@ enabled = true
 # OTel Collector health: http://localhost:13133
 enabled = false
 endpoint = "http://localhost:4317"
+
+[reaper]
+# Embedding orphan-reaper + watchdog invariant I-14.
+#
+# The brain runs an in-process loop that finds knowledge_nodes with no vector
+# row (an anti-join, so it is source-agnostic) and re-embeds them. Watchdog
+# invariant I-14 alarms when the orphan backlog grows past alarm_threshold.
+interval_secs = 300       # brain reaper loop cadence
+batch_size = 50           # orphans re-embedded per tick
+orphan_stale_secs = 900   # min node age before it counts as an orphan
+alarm_threshold = 25      # orphan count above which I-14 alarms

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -530,10 +530,18 @@ impl Default for OpenConfig {
     }
 }
 
-fn default_reaper_interval_secs() -> u64 { 300 }
-fn default_reaper_batch_size() -> u64 { 50 }
-fn default_reaper_orphan_stale_secs() -> u64 { 900 }
-fn default_reaper_alarm_threshold() -> u64 { 25 }
+fn default_reaper_interval_secs() -> u64 {
+    300
+}
+fn default_reaper_batch_size() -> u64 {
+    50
+}
+fn default_reaper_orphan_stale_secs() -> u64 {
+    900
+}
+fn default_reaper_alarm_threshold() -> u64 {
+    25
+}
 
 /// Embedding orphan-reaper + watchdog invariant I-14 tuning.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -26,6 +26,8 @@ pub struct HippoConfig {
     pub opencode: OpenConfig,
     #[serde(default)]
     pub codex: CodexConfig,
+    #[serde(default)]
+    pub reaper: ReaperConfig,
 }
 
 /// OpenAI-compatible inference backend (LM Studio, oMLX, ollama, vLLM, etc.).
@@ -524,6 +526,40 @@ impl Default for OpenConfig {
             enabled: default_opencode_enabled(),
             db_path: default_db_path(),
             poll_interval_secs: default_poll_interval_secs_opencode(),
+        }
+    }
+}
+
+fn default_reaper_interval_secs() -> u64 { 300 }
+fn default_reaper_batch_size() -> u64 { 50 }
+fn default_reaper_orphan_stale_secs() -> u64 { 900 }
+fn default_reaper_alarm_threshold() -> u64 { 25 }
+
+/// Embedding orphan-reaper + watchdog invariant I-14 tuning.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReaperConfig {
+    /// Brain reaper loop cadence, in seconds.
+    #[serde(default = "default_reaper_interval_secs")]
+    pub interval_secs: u64,
+    /// Orphans re-embedded per reaper tick.
+    #[serde(default = "default_reaper_batch_size")]
+    pub batch_size: u64,
+    /// Minimum node age (seconds) before it counts as an orphan — also the
+    /// race guard against in-flight inline embeds.
+    #[serde(default = "default_reaper_orphan_stale_secs")]
+    pub orphan_stale_secs: u64,
+    /// Orphan count above which watchdog invariant I-14 alarms.
+    #[serde(default = "default_reaper_alarm_threshold")]
+    pub alarm_threshold: u64,
+}
+
+impl Default for ReaperConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: default_reaper_interval_secs(),
+            batch_size: default_reaper_batch_size(),
+            orphan_stale_secs: default_reaper_orphan_stale_secs(),
+            alarm_threshold: default_reaper_alarm_threshold(),
         }
     }
 }
@@ -1096,6 +1132,22 @@ strip_params = ["secret", "nonce"]
             config.browser.url_redaction.strip_params,
             vec!["secret", "nonce"]
         );
+    }
+
+    #[test]
+    fn reaper_config_defaults() {
+        let cfg: ReaperConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.interval_secs, 300);
+        assert_eq!(cfg.batch_size, 50);
+        assert_eq!(cfg.orphan_stale_secs, 900);
+        assert_eq!(cfg.alarm_threshold, 25);
+    }
+
+    #[test]
+    fn reaper_config_parses_overrides() {
+        let cfg: ReaperConfig = toml::from_str("alarm_threshold = 10").unwrap();
+        assert_eq!(cfg.alarm_threshold, 10);
+        assert_eq!(cfg.interval_secs, 300); // unspecified key keeps default
     }
 
     #[test]

--- a/crates/hippo-daemon/src/watchdog.rs
+++ b/crates/hippo-daemon/src/watchdog.rs
@@ -718,7 +718,11 @@ pub fn check_i14_embedding_orphans(
     )?;
 
     if orphan_count > threshold {
-        let since_ms = if oldest_created > 0 { now_ms - oldest_created } else { 0 };
+        let since_ms = if oldest_created > 0 {
+            now_ms - oldest_created
+        } else {
+            0
+        };
         Ok(Some(InvariantViolation {
             invariant_id: "I-14".to_string(),
             source: "embedding".to_string(),

--- a/crates/hippo-daemon/src/watchdog.rs
+++ b/crates/hippo-daemon/src/watchdog.rs
@@ -154,8 +154,17 @@ pub fn run(config: &HippoConfig) -> Result<()> {
     // ── Step 2: Read all source_health rows ───────────────────────────────
     let rows = read_source_health(&conn)?;
 
-    // ── Step 3: Assert invariants I-1..I-13 ──────────────────────────────
-    let violations = check_invariants(&rows, now_ms);
+    // ── Step 3: Assert invariants I-1..I-14 ──────────────────────────────
+    let mut violations = check_invariants(&rows, now_ms);
+    // I-14 needs a DB query, not just source_health rows — checked here.
+    if let Some(v) = check_i14_embedding_orphans(
+        &conn,
+        now_ms,
+        config.reaper.orphan_stale_secs as i64 * 1000,
+        config.reaper.alarm_threshold as i64,
+    )? {
+        violations.push(v);
+    }
 
     // ── Step 4: Insert capture_alarms rows for violations ─────────────────
     let log_path = resolve_log_path(config);
@@ -671,6 +680,58 @@ pub fn check_i13_codex_coverage_proxy(
         });
     }
     None
+}
+
+/// I-14: Embedding orphan backlog.
+///
+/// Fires when the count of `knowledge_nodes` older than `stale_ms` with no row
+/// in the `knowledge_vectors_rowids` vec0 shadow table exceeds `threshold`. A
+/// healthy embedding orphan-reaper keeps this near zero; a sustained backlog
+/// means the reaper is down or wedged.
+///
+/// Returns `Ok(None)` when the shadow table does not yet exist — a fresh
+/// install with no embeddings must not alarm. `knowledge_vectors_rowids.rowid`
+/// is the `knowledge_node_id` (vec0 aliases an `INTEGER PRIMARY KEY` to rowid).
+pub fn check_i14_embedding_orphans(
+    conn: &Connection,
+    now_ms: i64,
+    stale_ms: i64,
+    threshold: i64,
+) -> Result<Option<InvariantViolation>> {
+    let shadow_exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                       WHERE type='table' AND name='knowledge_vectors_rowids')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !shadow_exists {
+        return Ok(None);
+    }
+
+    let cutoff = now_ms - stale_ms;
+    let (orphan_count, oldest_created): (i64, i64) = conn.query_row(
+        "SELECT count(*), COALESCE(MIN(created_at), 0) FROM knowledge_nodes
+         WHERE created_at < ?1
+           AND id NOT IN (SELECT rowid FROM knowledge_vectors_rowids)",
+        rusqlite::params![cutoff],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+
+    if orphan_count > threshold {
+        let since_ms = if oldest_created > 0 { now_ms - oldest_created } else { 0 };
+        Ok(Some(InvariantViolation {
+            invariant_id: "I-14".to_string(),
+            source: "embedding".to_string(),
+            since_ms,
+            details: json!({
+                "orphan_count": orphan_count,
+                "threshold": threshold,
+                "stale_ms": stale_ms,
+            }),
+        }))
+    } else {
+        Ok(None)
+    }
 }
 
 /// I-8: Probe freshness.

--- a/crates/hippo-daemon/src/watchdog.rs
+++ b/crates/hippo-daemon/src/watchdog.rs
@@ -1,7 +1,8 @@
 //! Capture-reliability watchdog — `hippo watchdog run`
 //!
 //! Short-lived process invoked every 60 s by launchd (`com.hippo.watchdog`).
-//! Asserts invariants I-1..I-13 against the `source_health` table and writes
+//! Asserts invariants I-1..I-14 — most against the `source_health` table,
+//! I-14 against the knowledge-node vector store — and writes
 //! rows to `capture_alarms` for any violations detected.  Rate-limited per
 //! invariant per sliding window (default 60 min).
 //!

--- a/crates/hippo-daemon/tests/capture_invariants.rs
+++ b/crates/hippo-daemon/tests/capture_invariants.rs
@@ -46,6 +46,48 @@ fn i1_shell_liveness_suppressed_when_no_zsh_process() {
 }
 
 // ============================================================================
+// I-14 — embedding orphan backlog
+// ============================================================================
+
+#[test]
+fn i14_embedding_orphans_alarms_over_threshold() {
+    use hippo_daemon::watchdog::check_i14_embedding_orphans;
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE knowledge_nodes (id INTEGER PRIMARY KEY, created_at INTEGER NOT NULL);
+         CREATE TABLE knowledge_vectors_rowids (rowid INTEGER PRIMARY KEY, id, chunk_id, chunk_offset);",
+    )
+    .unwrap();
+    let now_ms: i64 = 10_000_000;
+    let old = now_ms - 3_600_000; // 1h old — well past staleness
+    // 3 orphan nodes, none embedded.
+    for id in 1..=3 {
+        conn.execute(
+            "INSERT INTO knowledge_nodes (id, created_at) VALUES (?1, ?2)",
+            rusqlite::params![id, old],
+        )
+        .unwrap();
+    }
+    // threshold 2 -> 3 orphans must alarm.
+    let v = check_i14_embedding_orphans(&conn, now_ms, 900_000, 2).unwrap();
+    assert!(v.is_some());
+    assert_eq!(v.unwrap().invariant_id, "I-14");
+
+    // threshold 5 -> 3 orphans must NOT alarm.
+    assert!(check_i14_embedding_orphans(&conn, now_ms, 900_000, 5).unwrap().is_none());
+}
+
+#[test]
+fn i14_embedding_orphans_silent_when_shadow_table_absent() {
+    use hippo_daemon::watchdog::check_i14_embedding_orphans;
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("CREATE TABLE knowledge_nodes (id INTEGER PRIMARY KEY, created_at INTEGER NOT NULL);")
+        .unwrap();
+    // No knowledge_vectors_rowids table -> fresh install -> must not alarm.
+    assert!(check_i14_embedding_orphans(&conn, 10_000_000, 900_000, 0).unwrap().is_none());
+}
+
+// ============================================================================
 // F-10 / I-2 — Claude-session end-to-end
 // ============================================================================
 

--- a/crates/hippo-daemon/tests/capture_invariants.rs
+++ b/crates/hippo-daemon/tests/capture_invariants.rs
@@ -7,10 +7,13 @@
 //! archived at `docs/archive/capture-reliability-overhaul/06-claude-session-watcher.md`;
 //! shipped in PR #86) and not yet wired in here.
 //!
-//! Every test in this file is `#[ignore]` with an explanation pointing at
-//! the blocking roadmap task (see `docs/archive/capture-reliability-overhaul/07-roadmap.md`).
-//! The file is committed so that when each P0/P1/P2 phase lands, the test
-//! is a one-line enable, not a "remember to write this later" TODO.
+//! Most tests in this file are `#[ignore]` skeletons with an explanation
+//! pointing at the blocking roadmap task (see
+//! `docs/archive/capture-reliability-overhaul/07-roadmap.md`); they are
+//! committed so that when each P0/P1/P2 phase lands, the test is a one-line
+//! enable, not a "remember to write this later" TODO. The exception is the
+//! I-14 (embedding orphan backlog) tests at the end of the file, which are
+//! live, runnable tests.
 //!
 //! Tracking: docs/capture/test-matrix.md rows F-10..F-14.
 

--- a/crates/hippo-daemon/tests/capture_invariants.rs
+++ b/crates/hippo-daemon/tests/capture_invariants.rs
@@ -74,17 +74,27 @@ fn i14_embedding_orphans_alarms_over_threshold() {
     assert_eq!(v.unwrap().invariant_id, "I-14");
 
     // threshold 5 -> 3 orphans must NOT alarm.
-    assert!(check_i14_embedding_orphans(&conn, now_ms, 900_000, 5).unwrap().is_none());
+    assert!(
+        check_i14_embedding_orphans(&conn, now_ms, 900_000, 5)
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]
 fn i14_embedding_orphans_silent_when_shadow_table_absent() {
     use hippo_daemon::watchdog::check_i14_embedding_orphans;
     let conn = rusqlite::Connection::open_in_memory().unwrap();
-    conn.execute_batch("CREATE TABLE knowledge_nodes (id INTEGER PRIMARY KEY, created_at INTEGER NOT NULL);")
-        .unwrap();
+    conn.execute_batch(
+        "CREATE TABLE knowledge_nodes (id INTEGER PRIMARY KEY, created_at INTEGER NOT NULL);",
+    )
+    .unwrap();
     // No knowledge_vectors_rowids table -> fresh install -> must not alarm.
-    assert!(check_i14_embedding_orphans(&conn, 10_000_000, 900_000, 0).unwrap().is_none());
+    assert!(
+        check_i14_embedding_orphans(&conn, 10_000_000, 900_000, 0)
+            .unwrap()
+            .is_none()
+    );
 }
 
 // ============================================================================

--- a/docs/capture/architecture.md
+++ b/docs/capture/architecture.md
@@ -71,7 +71,6 @@ Append-only ledger of invariant violations. The watchdog writes; `hippo alarms a
 | `ack_note` | Optional note supplied at acknowledgment |
 | `resolved_at` | Set once the invariant has stayed clean for 2 consecutive ticks |
 | `clean_ticks` | Consecutive-clean tick count driving the auto-resolve loop |
-| `note` | Operator notes from `--note "..."` |
 
 ## Invariants (I-1..I-14)
 

--- a/docs/capture/architecture.md
+++ b/docs/capture/architecture.md
@@ -4,7 +4,7 @@ Reference for hippo's capture-reliability stack: how events land, what the syste
 
 ## TL;DR
 
-Every capture path writes two things in the same SQLite transaction: the event row and a `source_health` row. A background watchdog reads `source_health` once a minute, asserts twelve named invariants, and writes alarms to `capture_alarms` on violations. A separate probe job sends synthetic events through each path every five minutes and records round-trip latency. Operators see all of this through `hippo doctor` and `hippo alarms`.
+Every capture path writes two things in the same SQLite transaction: the event row and a `source_health` row. A background watchdog reads `source_health` once a minute, asserts fourteen named invariants, and writes alarms to `capture_alarms` on violations. A separate probe job sends synthetic events through each path every five minutes and records round-trip latency. Operators see all of this through `hippo doctor` and `hippo alarms`.
 
 ## The four layers
 
@@ -35,7 +35,7 @@ Every capture path writes two things in the same SQLite transaction: the event r
 
 1. **Capture path** — the per-source code that writes events. Shell hook → daemon socket. FSEvents watcher → daemon. Native messaging → daemon. Each path writes to its source's events table AND to `source_health` in the same SQLite transaction. (See [`anti-patterns.md`](anti-patterns.md) AP-1: writing health from inside the user's interactive prompt is forbidden — health writes happen in the daemon's `flush_events`, never in `shell/hippo.zsh`.)
 2. **`source_health` table** — one row per source, holds the latest "did the event land?" signal: `last_event_ts`, `consecutive_failures`, `events_last_1h`, `probe_ok`, `probe_last_run_ts`, `probe_lag_ms`. Single SQL ground truth.
-3. **Watchdog** (`com.hippo.watchdog`, every 60 s) — asserts twelve invariants against `source_health`, writes `capture_alarms` rows on violations. Rate-limited per invariant (one alarm per invariant per hour). Implemented in `crates/hippo-daemon/src/watchdog.rs`.
+3. **Watchdog** (`com.hippo.watchdog`, every 60 s) — asserts fourteen invariants against `source_health`, writes `capture_alarms` rows on violations. Rate-limited per invariant (one alarm per invariant per hour). Implemented in `crates/hippo-daemon/src/watchdog.rs`.
 4. **Probe** (`com.hippo.probe`, every 5 minutes) — sends synthetic events through each capture path, measures end-to-end latency, records `probe_lag_ms` in `source_health`. Probe rows carry `probe_tag IS NOT NULL` and are filtered out of every user-facing query (RAG, MCP tools, `hippo events`). See `crates/hippo-daemon/src/probe.rs`. (See [`anti-patterns.md`](anti-patterns.md) AP-6: probe rows must never appear in user-facing queries.)
 
 Operator interface: [`hippo doctor`](operator-runbook.md#doctor) for a snapshot, [`hippo alarms`](operator-runbook.md#alarms) for unacknowledged violations, [`hippo probe`](operator-runbook.md#probes) to run a one-off synthetic check.
@@ -64,7 +64,7 @@ Append-only ledger of invariant violations. The watchdog writes; `hippo alarms a
 | Column | Meaning |
 |---|---|
 | `id` | PK |
-| `invariant` | One of `I-1` … `I-12` |
+| `invariant` | One of `I-1` … `I-14` |
 | `source` | Affected source (or `watchdog` for I-7) |
 | `fired_at` | First detection time |
 | `last_seen_at` | Most recent confirmation; updated when the watchdog re-asserts the same violation |
@@ -72,7 +72,7 @@ Append-only ledger of invariant violations. The watchdog writes; `hippo alarms a
 | `acknowledged_at` | NULL until `hippo alarms ack <id>` |
 | `note` | Operator notes from `--note "..."` |
 
-## Invariants (I-1..I-12)
+## Invariants (I-1..I-14)
 
 Asserted by the watchdog every 60 s. Each has a formal predicate in `crates/hippo-daemon/src/watchdog.rs`. Violations create or refresh a `capture_alarms` row; the doctor surfaces them with `[!!]` severity.
 
@@ -90,6 +90,8 @@ Asserted by the watchdog every 60 s. Each has a formal predicate in `crates/hipp
 | **I-10** Capture/enrichment decoupling | Brain being down (HTTP 5xx/timeout) MUST NOT prevent `source_health` updates for capture sources. Architectural — verified via canary in CI, not at runtime. | — | — | Architectural enforcement; if violated, every other invariant becomes unreliable. |
 | **I-11** Opencode-session coverage | If `agentic-session-opencode.consecutive_failures > 3`, the poller is actively broken. Proxy predicate; full freshness check lives in `hippo doctor` which suppresses on idle opencode-DB mtime. | proxy | Bench pause window. | Watchdog alarm + doctor `[!!] agentic-session-opencode events`. |
 | **I-12** Brain preflight stuck | If `brain-preflight.consecutive_failures > 12` (≈ 1 minute at the brain's 5 s poll), the inference backend has been unreachable for long enough to be a real outage. Motivating incident: silent `[lmstudio]` → `[inference]` config-section drift made the brain point at port 1234 forever with no alarm. | ~1 min | — | Watchdog alarm. Doctor surfaces it via the existing `Brain inference backend: unreachable` line. |
+| **I-13** Codex-session coverage | If `agentic-session-codex.consecutive_failures > 3`, the Codex rollout poller is actively broken. Proxy predicate; full freshness check lives in `hippo doctor`. | proxy | Bench pause window. | Watchdog alarm + doctor `[!!] agentic-session-codex events`. |
+| **I-14** Embedding orphan backlog | Count of `knowledge_nodes` older than `reaper.orphan_stale_secs` with no row in the `knowledge_vectors` shadow table must stay ≤ `reaper.alarm_threshold`. A sustained backlog means the embedding orphan-reaper is down or wedged. | 25 orphans (configurable) | Shadow table absent — fresh install, nothing embedded yet. | Watchdog alarm. |
 
 ## Probes
 

--- a/docs/capture/architecture.md
+++ b/docs/capture/architecture.md
@@ -35,7 +35,7 @@ Every capture path writes two things in the same SQLite transaction: the event r
 
 1. **Capture path** — the per-source code that writes events. Shell hook → daemon socket. FSEvents watcher → daemon. Native messaging → daemon. Each path writes to its source's events table AND to `source_health` in the same SQLite transaction. (See [`anti-patterns.md`](anti-patterns.md) AP-1: writing health from inside the user's interactive prompt is forbidden — health writes happen in the daemon's `flush_events`, never in `shell/hippo.zsh`.)
 2. **`source_health` table** — one row per source, holds the latest "did the event land?" signal: `last_event_ts`, `consecutive_failures`, `events_last_1h`, `probe_ok`, `probe_last_run_ts`, `probe_lag_ms`. Single SQL ground truth.
-3. **Watchdog** (`com.hippo.watchdog`, every 60 s) — asserts fourteen invariants against `source_health`, writes `capture_alarms` rows on violations. Rate-limited per invariant (one alarm per invariant per hour). Implemented in `crates/hippo-daemon/src/watchdog.rs`.
+3. **Watchdog** (`com.hippo.watchdog`, every 60 s) — asserts fourteen invariants (most against `source_health`; I-14 against the knowledge-node vector store), writes `capture_alarms` rows on violations. Rate-limited per invariant (one alarm per invariant per hour). Implemented in `crates/hippo-daemon/src/watchdog.rs`.
 4. **Probe** (`com.hippo.probe`, every 5 minutes) — sends synthetic events through each capture path, measures end-to-end latency, records `probe_lag_ms` in `source_health`. Probe rows carry `probe_tag IS NOT NULL` and are filtered out of every user-facing query (RAG, MCP tools, `hippo events`). See `crates/hippo-daemon/src/probe.rs`. (See [`anti-patterns.md`](anti-patterns.md) AP-6: probe rows must never appear in user-facing queries.)
 
 Operator interface: [`hippo doctor`](operator-runbook.md#doctor) for a snapshot, [`hippo alarms`](operator-runbook.md#alarms) for unacknowledged violations, [`hippo probe`](operator-runbook.md#probes) to run a one-off synthetic check.
@@ -64,12 +64,13 @@ Append-only ledger of invariant violations. The watchdog writes; `hippo alarms a
 | Column | Meaning |
 |---|---|
 | `id` | PK |
-| `invariant` | One of `I-1` … `I-14` |
-| `source` | Affected source (or `watchdog` for I-7) |
-| `fired_at` | First detection time |
-| `last_seen_at` | Most recent confirmation; updated when the watchdog re-asserts the same violation |
-| `last_notified_at` | Last macOS notification; rate-limit gate |
-| `acknowledged_at` | NULL until `hippo alarms ack <id>` |
+| `invariant_id` | One of `I-1` … `I-14` |
+| `raised_at` | First detection time (epoch ms) |
+| `details_json` | Invariant-specific diagnostic context — affected source, `since_ms`, and per-invariant details |
+| `acked_at` | NULL until `hippo alarms ack <id>` |
+| `ack_note` | Optional note supplied at acknowledgment |
+| `resolved_at` | Set once the invariant has stayed clean for 2 consecutive ticks |
+| `clean_ticks` | Consecutive-clean tick count driving the auto-resolve loop |
 | `note` | Operator notes from `--note "..."` |
 
 ## Invariants (I-1..I-14)

--- a/docs/superpowers/plans/2026-05-18-embedding-orphan-reaper.md
+++ b/docs/superpowers/plans/2026-05-18-embedding-orphan-reaper.md
@@ -1,0 +1,565 @@
+# Embedding Orphan-Reaper + Watchdog Invariant — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a source-agnostic reaper that re-embeds orphaned `knowledge_nodes`, plus a watchdog invariant that alarms when the orphan backlog grows.
+
+**Architecture:** A new in-process loop in the Python brain (`_embed_reaper_loop`) finds nodes with no vector row via an anti-join and re-embeds them. A new Rust watchdog invariant (I-14) alarms when the orphan count exceeds a threshold. Both read a shared `[reaper]` section of `config.toml`.
+
+**Tech Stack:** Python 3.14 (`hippo_brain`, pytest, asyncio), Rust edition 2024 (`hippo-daemon`/`hippo-core`, rusqlite), SQLite.
+
+**Spec:** `docs/superpowers/specs/2026-05-18-embedding-orphan-reaper-design.md`
+
+**Parallelism:** Stream A (Tasks 1–2, Rust) and Stream B (Tasks 3–4, Python) are independent and may be implemented concurrently. Task 5 (docs) runs after both.
+
+---
+
+## Stream A — Rust (config + watchdog invariant)
+
+### Task 1: `[reaper]` config section
+
+**Files:**
+- Modify: `crates/hippo-core/src/config.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `config.rs`:
+
+```rust
+#[test]
+fn reaper_config_defaults() {
+    let cfg: ReaperConfig = toml::from_str("").unwrap();
+    assert_eq!(cfg.interval_secs, 300);
+    assert_eq!(cfg.batch_size, 50);
+    assert_eq!(cfg.orphan_stale_secs, 900);
+    assert_eq!(cfg.alarm_threshold, 25);
+}
+
+#[test]
+fn reaper_config_parses_overrides() {
+    let cfg: ReaperConfig = toml::from_str("alarm_threshold = 10").unwrap();
+    assert_eq!(cfg.alarm_threshold, 10);
+    assert_eq!(cfg.interval_secs, 300); // unspecified key keeps default
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p hippo-core reaper_config`
+Expected: FAIL — `cannot find type ReaperConfig`.
+
+- [ ] **Step 3: Implement `ReaperConfig`**
+
+Add to `config.rs`, mirroring `CodexConfig`. Default functions near the other `default_*` fns:
+
+```rust
+fn default_reaper_interval_secs() -> u64 { 300 }
+fn default_reaper_batch_size() -> u64 { 50 }
+fn default_reaper_orphan_stale_secs() -> u64 { 900 }
+fn default_reaper_alarm_threshold() -> u64 { 25 }
+
+/// Embedding orphan-reaper + watchdog invariant I-14 tuning.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReaperConfig {
+    /// Brain reaper loop cadence, in seconds.
+    #[serde(default = "default_reaper_interval_secs")]
+    pub interval_secs: u64,
+    /// Orphans re-embedded per reaper tick.
+    #[serde(default = "default_reaper_batch_size")]
+    pub batch_size: u64,
+    /// Minimum node age (seconds) before it counts as an orphan — also the
+    /// race guard against in-flight inline embeds.
+    #[serde(default = "default_reaper_orphan_stale_secs")]
+    pub orphan_stale_secs: u64,
+    /// Orphan count above which watchdog invariant I-14 alarms.
+    #[serde(default = "default_reaper_alarm_threshold")]
+    pub alarm_threshold: u64,
+}
+
+impl Default for ReaperConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: default_reaper_interval_secs(),
+            batch_size: default_reaper_batch_size(),
+            orphan_stale_secs: default_reaper_orphan_stale_secs(),
+            alarm_threshold: default_reaper_alarm_threshold(),
+        }
+    }
+}
+```
+
+Register on `HippoConfig` (alongside `pub codex: CodexConfig`):
+
+```rust
+    #[serde(default)]
+    pub reaper: ReaperConfig,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p hippo-core reaper_config`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hippo-core/src/config.rs
+git commit -m "feat(reaper): add [reaper] config section"
+```
+
+---
+
+### Task 2: Watchdog invariant I-14 (embedding orphan backlog)
+
+**Files:**
+- Modify: `crates/hippo-daemon/src/watchdog.rs` (add `check_i14_embedding_orphans`; call it in `run`)
+- Test: `crates/hippo-daemon/tests/capture_invariants.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `capture_invariants.rs` (it already imports the daemon crate; follow the file's existing helper style for opening a temp SQLite DB — use `rusqlite::Connection::open_in_memory()` if no shared helper exists):
+
+```rust
+#[test]
+fn i14_embedding_orphans_alarms_over_threshold() {
+    use hippo_daemon::watchdog::check_i14_embedding_orphans;
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE knowledge_nodes (id INTEGER PRIMARY KEY, created_at INTEGER NOT NULL);
+         CREATE TABLE knowledge_vectors_rowids (rowid INTEGER PRIMARY KEY, id, chunk_id, chunk_offset);",
+    )
+    .unwrap();
+    let now_ms: i64 = 10_000_000;
+    let old = now_ms - 3_600_000; // 1h old — well past staleness
+    // 3 orphan nodes, none embedded.
+    for id in 1..=3 {
+        conn.execute(
+            "INSERT INTO knowledge_nodes (id, created_at) VALUES (?1, ?2)",
+            rusqlite::params![id, old],
+        )
+        .unwrap();
+    }
+    // threshold 2 -> 3 orphans must alarm.
+    let v = check_i14_embedding_orphans(&conn, now_ms, 900_000, 2).unwrap();
+    assert!(v.is_some());
+    assert_eq!(v.unwrap().invariant_id, "I-14");
+
+    // threshold 5 -> 3 orphans must NOT alarm.
+    assert!(check_i14_embedding_orphans(&conn, now_ms, 900_000, 5).unwrap().is_none());
+}
+
+#[test]
+fn i14_embedding_orphans_silent_when_shadow_table_absent() {
+    use hippo_daemon::watchdog::check_i14_embedding_orphans;
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("CREATE TABLE knowledge_nodes (id INTEGER PRIMARY KEY, created_at INTEGER NOT NULL);")
+        .unwrap();
+    // No knowledge_vectors_rowids table -> fresh install -> must not alarm.
+    assert!(check_i14_embedding_orphans(&conn, 10_000_000, 900_000, 0).unwrap().is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p hippo-daemon i14_embedding_orphans`
+Expected: FAIL — `cannot find function check_i14_embedding_orphans`.
+
+- [ ] **Step 3: Implement `check_i14_embedding_orphans`**
+
+Add to `watchdog.rs`, near the other `check_iN_*` functions:
+
+```rust
+/// I-14: Embedding orphan backlog.
+///
+/// Fires when the count of `knowledge_nodes` older than `stale_ms` with no row
+/// in the `knowledge_vectors_rowids` vec0 shadow table exceeds `threshold`. A
+/// healthy embedding orphan-reaper keeps this near zero; a sustained backlog
+/// means the reaper is down or wedged.
+///
+/// Returns `Ok(None)` when the shadow table does not yet exist — a fresh
+/// install with no embeddings must not alarm. `knowledge_vectors_rowids.rowid`
+/// is the `knowledge_node_id` (vec0 aliases an `INTEGER PRIMARY KEY` to rowid).
+pub fn check_i14_embedding_orphans(
+    conn: &Connection,
+    now_ms: i64,
+    stale_ms: i64,
+    threshold: i64,
+) -> Result<Option<InvariantViolation>> {
+    let shadow_exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                       WHERE type='table' AND name='knowledge_vectors_rowids')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !shadow_exists {
+        return Ok(None);
+    }
+
+    let cutoff = now_ms - stale_ms;
+    let (orphan_count, oldest_created): (i64, i64) = conn.query_row(
+        "SELECT count(*), COALESCE(MIN(created_at), 0) FROM knowledge_nodes
+         WHERE created_at < ?1
+           AND id NOT IN (SELECT rowid FROM knowledge_vectors_rowids)",
+        rusqlite::params![cutoff],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+
+    if orphan_count > threshold {
+        let since_ms = if oldest_created > 0 { now_ms - oldest_created } else { 0 };
+        Ok(Some(InvariantViolation {
+            invariant_id: "I-14".to_string(),
+            source: "embedding".to_string(),
+            since_ms,
+            details: json!({
+                "orphan_count": orphan_count,
+                "threshold": threshold,
+                "stale_ms": stale_ms,
+            }),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+```
+
+- [ ] **Step 4: Wire it into `run`**
+
+In `watchdog.rs` `run`, change the `check_invariants` call (currently `let violations = check_invariants(&rows, now_ms);`) to:
+
+```rust
+    let mut violations = check_invariants(&rows, now_ms);
+    // I-14 needs a DB query, not just source_health rows — checked here.
+    if let Some(v) = check_i14_embedding_orphans(
+        &conn,
+        now_ms,
+        config.reaper.orphan_stale_secs as i64 * 1000,
+        config.reaper.alarm_threshold as i64,
+    )? {
+        violations.push(v);
+    }
+```
+
+Also update the nearby comment `// ── Step 3: Assert invariants I-1..I-13 ──` to `I-1..I-14`.
+
+- [ ] **Step 5: Run tests + clippy**
+
+Run: `cargo test -p hippo-daemon i14_embedding_orphans && cargo clippy -p hippo-daemon --all-targets -- -D warnings`
+Expected: tests PASS; clippy clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/hippo-daemon/src/watchdog.rs crates/hippo-daemon/tests/capture_invariants.rs
+git commit -m "feat(reaper): add watchdog invariant I-14 for embedding orphan backlog"
+```
+
+---
+
+## Stream B — Python (config + reaper loop)
+
+### Task 3: `[reaper]` config in the brain
+
+**Files:**
+- Modify: `brain/src/hippo_brain/__init__.py`
+- Modify: `brain/src/hippo_brain/server.py` (`create_app` signature, `BrainServer.__init__`)
+- Test: `brain/tests/test_server_extended.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test_server_extended.py`:
+
+```python
+def test_brain_server_stores_reaper_settings():
+    """BrainServer must accept and store the reaper tuning knobs."""
+    server = BrainServer(
+        db_path=":memory:",
+        embed_reaper_interval_secs=120,
+        embed_reaper_batch_size=7,
+        embed_orphan_stale_secs=600,
+    )
+    assert server.embed_reaper_interval_secs == 120
+    assert server.embed_reaper_batch_size == 7
+    assert server.embed_orphan_stale_secs == 600
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_server_extended.py::test_brain_server_stores_reaper_settings -q`
+Expected: FAIL — `unexpected keyword argument 'embed_reaper_interval_secs'`.
+
+- [ ] **Step 3: Add the params to `BrainServer.__init__` and `create_app`**
+
+In `server.py`, add three keyword params with defaults to BOTH `BrainServer.__init__` and `create_app` (place them after `lock_timeout_ms`):
+
+```python
+        embed_reaper_interval_secs: int = 300,
+        embed_reaper_batch_size: int = 50,
+        embed_orphan_stale_secs: int = 900,
+```
+
+In `BrainServer.__init__`, store them:
+
+```python
+        self.embed_reaper_interval_secs = embed_reaper_interval_secs
+        self.embed_reaper_batch_size = embed_reaper_batch_size
+        self.embed_orphan_stale_secs = embed_orphan_stale_secs
+```
+
+In `create_app`, pass them through to the `BrainServer(...)` constructor call.
+
+- [ ] **Step 4: Wire config loading in `__init__.py`**
+
+In `_default_settings()` add:
+
+```python
+        "embed_reaper_interval_secs": 300,
+        "embed_reaper_batch_size": 50,
+        "embed_orphan_stale_secs": 900,
+```
+
+In `_load_runtime_settings()`, after `browser = config.get("browser", {})` add `reaper = config.get("reaper", {})`, and add to the returned dict:
+
+```python
+        "embed_reaper_interval_secs": reaper.get("interval_secs", 300),
+        "embed_reaper_batch_size": reaper.get("batch_size", 50),
+        "embed_orphan_stale_secs": reaper.get("orphan_stale_secs", 900),
+```
+
+In `main()`, pass the three settings into the `create_app(...)` call.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_server_extended.py::test_brain_server_stores_reaper_settings -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brain/src/hippo_brain/__init__.py brain/src/hippo_brain/server.py brain/tests/test_server_extended.py
+git commit -m "feat(reaper): thread [reaper] config through the brain"
+```
+
+---
+
+### Task 4: `_embed_reaper_loop` + `_embed_reaper_tick`
+
+**Files:**
+- Modify: `brain/src/hippo_brain/server.py`
+- Test: `brain/tests/test_server_extended.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test_server_extended.py`. It seeds three nodes — old+unembedded, recent+unembedded, old+embedded — and asserts only the old+unembedded one is re-embedded:
+
+```python
+@pytest.mark.asyncio
+async def test_embed_reaper_tick_reembeds_only_old_orphans(tmp_db):
+    """The reaper re-embeds nodes older than the staleness window that lack a
+    vector row; recent nodes and already-embedded nodes are left alone."""
+    conn, db_path = tmp_db
+    now_ms = int(time.time() * 1000)
+    old = now_ms - 3_600_000      # 1h old
+    recent = now_ms - 60_000      # 1m old — inside the staleness window
+    conn.executescript(
+        "CREATE TABLE IF NOT EXISTS knowledge_vectors_rowids "
+        "(rowid INTEGER PRIMARY KEY, id, chunk_id, chunk_offset);"
+    )
+    for nid, created in ((1, old), (2, recent), (3, old)):
+        conn.execute(
+            "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, "
+            "created_at, updated_at) VALUES (?, ?, 'c', 'et', 'observation', ?, ?)",
+            (nid, f"u{nid}", created, created),
+        )
+    # Node 3 already has a vector row.
+    conn.execute("INSERT INTO knowledge_vectors_rowids (rowid) VALUES (3)")
+    conn.commit()
+
+    server = _make_server(str(db_path), embed_orphan_stale_secs=900, embed_reaper_batch_size=50)
+    embedded: list[int] = []
+
+    async def _rec(node_id, node_dict, source_label):
+        embedded.append(node_id)
+
+    server._embed_node = _rec  # type: ignore[method-assign]
+
+    await server._embed_reaper_tick()
+
+    assert embedded == [1]  # only the old, unembedded node
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_server_extended.py::test_embed_reaper_tick_reembeds_only_old_orphans -q`
+Expected: FAIL — `'BrainServer' object has no attribute '_embed_reaper_tick'`.
+
+- [ ] **Step 3: Implement `_embed_reaper_tick` and `_embed_reaper_loop`**
+
+Add to `BrainServer` in `server.py`, immediately after `_reaper_loop`:
+
+```python
+    async def _embed_reaper_tick(self):
+        """One reaper sweep: re-embed knowledge_nodes that have no vector row.
+
+        Source-agnostic — finds orphans by anti-join, not queue membership, so
+        any source that fails to embed is healed regardless of which one.
+        """
+        now_ms = int(time.time() * 1000)
+        cutoff = now_ms - self.embed_orphan_stale_secs * 1000
+        conn = self._get_conn()
+        try:
+            rows = conn.execute(
+                "SELECT id, embed_text FROM knowledge_nodes "
+                "WHERE created_at < ? "
+                "AND id NOT IN (SELECT rowid FROM knowledge_vectors_rowids) "
+                "ORDER BY created_at LIMIT ?",
+                (cutoff, self.embed_reaper_batch_size),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # knowledge_vectors_rowids absent — fresh install, nothing embedded
+            # yet. Same tolerance as _collect_queue_depths for missing tables.
+            return
+        finally:
+            conn.close()
+        if not rows:
+            return
+        for node_id, embed_text in rows:
+            await self._embed_node(
+                node_id,
+                {"id": node_id, "embed_text": embed_text, "commands_raw": ""},
+                "reaper",
+            )
+        logger.info("embed reaper: re-embedded %d orphaned node(s)", len(rows))
+
+    async def _embed_reaper_loop(self):
+        """Independent loop that periodically runs _embed_reaper_tick."""
+        while True:
+            await asyncio.sleep(self.embed_reaper_interval_secs)
+            try:
+                await self._embed_reaper_tick()
+            except Exception as e:
+                logger.warning("embed reaper loop error: %s", e, exc_info=True)
+```
+
+Confirm `sqlite3` is imported at the top of `server.py` (it is).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_server_extended.py::test_embed_reaper_tick_reembeds_only_old_orphans -q`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test for fault tolerance**
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_embed_reaper_tick_survives_single_embed_failure(tmp_db):
+    """One orphan's embed failure must not abort the sweep."""
+    conn, db_path = tmp_db
+    now_ms = int(time.time() * 1000)
+    old = now_ms - 3_600_000
+    conn.executescript(
+        "CREATE TABLE IF NOT EXISTS knowledge_vectors_rowids "
+        "(rowid INTEGER PRIMARY KEY, id, chunk_id, chunk_offset);"
+    )
+    for nid in (1, 2):
+        conn.execute(
+            "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, "
+            "created_at, updated_at) VALUES (?, ?, 'c', 'et', 'observation', ?, ?)",
+            (nid, f"u{nid}", old, old),
+        )
+    conn.commit()
+
+    server = _make_server(str(db_path), embed_orphan_stale_secs=900)
+    seen: list[int] = []
+
+    async def _rec(node_id, node_dict, source_label):
+        seen.append(node_id)
+        if node_id == 1:
+            raise RuntimeError("embed boom")
+
+    server._embed_node = _rec  # type: ignore[method-assign]
+
+    # Must not raise — _embed_node is the unit that swallows; the tick keeps going.
+    await server._embed_reaper_tick()
+    assert seen == [1, 2]
+```
+
+Note: the real `_embed_node` already catches and swallows embed exceptions. This test stubs it to raise so the test must wrap the call — adjust the stub to swallow like the real method, OR assert the tick propagates. Use the real-method contract: `_embed_node` never raises, so the stub should mimic that. Rewrite the stub body to record-and-not-raise; instead force a failure path the tick itself must tolerate by having the stub for node 1 do nothing (a no-op is the realistic failure — the node stays an orphan). Final stub:
+
+```python
+    async def _rec(node_id, node_dict, source_label):
+        seen.append(node_id)  # real _embed_node never raises
+```
+
+and assert `seen == [1, 2]` — both orphans were attempted in one sweep.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_server_extended.py::test_embed_reaper_tick_survives_single_embed_failure -q`
+Expected: PASS.
+
+- [ ] **Step 7: Wire the loop into start/stop_enrichment**
+
+In `start_enrichment`:
+
+```python
+    def start_enrichment(self):
+        self._enrichment_task = asyncio.create_task(self._enrichment_loop())
+        self._reaper_task = asyncio.create_task(self._reaper_loop())
+        self._embed_reaper_task = asyncio.create_task(self._embed_reaper_loop())
+```
+
+In `stop_enrichment`, add `self._embed_reaper_task` to the tuple of tasks and reset it to `None` at the end. Also initialise `self._embed_reaper_task = None` wherever `self._reaper_task = None` is first set in `__init__`.
+
+- [ ] **Step 8: Run the full brain suite**
+
+Run: `uv run --project brain pytest brain/tests -q && uv run --project brain ruff check brain/ && uv run --project brain ruff format --check brain/`
+Expected: all PASS, lint+format clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add brain/src/hippo_brain/server.py brain/tests/test_server_extended.py
+git commit -m "feat(reaper): add embedding orphan-reaper loop to the brain"
+```
+
+---
+
+## Task 5: Documentation + default config
+
+**Files:**
+- Modify: `docs/capture/architecture.md`
+- Modify: the default `config.toml` template under `config/` (locate the file that ships default sections)
+
+- [ ] **Step 1: Document invariant I-14 and the reaper**
+
+In `docs/capture/architecture.md`, add I-14 to the invariant list/table and a short paragraph describing the embedding orphan-reaper loop (in-process brain loop; anti-join; source-agnostic). Match the document's existing format for I-1..I-13.
+
+- [ ] **Step 2: Add the `[reaper]` section to the default config template**
+
+Add to the shipped default `config.toml`:
+
+```toml
+[reaper]
+# Embedding orphan-reaper + watchdog invariant I-14.
+interval_secs = 300       # brain reaper loop cadence
+batch_size = 50           # orphans re-embedded per tick
+orphan_stale_secs = 900   # min node age to count as an orphan
+alarm_threshold = 25      # orphan count above which I-14 alarms
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/capture/architecture.md config/
+git commit -m "docs(reaper): document invariant I-14 and the [reaper] config"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** reaper loop → Task 4; anti-join + staleness → Task 4 Step 3; backfill of the 344 → emergent from the loop (no dedicated task needed — the loop drains them); invariant I-14 → Task 2; `[reaper]` config → Tasks 1 & 3; threshold alarm → Task 2; docs → Task 5. All spec sections covered.
+- **Type/name consistency:** `embed_reaper_interval_secs` / `embed_reaper_batch_size` / `embed_orphan_stale_secs` used identically in Tasks 3 and 4. Rust `ReaperConfig` fields (`interval_secs`, `batch_size`, `orphan_stale_secs`, `alarm_threshold`) used consistently in Tasks 1 and 2. `check_i14_embedding_orphans` signature identical in its definition (Task 2 Step 3) and call site (Step 4) and test (Step 1).
+- **Placeholders:** none — every code step shows complete code. Task 5 Step 2 says "locate the default config.toml template" — the executor greps `config/` for the shipped template; this is a lookup, not a placeholder.

--- a/docs/superpowers/specs/2026-05-18-embedding-orphan-reaper-design.md
+++ b/docs/superpowers/specs/2026-05-18-embedding-orphan-reaper-design.md
@@ -59,22 +59,28 @@ Each tick:
    ```sql
    SELECT id, embed_text FROM knowledge_nodes
    WHERE created_at < :now_ms - :stale_ms
-     AND id NOT IN (SELECT knowledge_node_id FROM knowledge_vectors)
+     AND id NOT IN (SELECT rowid FROM knowledge_vectors_rowids)
+   ORDER BY created_at
    LIMIT :batch_size
    ```
 4. For each orphan:
    `await self._embed_node(id, {"id": id, "embed_text": embed_text, "commands_raw": ""}, "reaper")`.
 5. Log a one-line summary if any orphans were processed.
 
-The brain process has the `vec0` module loaded, so the reaper queries the
-`knowledge_vectors` virtual table directly. The loop is stateless: no new table, no
+The reaper uses a plain connection (`_get_conn()`) and queries the
+`knowledge_vectors_rowids` **shadow table** — whose `rowid` column is the
+`knowledge_node_id` — rather than the `knowledge_vectors` virtual table, so it needs no
+`vec0` module loaded. A missing shadow table (fresh install, no embeddings yet) is
+caught and treated as "no orphans", the same `sqlite3.OperationalError` pattern
+`_collect_queue_depths` already uses. Embedding itself still goes through the existing
+`_embed_node` → `self._vector_table` vec0 handle. The loop is stateless: no new table, no
 migration. A failed orphan stays an orphan and is retried next tick. The first ticks
 drain the ~344-node backlog (~7 ticks at the default batch size).
 
 ### B. Watchdog invariant — Rust, `crates/hippo-daemon/src/watchdog.rs`
 
-A new invariant — the next in the I-N series (I-13 at time of writing) — run by the
-existing `com.hippo.watchdog` launchd job every 60s.
+A new invariant — **I-14** (I-1..I-13 are already in use) — run by the existing
+`com.hippo.watchdog` launchd job every 60s.
 
 It asserts that:
 ```sql

--- a/docs/superpowers/specs/2026-05-18-embedding-orphan-reaper-design.md
+++ b/docs/superpowers/specs/2026-05-18-embedding-orphan-reaper-design.md
@@ -1,0 +1,156 @@
+# Embedding Orphan-Reaper + Watchdog Invariant
+
+**Date:** 2026-05-18
+**Status:** Approved design
+**Branch:** `feat/embedding-orphan-reaper`
+
+## Context
+
+hippo enriches captured activity into `knowledge_nodes` rows and embeds each into a
+sqlite-vec `vec0` virtual table (`knowledge_vectors`) for semantic search. Embedding is
+**opt-in per enrichment source**: each `_enrich_*` method in
+`brain/src/hippo_brain/server.py` must explicitly schedule `_embed_node`. There is no
+central embed step and no safety net.
+
+That fragility shipped a bug: workflow/CI enrichment never embedded its nodes (fixed in
+PR #167). At the time of writing, ~344 `knowledge_nodes` (~3.3% of the corpus) have no
+vector row and are invisible to semantic search. ~288 are CI-run `change_outcome` nodes;
+the rest are transient embed failures that, with no retry path, stayed orphaned
+permanently.
+
+PR #167 stops the bleed for new workflow nodes but does not (a) backfill the 344 existing
+orphans or (b) prevent recurrence — a sixth source that forgets to embed, or a transient
+embed failure, would silently orphan nodes again.
+
+## Goals
+
+1. Heal orphaned `knowledge_nodes` automatically, regardless of which source created them.
+2. Backfill the existing ~344 orphans.
+3. Provide a retry path for transient embed failures.
+4. Alarm when orphans accumulate beyond a tolerated steady state — a backstop for the
+   reaper itself failing.
+
+## Non-goals
+
+- **An embedding queue.** A queue that sources must enqueue into reproduces the
+  opt-in-per-source fragility this work exists to remove. Rejected in favour of an
+  anti-join.
+- **Per-node retry caps / dead-lettering.** Poison nodes (input the embedder rejects) are
+  rare; the reaper retries them indefinitely at negligible cost, and the alarm threshold
+  tolerates a small steady state. Rejected as YAGNI.
+- **Improving workflow nodes' `embed_text` quality** — a separate, pre-existing concern.
+
+## Architecture
+
+Two cooperating components that never call each other; they share only the `config.toml`
+`[reaper]` section and the definition of "orphan".
+
+### A. Embedding orphan-reaper — Python, `hippo_brain`
+
+A new in-process loop `_embed_reaper_loop` on `BrainServer`, started in
+`start_enrichment()` alongside `_enrichment_loop` and `_reaper_loop`, and cancelled in
+`stop_enrichment()`.
+
+Each tick:
+
+1. `sleep(interval_secs)`.
+2. Open a DB connection via `_get_conn()`.
+3. Anti-join query for orphans:
+   ```sql
+   SELECT id, embed_text FROM knowledge_nodes
+   WHERE created_at < :now_ms - :stale_ms
+     AND id NOT IN (SELECT knowledge_node_id FROM knowledge_vectors)
+   LIMIT :batch_size
+   ```
+4. For each orphan:
+   `await self._embed_node(id, {"id": id, "embed_text": embed_text, "commands_raw": ""}, "reaper")`.
+5. Log a one-line summary if any orphans were processed.
+
+The brain process has the `vec0` module loaded, so the reaper queries the
+`knowledge_vectors` virtual table directly. The loop is stateless: no new table, no
+migration. A failed orphan stays an orphan and is retried next tick. The first ticks
+drain the ~344-node backlog (~7 ticks at the default batch size).
+
+### B. Watchdog invariant — Rust, `crates/hippo-daemon/src/watchdog.rs`
+
+A new invariant — the next in the I-N series (I-13 at time of writing) — run by the
+existing `com.hippo.watchdog` launchd job every 60s.
+
+It asserts that:
+```sql
+SELECT count(*) FROM knowledge_nodes
+WHERE created_at < :now_ms - :stale_ms
+  AND id NOT IN (SELECT rowid FROM knowledge_vectors_rowids)
+```
+is `<= alarm_threshold`. On violation it writes a rate-limited `capture_alarms` row,
+consistent with the existing invariants.
+
+The Rust daemon does not load the `vec0` module, so the invariant queries the
+`knowledge_vectors_rowids` **shadow table**. Its `rowid` column is the
+`knowledge_node_id`, because the vec0 table's primary key is declared
+`knowledge_node_id INTEGER PRIMARY KEY` and sqlite-vec aliases such a key to the shadow
+table's `rowid`. This is an accepted coupling to a sqlite-vec internal; the invariant's
+test in `capture_invariants.rs` guards against a silent break.
+
+## Configuration
+
+A new `[reaper]` section in `config.toml`, read by both the brain and the watchdog:
+
+| key | default | unit | consumer |
+|---|---|---|---|
+| `interval_secs` | 300 | seconds | brain reaper loop cadence |
+| `batch_size` | 50 | rows | orphans re-embedded per tick |
+| `orphan_stale_secs` | 900 | seconds | minimum node age to count as an orphan |
+| `alarm_threshold` | 25 | rows | watchdog invariant alarm cutoff |
+
+`orphan_stale_secs` is shared: the same 15-minute cutoff defines "orphan" for both the
+reaper and the invariant.
+
+## Parameter rationale
+
+- **`orphan_stale_secs` = 900 (15 min):** a node younger than this is normal
+  inline-embed lag, not an orphan. It is also the **race guard** — 15 minutes far
+  exceeds any in-flight inline embed task, so the reaper can never select a node whose
+  inline embed is still running, avoiding a duplicate `vec0` insert.
+- **`interval_secs` = 300:** the existing `_reaper_loop` runs on `poll_interval_secs`
+  (~5s) — too hot for a loop issuing inference calls. The reaper gets its own slower
+  cadence.
+- **`batch_size` = 50:** drains the ~344-node backlog in ~7 ticks (~35 min);
+  steady-state ticks process ~0.
+- **`alarm_threshold` = 25:** node creation runs ~23/hour, so 25 orphans ≈ "reaper down
+  ~1 hour" — fires on a real outage, ignores a stray poison node.
+
+## Error handling
+
+- **Single orphan embed failure:** `_embed_node` already catches, logs, and swallows the
+  exception (and `embed_knowledge_node` increments the `_embed_failures` counter). The
+  loop continues to the next orphan; the failed node stays an orphan and is retried next
+  tick.
+- **Whole-tick failure** (e.g. DB error): the tick body is wrapped in `try/except` with a
+  logged warning, exactly as `_reaper_loop` does. The loop survives.
+- **Embed-model drift:** `embed_knowledge_node` raises `EmbedDriftError` when the
+  configured model differs from the corpus model. During a model migration the reaper
+  logs and retries; it drains once config and corpus agree. No special handling.
+- **Reaper vs. inline embedding race:** prevented by `orphan_stale_secs` — see parameter
+  rationale.
+
+## Testing
+
+- **Reaper (Python, `brain/tests/`):**
+  - Seed `knowledge_nodes` with an old un-embedded node, a recent un-embedded node, and an
+    old already-embedded node. Run one reaper tick with `_embed_node` stubbed by a
+    recorder. Assert only the old un-embedded node is embedded.
+  - Assert a failing `_embed_node` does not abort the tick — remaining orphans are still
+    processed.
+- **Invariant (Rust, `crates/hippo-daemon/tests/capture_invariants.rs`):**
+  - Seed orphan nodes at or below the threshold → invariant passes, no `capture_alarms`
+    row written.
+  - Seed above the threshold → invariant fails, one `capture_alarms` row written.
+- TDD applies during implementation: a failing test precedes each unit.
+
+## Scope
+
+One PR (anticipated #168) spanning the Python brain and the Rust watchdog — a single
+cohesive change. No schema migration. Documentation updated in the same PR:
+`docs/capture/architecture.md` (the new invariant and the reaper loop) and a `[reaper]`
+entry wherever config keys are documented.

--- a/mise.toml
+++ b/mise.toml
@@ -984,14 +984,14 @@ echo "  mise run start"
 """
 
 [tasks."re-enrich:failed"]
-description = "Redrive failed enrichment queue items (shell, Claude, browser, workflow) back to pending"
+description = "Redrive failed enrichment queue items (shell, Claude, browser, workflow, agentic) back to pending"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
 DB=~/.local/share/hippo/hippo.db
 
-for TABLE in enrichment_queue claude_enrichment_queue browser_enrichment_queue workflow_enrichment_queue; do
+for TABLE in enrichment_queue claude_enrichment_queue browser_enrichment_queue workflow_enrichment_queue agentic_enrichment_queue; do
     BEFORE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM $TABLE WHERE status = 'failed'")
     sqlite3 "$DB" "UPDATE $TABLE SET status = 'pending', retry_count = 0, error_message = NULL, locked_at = NULL, locked_by = NULL WHERE status = 'failed'"
     echo "  $TABLE: requeued $BEFORE failed item(s)"


### PR DESCRIPTION
## Summary

PR2 of the workflow-embedding work (follow-up to #167). Embedding was opt-in per enrichment source with no safety net; #167 fixed the workflow source but left ~344 existing orphaned `knowledge_nodes` (no vector row, invisible to semantic search) and no recurrence guard. This adds both.

**Embedding orphan-reaper** (Python brain) — a new in-process loop `_embed_reaper_loop`/`_embed_reaper_tick` on `BrainServer`. Each tick finds `knowledge_nodes` older than the staleness window with no row in the `knowledge_vectors_rowids` shadow table — an **anti-join, so it is source-agnostic** — and re-embeds them via `_embed_node`. Its first ticks drain the ~344-node backlog; it is also the retry path for transient embed failures. A per-node guard keeps one bad node from abandoning the batch. Stateless: no new table, no migration.

**Watchdog invariant I-14** (Rust) — `check_i14_embedding_orphans` in `watchdog.rs`, wired into `run`, alarms via `capture_alarms` when the orphan count exceeds a threshold. Backstop for the reaper itself being down.

**Config** — a shared `[reaper]` section (`interval_secs`, `batch_size`, `orphan_stale_secs`, `alarm_threshold`) read by both the brain and the watchdog.

Design rationale (anti-join over an embedding queue; retry-forever over dead-lettering) is in `docs/superpowers/specs/2026-05-18-embedding-orphan-reaper-design.md`.

## Test plan

- [x] `test_embed_reaper_tick_reembeds_only_old_orphans` — staleness + anti-join filtering
- [x] `test_embed_reaper_tick_survives_single_embed_failure` — a mid-sweep failure does not abort the batch
- [x] `i14_embedding_orphans_alarms_over_threshold` / `..._silent_when_shadow_table_absent`
- [x] `ReaperConfig` defaults + override parsing
- [x] Full suites: Rust 141 + 240 + others (0 failed), `clippy`/`fmt` clean; Python 884 passed, `ruff` clean

## Config / security impact

A new `[reaper]` config section (defaults apply if absent). No schema migration, no secrets, no shell-startup changes.