### PR TITLE
docs: correct hippo skill docs against current schema and runtime

### DIFF
--- a/extension/claude-skill/monitoring-hippo/SKILL.md
+++ b/extension/claude-skill/monitoring-hippo/SKILL.md
@@ -7,6 +7,24 @@ description: Use when user asks if hippo is working, running, healthy, or needs 
 
 Use this skill when the user asks if Hippo is working, running, healthy, or needs debugging.
 
+Hippo installs a `hippo` binary on PATH (`~/.local/bin/hippo`) and runs as
+launchd services (`com.hippo.*`). The `hippo` and `curl`/`sqlite3`/`launchctl`
+commands below work from any directory. The `mise run …` commands require the
+hippo checkout (`cd ~/projects/hippo` first).
+
+## Start Here: `hippo doctor`
+
+The canonical health check. Runs diagnostic checks across the daemon, brain,
+inference server, and per-source data freshness in one shot:
+
+```bash
+hippo doctor      # full diagnostics — start here
+hippo status      # daemon status only (faster)
+```
+
+If `doctor` is green, you're done. Use the deeper checks below only to chase a
+specific failure it reports.
+
 ## Quick Health Check
 
 Run these commands to verify everything is operational:
@@ -52,9 +70,19 @@ tail -20 ~/.local/share/hippo/daemon.stderr.log
 
 ## Database Status
 
-### Check enrichment queue
+There is one enrichment queue **per source**, each with a `status` column
+(`pending` / `processing` / `done` / `failed` / `skipped`):
+`enrichment_queue` (shell), `claude_enrichment_queue`,
+`browser_enrichment_queue`, `workflow_enrichment_queue`,
+`agentic_enrichment_queue` (Codex / opencode).
+
+### Check enrichment queue depth (all sources)
 ```bash
-sqlite3 ~/.local/share/hippo/hippo.db "SELECT status, COUNT(*) FROM claude_segments GROUP BY status;"
+for q in enrichment_queue claude_enrichment_queue browser_enrichment_queue \
+         workflow_enrichment_queue agentic_enrichment_queue; do
+  echo "== $q =="
+  sqlite3 ~/.local/share/hippo/hippo.db "SELECT status, COUNT(*) FROM $q GROUP BY status;"
+done
 ```
 
 ### Check knowledge nodes count
@@ -62,19 +90,40 @@ sqlite3 ~/.local/share/hippo/hippo.db "SELECT status, COUNT(*) FROM claude_segme
 sqlite3 ~/.local/share/hippo/hippo.db "SELECT COUNT(*) FROM knowledge_nodes;"
 ```
 
-### Check pending segments
+### Inspect failed enrichment (with error messages)
 ```bash
-sqlite3 ~/.local/share/hippo/hippo.db "SELECT id, source_type, LENGTH(content) as len FROM claude_segments WHERE status = 'pending' ORDER BY id DESC LIMIT 10;"
+sqlite3 ~/.local/share/hippo/hippo.db "SELECT id, retry_count, error_message FROM claude_enrichment_queue WHERE status = 'failed' ORDER BY updated_at DESC LIMIT 10;"
+```
+
+## Service Management (launchd)
+
+Hippo runs as launchd agents under `gui/$(id -u)`: `com.hippo.daemon`,
+`com.hippo.brain`, `com.hippo.omlx`, plus `watchdog`, `probe`,
+`claude-session-watcher`, `gh-poll`, `opencode-poll`, `codex-session`.
+
+```bash
+launchctl list | grep com.hippo                       # which services are loaded
+launchctl kickstart -k "gui/$(id -u)/com.hippo.brain" # restart one service (from anywhere)
+```
+
+From the hippo checkout (`cd ~/projects/hippo`):
+```bash
+mise run start     # bootstrap all services
+mise run stop      # bootout all services
+mise run restart   # stop + start all services
+mise run monitor   # live enrichment pipeline view (refreshes every 5s)
+mise run nuke      # SIGKILL everything + remove socket (hard reset; data preserved)
 ```
 
 ## Common Issues
 
 | Symptom | Check | Fix |
 |---------|-------|-----|
-| "brain not reachable" in daemon logs | Brain running on port 9175? | `mise run run:brain` |
-| No enrichment happening | Check `brain.stderr.log` for errors | Restart brain |
-| Inference server not responding | Check `http://localhost:8000/v1/models` (or `:1234` for LM Studio) | Start the server, load a model |
-| Socket not found | Daemon running? | `mise run run:daemon` |
+| "brain not reachable" in daemon logs | Brain on port 9175? `curl localhost:9175/health` | `launchctl kickstart -k "gui/$(id -u)/com.hippo.brain"` |
+| No enrichment happening | `brain.stderr.log` for errors; queue depth growing? | Restart brain (kickstart), then `hippo doctor` |
+| Inference server not responding | `curl http://localhost:8000/v1/models` (`:1234` for LM Studio) | `launchctl kickstart -k "gui/$(id -u)/com.hippo.omlx"`, ensure a model is loaded |
+| Socket not found | Daemon loaded? `launchctl list \| grep daemon` | `launchctl kickstart -k "gui/$(id -u)/com.hippo.daemon"` |
+| Multiple things wedged | — | `cd ~/projects/hippo && mise run restart` (or `mise run nuke` then `mise run start`) |
 
 ## OTEL Stack Monitoring
 
@@ -162,9 +211,10 @@ mise run otel:up
 
 Run these to confirm hippo is fully operational:
 
-1. Daemon: `cargo run --bin hippo -- status`
-2. Brain health: `curl -s http://localhost:9175/health`
-3. Inference server: `curl -s http://localhost:8000/v1/models | jq '.data[].id'`  (`:1234` for LM Studio)
-4. Recent enrichment: `tail -10 ~/.local/share/hippo/brain.stderr.log | grep enriched`
-5. OTEL collector: `curl -s http://localhost:13133/`
-6. Grafana: `curl -s -u admin:hippo 'http://localhost:3030/api/search' | jq '.[] | .title'`
+1. Everything at once: `hippo doctor`
+2. Daemon: `hippo status`
+3. Brain health: `curl -s http://localhost:9175/health`
+4. Inference server: `curl -s http://localhost:8000/v1/models | jq '.data[].id'`  (`:1234` for LM Studio)
+5. Recent enrichment: `tail -10 ~/.local/share/hippo/brain.stderr.log | grep enriched`
+6. OTEL collector: `curl -s http://localhost:13133/`
+7. Grafana: `curl -s -u admin:hippo 'http://localhost:3030/api/search' | jq '.[] | .title'`

--- a/extension/claude-skill/using-hippo-brain/SKILL.md
+++ b/extension/claude-skill/using-hippo-brain/SKILL.md
@@ -34,13 +34,42 @@ a fix — don't bury it. If CI passed, no need to mention unless asked.
 
 ## Tool selection
 
-- `get_ci_status(repo, sha)` — structured CI outcome. Use for "did it pass."
-- `get_lessons(repo?, path?, tool?)` — distilled past mistakes. Use pre-flight.
-- `search_knowledge(query)` — semantic retrieval over knowledge nodes.
-- `search_events(query)` — raw event timeline.
-- `ask(question)` — synthesized prose answer. Use for human-shaped questions.
-- `get_entities(...)` — graph exploration.
+Retrieval, cheapest/most-structured first:
 
-Prefer the structured tools over `ask` when you know what shape you
-want — they are cheaper and machine-friendly. `ask` runs a full RAG
-pipeline and returns prose.
+- `search_hybrid(query, mode=hybrid|semantic|lexical|recent)` — ranked hits
+  as structured dicts (uuid, score, summary, outcome, cwd, branch, …), no
+  synthesis. The default general-purpose retriever.
+- `search_knowledge(query, mode=semantic|lexical)` — enriched knowledge
+  nodes only. Use when you specifically want distilled knowledge, not raw events.
+- `search_events(query, source=shell|claude|browser|all)` — raw event
+  timeline (shell commands, sessions, browser history).
+- `get_context(query)` — hybrid retrieval rendered as a Markdown block ready
+  to paste into a prompt. Use when you want context *for the model*, not a list.
+- `ask(question)` — synthesized prose answer (full RAG pipeline). The most
+  expensive option; use only for human-shaped questions where prose is wanted.
+
+Targeted lookups:
+
+- `get_ci_status(repo, sha=…|branch=…)` — structured CI outcome. Use for "did it pass."
+- `get_lessons(repo?, path?, tool?)` — distilled past mistakes. Use pre-flight.
+  Only patterns seen 2+ times graduate — a single failure won't appear.
+- `get_entities(type?, query?)` — knowledge-graph entities (project, tool,
+  file, domain, concept, service).
+- `list_projects()` — distinct projects seen. Use for discovery before scoping.
+
+Prefer the structured retrievers (`search_hybrid` / `search_knowledge`) over
+`ask` when you know what shape you want — they are cheaper and machine-friendly.
+
+## Scope every query
+
+All retrieval tools (`search_hybrid`, `search_knowledge`, `search_events`,
+`get_context`, `ask`) share these filters — using them is the biggest
+precision win:
+
+- `project=<repo-or-cwd-substring>` — restrict to the repo you're in.
+- `since="24h"` / `"7d"` / `"30m"` — bound the time window.
+- `source="shell"|"claude"|"browser"|"workflow"` — restrict by origin.
+- `branch=<git-branch>` — exact-match the branch.
+
+When working in a specific repo, default to scoping by `project` — an
+unscoped query searches every project you've ever touched.


### PR DESCRIPTION
## Purpose

Veracity pass over the two Claude Code skills in `extension/claude-skill/`, checked against the current MCP tool schemas, `crates/hippo-core/src/schema.sql`, `mise.toml`, and the installed runtime. Found one incomplete skill and one with stale facts.

## `using-hippo-brain` (was incomplete)

- Documented 3 MCP tools that were missing entirely: `search_hybrid` (the default hybrid retriever), `get_context` (paste-ready Markdown block), `list_projects` (discovery).
- Added a "scope every query" section covering the shared `project` / `since` / `source` / `branch` / `mode` filters — the biggest precision win for repo-scoped use.
- Noted `get_ci_status` accepts `branch` (not only `sha`) and that `get_lessons` only graduates patterns seen 2+ times.

## `monitoring-hippo` (was stale)

- **Fixed broken DB queries**: `claude_segments` is not a real table. Switched to the per-source `*_enrichment_queue` tables (`enrichment_queue`, `claude_enrichment_queue`, `browser_enrichment_queue`, `workflow_enrichment_queue`, `agentic_enrichment_queue`).
- **Lead with `hippo doctor`** — the canonical diagnostics command (incl. per-source freshness), plus `hippo status`. Both ship on PATH (`~/.local/bin/hippo`) and work from any directory.
- **Corrected the service model**: hippo runs as launchd agents (`com.hippo.*`). Replaced the foreground `mise run run:brain` / `run:daemon` fixes with `launchctl kickstart` and `mise run start/stop/restart/nuke`.
- Verified-correct and left untouched: ports (9175 / 8000 / 1234), OTEL (3030 admin/hippo, 13133, 4317, 9090), socket/db/log paths.

## Config/security impact

Docs only. No code, no secrets. Shell snippets are illustrative.