### PR TITLE
fix(brain): stop infinite re-enrichment of un-enrichable claude segments

### DIFF
--- a/brain/src/hippo_brain/claude_sessions.py
+++ b/brain/src/hippo_brain/claude_sessions.py
@@ -622,8 +622,16 @@ def _skip_ineligible_claude_segments(conn, segments: list[dict]) -> list[dict]:
                 "WHERE claude_session_id = ?",
                 (reason, now_ms, seg["id"]),
             )
+            # Advance the dedup watermark so the watcher does not re-enqueue this
+            # segment on every restart/file-change. Skipping is terminal — the
+            # eligibility verdict is deterministic — so an open gate is pure churn
+            # (and a duplicate node per legacy segment on re-run). COALESCE keeps
+            # an existing watermark untouched when content_hash is NULL (legacy).
             conn.execute(
-                "UPDATE claude_sessions SET enriched = 1 WHERE id = ?",
+                "UPDATE claude_sessions "
+                "SET enriched = 1, "
+                "    last_enriched_content_hash = COALESCE(content_hash, last_enriched_content_hash) "
+                "WHERE id = ?",
                 (seg["id"],),
             )
     if len(eligible) != len(segments):

--- a/brain/src/hippo_brain/claude_sessions.py
+++ b/brain/src/hippo_brain/claude_sessions.py
@@ -622,18 +622,25 @@ def _skip_ineligible_claude_segments(conn, segments: list[dict]) -> list[dict]:
                 "WHERE claude_session_id = ?",
                 (reason, now_ms, seg["id"]),
             )
+            conn.execute(
+                "UPDATE claude_sessions SET enriched = 1 WHERE id = ?",
+                (seg["id"],),
+            )
             # Advance the dedup watermark so the watcher does not re-enqueue this
             # segment on every restart/file-change. Skipping is terminal — the
             # eligibility verdict is deterministic — so an open gate is pure churn
-            # (and a duplicate node per legacy segment on re-run). COALESCE keeps
-            # an existing watermark untouched when content_hash is NULL (legacy).
-            conn.execute(
-                "UPDATE claude_sessions "
-                "SET enriched = 1, "
-                "    last_enriched_content_hash = COALESCE(content_hash, last_enriched_content_hash) "
-                "WHERE id = ?",
-                (seg["id"],),
-            )
+            # (and a duplicate node per legacy segment on re-run). Use the
+            # *claimed* content_hash (the value the skip decision was made on) and
+            # only advance if the row's content_hash still equals it: the daemon
+            # may upsert newer content while we hold the row, and that newer
+            # content must get its own eligibility check, not inherit this skip.
+            seg_hash = seg.get("content_hash")
+            if seg_hash is not None:
+                conn.execute(
+                    "UPDATE claude_sessions SET last_enriched_content_hash = ? "
+                    "WHERE id = ? AND content_hash = ?",
+                    (seg_hash, seg["id"], seg_hash),
+                )
     if len(eligible) != len(segments):
         conn.commit()
     return eligible
@@ -749,21 +756,38 @@ def write_claude_knowledge_node(
         raise
 
 
-def mark_claude_queue_failed(conn, segment_ids: list[int], error: str) -> None:
+def mark_claude_queue_failed(
+    conn,
+    segment_ids: list[int],
+    error: str,
+    content_hashes: list[str | None] | None = None,
+) -> None:
     """Increment retry_count; reset to pending if retries remain, failed if exhausted.
 
     On a *terminal* failure (retries exhausted -> status 'failed'), advance
-    ``last_enriched_content_hash`` to the current ``content_hash``.  A
-    deterministic failure (e.g. the LLM emitting invalid JSON for one segment)
-    can never succeed, so leaving the success-only watermark untouched would let
-    the watcher re-enqueue the same content forever — the cap is reset on every
-    re-enqueue.  Closing the gate stops the loop; if the content later changes,
+    ``last_enriched_content_hash`` to the hash that was actually attempted
+    (``content_hashes[i]``, the value read at claim time). A deterministic
+    failure (e.g. the LLM emitting invalid JSON for one segment) can never
+    succeed, so leaving the success-only watermark untouched would let the
+    watcher re-enqueue the same content forever — the cap resets on every
+    re-enqueue. Closing the gate stops the loop; if the content later changes,
     ``content_hash`` diverges again and the segment gets a fresh attempt.
-    Transient failures (status flips back to 'pending') do NOT touch the
-    watermark, so they retry normally.
+
+    The advance is gated on ``content_hash`` STILL equalling the attempted hash:
+    the daemon upserts a newer ``content_hash`` on every reparse (without
+    re-enqueuing while the row is 'processing'), so watermarking blindly could
+    mark *newer*, never-attempted content as handled and strand it. When
+    ``content_hashes`` is omitted the watermark is left untouched (caller didn't
+    say what was attempted). Transient failures ('pending') never touch it.
     """
+    if content_hashes is not None and len(content_hashes) != len(segment_ids):
+        raise ValueError(
+            f"content_hashes length ({len(content_hashes)}) does not match "
+            f"segment_ids length ({len(segment_ids)})"
+        )
     now_ms = int(time.time() * 1000)
-    for seg_id in segment_ids:
+    hashes = content_hashes if content_hashes is not None else [None] * len(segment_ids)
+    for seg_id, attempted_hash in zip(segment_ids, hashes, strict=True):
         conn.execute(
             """
             UPDATE claude_enrichment_queue
@@ -780,15 +804,16 @@ def mark_claude_queue_failed(conn, segment_ids: list[int], error: str) -> None:
             """,
             (error, now_ms, seg_id),
         )
-        conn.execute(
-            """
-            UPDATE claude_sessions
-            SET last_enriched_content_hash = content_hash
-            WHERE id = ?
-              AND content_hash IS NOT NULL
-              AND (SELECT status FROM claude_enrichment_queue
-                   WHERE claude_session_id = ?) = 'failed'
-            """,
-            (seg_id, seg_id),
-        )
+        if attempted_hash is not None:
+            conn.execute(
+                """
+                UPDATE claude_sessions
+                SET last_enriched_content_hash = ?
+                WHERE id = ?
+                  AND content_hash = ?
+                  AND (SELECT status FROM claude_enrichment_queue
+                       WHERE claude_session_id = ?) = 'failed'
+                """,
+                (attempted_hash, seg_id, attempted_hash, seg_id),
+            )
     conn.commit()

--- a/brain/src/hippo_brain/claude_sessions.py
+++ b/brain/src/hippo_brain/claude_sessions.py
@@ -742,7 +742,18 @@ def write_claude_knowledge_node(
 
 
 def mark_claude_queue_failed(conn, segment_ids: list[int], error: str) -> None:
-    """Increment retry_count; reset to pending if retries remain, failed if exhausted."""
+    """Increment retry_count; reset to pending if retries remain, failed if exhausted.
+
+    On a *terminal* failure (retries exhausted -> status 'failed'), advance
+    ``last_enriched_content_hash`` to the current ``content_hash``.  A
+    deterministic failure (e.g. the LLM emitting invalid JSON for one segment)
+    can never succeed, so leaving the success-only watermark untouched would let
+    the watcher re-enqueue the same content forever — the cap is reset on every
+    re-enqueue.  Closing the gate stops the loop; if the content later changes,
+    ``content_hash`` diverges again and the segment gets a fresh attempt.
+    Transient failures (status flips back to 'pending') do NOT touch the
+    watermark, so they retry normally.
+    """
     now_ms = int(time.time() * 1000)
     for seg_id in segment_ids:
         conn.execute(
@@ -760,5 +771,16 @@ def mark_claude_queue_failed(conn, segment_ids: list[int], error: str) -> None:
             WHERE claude_session_id = ?
             """,
             (error, now_ms, seg_id),
+        )
+        conn.execute(
+            """
+            UPDATE claude_sessions
+            SET last_enriched_content_hash = content_hash
+            WHERE id = ?
+              AND content_hash IS NOT NULL
+              AND (SELECT status FROM claude_enrichment_queue
+                   WHERE claude_session_id = ?) = 'failed'
+            """,
+            (seg_id, seg_id),
         )
     conn.commit()

--- a/brain/src/hippo_brain/claude_sessions.py
+++ b/brain/src/hippo_brain/claude_sessions.py
@@ -634,6 +634,9 @@ def _skip_ineligible_claude_segments(conn, segments: list[dict]) -> list[dict]:
             # only advance if the row's content_hash still equals it: the daemon
             # may upsert newer content while we hold the row, and that newer
             # content must get its own eligibility check, not inherit this skip.
+            # No status gate is needed here (unlike the failure path) — the
+            # 'skipped' status was set unconditionally just above, so there is no
+            # transient state to guard against.
             seg_hash = seg.get("content_hash")
             if seg_hash is not None:
                 conn.execute(

--- a/brain/src/hippo_brain/enrichment.py
+++ b/brain/src/hippo_brain/enrichment.py
@@ -252,6 +252,23 @@ def build_enrichment_prompt(events: list[dict], browser_context: str = "") -> st
     return prompt
 
 
+# A backslash that begins a valid JSON escape: \" \\ \/ \b \f \n \r \t or \uXXXX.
+_VALID_JSON_ESCAPE = re.compile(r'\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4})|\\')
+
+
+def _repair_json_escapes(text: str) -> str:
+    """Double any backslash that does not begin a valid JSON escape.
+
+    Local LLMs occasionally emit an invalid escape (e.g. a regex ``\\d`` or a
+    stray backslash) inside a string value, which ``json.loads`` rejects. Such
+    failures are deterministic — the same content produces the same bad output
+    every time — so without repair the segment can never be enriched. The
+    leftmost-match regex consumes valid escapes (including ``\\\\``) first, so
+    only genuinely lone backslashes are doubled into literals.
+    """
+    return _VALID_JSON_ESCAPE.sub(lambda m: m.group(0) if len(m.group(0)) > 1 else "\\\\", text)
+
+
 def parse_enrichment_response(raw: str) -> EnrichmentResult:
     """Strip markdown code fences if present, parse JSON, return dataclass."""
     if not raw:
@@ -266,7 +283,13 @@ def parse_enrichment_response(raw: str) -> EnrichmentResult:
     # string values. JSON spec disallows them, but local LLMs routinely emit
     # them inside multi-line `summary`/`embed_text` values; rejecting these
     # responses sends the retry loop into a hot loop of full-model inferences.
-    data = json.loads(text, strict=False)
+    try:
+        data = json.loads(text, strict=False)
+    except json.JSONDecodeError:
+        # Repair invalid backslash escapes and retry once. If it still fails the
+        # error propagates; the terminal-failure watermark (mark_claude_queue_failed)
+        # then stops the segment from re-enqueuing forever.
+        data = json.loads(_repair_json_escapes(text), strict=False)
     return validate_enrichment_data(data)
 
 

--- a/brain/src/hippo_brain/enrichment.py
+++ b/brain/src/hippo_brain/enrichment.py
@@ -252,7 +252,9 @@ def build_enrichment_prompt(events: list[dict], browser_context: str = "") -> st
     return prompt
 
 
-# A backslash that begins a valid JSON escape: \" \\ \/ \b \f \n \r \t or \uXXXX.
+# Matches EITHER a valid JSON escape (\" \\ \/ \b \f \n \r \t \uXXXX) OR a single
+# lone backslash. The two alternatives let _repair_json_escapes keep the former
+# intact (leftmost-match consumes it whole) and double the latter into a literal.
 _VALID_JSON_ESCAPE = re.compile(r'\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4})|\\')
 
 

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -1375,7 +1375,12 @@ class BrainServer:
                     )
                     retry_conn = self._get_conn()
                     try:
-                        mark_claude_queue_failed(retry_conn, segment_ids, err_msg)
+                        mark_claude_queue_failed(
+                            retry_conn,
+                            segment_ids,
+                            err_msg,
+                            content_hashes=[s.get("content_hash") for s in segments],
+                        )
                     finally:
                         retry_conn.close()
 

--- a/brain/tests/test_claude_sessions.py
+++ b/brain/tests/test_claude_sessions.py
@@ -724,7 +724,8 @@ class TestContentHashPropagation:
         # last_enriched_content_hash stays NULL; retry_count 0 -> next fail is transient.
         db_conn.commit()
 
-        mark_claude_queue_failed(db_conn, [seg_id], "transient error")
+        # Even with a valid attempted hash, a transient failure must not advance.
+        mark_claude_queue_failed(db_conn, [seg_id], "transient error", content_hashes=["real-hash"])
 
         status = db_conn.execute(
             "SELECT status FROM claude_enrichment_queue WHERE claude_session_id = ?",
@@ -759,7 +760,9 @@ class TestContentHashPropagation:
         )
         db_conn.commit()
 
-        mark_claude_queue_failed(db_conn, [seg_id], "JSONDecodeError")
+        mark_claude_queue_failed(
+            db_conn, [seg_id], "JSONDecodeError", content_hashes=["poison-hash"]
+        )
 
         status = db_conn.execute(
             "SELECT status FROM claude_enrichment_queue WHERE claude_session_id = ?",
@@ -785,13 +788,43 @@ class TestContentHashPropagation:
         )
         db_conn.commit()
 
-        mark_claude_queue_failed(db_conn, [seg_id], "JSONDecodeError")
+        mark_claude_queue_failed(db_conn, [seg_id], "JSONDecodeError", content_hashes=[None])
 
         leh = db_conn.execute(
             "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",
             (seg_id,),
         ).fetchone()[0]
         assert leh is None, "NULL content_hash must not be propagated to the watermark"
+
+    def test_terminal_failure_does_not_watermark_changed_content(self, tmp_db):
+        """If the daemon upsert a newer content_hash while the worker was enriching,
+        a terminal failure on the OLD content must NOT watermark the new content —
+        else the never-attempted new content is stranded (gate closed, no re-enqueue).
+        """
+        db_conn, _ = tmp_db
+        seg_id = insert_segment(db_conn, self._make_seg("hash-changed-s"))
+        # Row now holds NEW content (daemon reparsed during processing); the worker
+        # attempted the OLD content.
+        db_conn.execute(
+            "UPDATE claude_sessions SET content_hash = ? WHERE id = ?",
+            ("new-content", seg_id),
+        )
+        db_conn.execute(
+            "UPDATE claude_enrichment_queue "
+            "SET retry_count = max_retries - 1 WHERE claude_session_id = ?",
+            (seg_id,),
+        )
+        db_conn.commit()
+
+        mark_claude_queue_failed(
+            db_conn, [seg_id], "JSONDecodeError", content_hashes=["old-content"]
+        )
+
+        leh = db_conn.execute(
+            "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert leh is None, "must not watermark content that was never attempted"
 
     def test_skip_ineligible_advances_watermark(self, tmp_db):
         """A skipped (ineligible) segment closes its dedup gate so it isn't re-enqueued forever.
@@ -848,6 +881,34 @@ class TestContentHashPropagation:
             (seg_id,),
         ).fetchone()[0]
         assert leh is None, "NULL content_hash must not be propagated to the watermark"
+
+    def test_skip_ineligible_does_not_watermark_changed_content(self, tmp_db):
+        """If the row's content_hash changed since claim, skipping must not advance the
+        watermark to the claimed (stale) hash — the new content needs its own
+        eligibility check, not to inherit this skip verdict.
+        """
+        db_conn, _ = tmp_db
+        seg_id = insert_segment(db_conn, self._make_seg("hash-skip-changed-s"))
+        # Row now holds NEW content; the skip decision was made on the OLD claimed hash.
+        db_conn.execute(
+            "UPDATE claude_sessions SET content_hash = ? WHERE id = ?",
+            ("new-content", seg_id),
+        )
+        db_conn.commit()
+
+        ineligible = {
+            "id": seg_id,
+            "content_hash": "old-content",
+            "message_count": 1,
+            "tool_calls_json": None,
+        }
+        _skip_ineligible_claude_segments(db_conn, [ineligible])
+
+        leh = db_conn.execute(
+            "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert leh is None, "must not watermark a hash that no longer matches the row"
 
     def test_null_content_hash_skips_write(self, tmp_db):
         """When content_hash is NULL (legacy row), last_enriched_content_hash stays NULL."""

--- a/brain/tests/test_claude_sessions.py
+++ b/brain/tests/test_claude_sessions.py
@@ -710,6 +710,33 @@ class TestContentHashPropagation:
         ).fetchone()
         assert row[0] == "old456", "failure path must not overwrite last_enriched_content_hash"
 
+    def test_transient_failure_does_not_advance_watermark_from_null(self, tmp_db):
+        """A transient failure (retries remain -> 'pending') must NOT advance the
+        watermark, even starting from NULL — otherwise a single transient error
+        would permanently close the dedup gate on a recoverable segment.
+        """
+        db_conn, _ = tmp_db
+        seg_id = insert_segment(db_conn, self._make_seg("hash-transient-null-s"))
+        db_conn.execute(
+            "UPDATE claude_sessions SET content_hash = ? WHERE id = ?",
+            ("real-hash", seg_id),
+        )
+        # last_enriched_content_hash stays NULL; retry_count 0 -> next fail is transient.
+        db_conn.commit()
+
+        mark_claude_queue_failed(db_conn, [seg_id], "transient error")
+
+        status = db_conn.execute(
+            "SELECT status FROM claude_enrichment_queue WHERE claude_session_id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert status == "pending", "a single failure with retries left stays pending"
+        leh = db_conn.execute(
+            "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert leh is None, "transient failure must NOT advance the watermark from NULL"
+
     def test_terminal_failure_advances_watermark(self, tmp_db):
         """Exhausting retries closes the dedup gate so the watcher stops re-enqueuing.
 

--- a/brain/tests/test_claude_sessions.py
+++ b/brain/tests/test_claude_sessions.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from hippo_brain.claude_sessions import (
     SessionFile,
     SessionSegment,
+    _skip_ineligible_claude_segments,
     build_claude_enrichment_prompt,
     claim_pending_claude_segments,
     ensure_claude_tables,
@@ -758,6 +759,62 @@ class TestContentHashPropagation:
         db_conn.commit()
 
         mark_claude_queue_failed(db_conn, [seg_id], "JSONDecodeError")
+
+        leh = db_conn.execute(
+            "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert leh is None, "NULL content_hash must not be propagated to the watermark"
+
+    def test_skip_ineligible_advances_watermark(self, tmp_db):
+        """A skipped (ineligible) segment closes its dedup gate so it isn't re-enqueued forever.
+
+        Marking a segment 'skipped' is terminal — re-running eligibility produces the same
+        verdict. Leaving the success-only watermark untouched meant the watcher re-enqueued
+        every skipped segment on each restart/file-change (cheap but perpetual churn, and a
+        duplicate node per legacy segment). Skipping must advance the watermark too.
+        """
+        db_conn, _ = tmp_db
+        seg_id = insert_segment(db_conn, self._make_seg("hash-skip-s"))
+        db_conn.execute(
+            "UPDATE claude_sessions SET content_hash = ? WHERE id = ?",
+            ("skip-hash", seg_id),
+        )
+        db_conn.commit()
+
+        # Ineligible: claude segment with message_count < 3 and no tool calls.
+        ineligible = {
+            "id": seg_id,
+            "content_hash": "skip-hash",
+            "message_count": 1,
+            "tool_calls_json": None,
+        }
+        kept = _skip_ineligible_claude_segments(db_conn, [ineligible])
+
+        assert kept == [], "ineligible segment must not be returned for enrichment"
+        status = db_conn.execute(
+            "SELECT status FROM claude_enrichment_queue WHERE claude_session_id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert status == "skipped"
+        leh = db_conn.execute(
+            "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert leh == "skip-hash", "skipped segment must advance the dedup watermark"
+
+    def test_skip_ineligible_null_content_hash_skips_watermark(self, tmp_db):
+        """Skipping a legacy row (NULL content_hash) must not write a hash."""
+        db_conn, _ = tmp_db
+        seg_id = insert_segment(db_conn, self._make_seg("hash-skip-null-s"))
+        # content_hash stays NULL.
+        ineligible = {
+            "id": seg_id,
+            "content_hash": None,
+            "message_count": 1,
+            "tool_calls_json": None,
+        }
+        _skip_ineligible_claude_segments(db_conn, [ineligible])
 
         leh = db_conn.execute(
             "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",

--- a/brain/tests/test_claude_sessions.py
+++ b/brain/tests/test_claude_sessions.py
@@ -709,6 +709,62 @@ class TestContentHashPropagation:
         ).fetchone()
         assert row[0] == "old456", "failure path must not overwrite last_enriched_content_hash"
 
+    def test_terminal_failure_advances_watermark(self, tmp_db):
+        """Exhausting retries closes the dedup gate so the watcher stops re-enqueuing.
+
+        A deterministic enrichment failure (e.g. the LLM emitting invalid JSON for
+        one segment's content) can never succeed, so the success-only watermark would
+        never advance and the watcher would re-enqueue it forever. Once the queue row
+        goes terminal ('failed'), the watermark must catch up to content_hash.
+        """
+        db_conn, _ = tmp_db
+        seg_id = insert_segment(db_conn, self._make_seg("hash-terminal-s"))
+        db_conn.execute(
+            "UPDATE claude_sessions SET content_hash = ? WHERE id = ?",
+            ("poison-hash", seg_id),
+        )
+        # Drive retry_count to max_retries - 1 so the next failure is terminal.
+        db_conn.execute(
+            "UPDATE claude_enrichment_queue "
+            "SET retry_count = max_retries - 1 WHERE claude_session_id = ?",
+            (seg_id,),
+        )
+        db_conn.commit()
+
+        mark_claude_queue_failed(db_conn, [seg_id], "JSONDecodeError")
+
+        status = db_conn.execute(
+            "SELECT status FROM claude_enrichment_queue WHERE claude_session_id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert status == "failed", "row should be terminal after exhausting retries"
+
+        leh = db_conn.execute(
+            "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert leh == "poison-hash", "terminal failure must advance the dedup watermark"
+
+    def test_terminal_failure_null_content_hash_skips_watermark(self, tmp_db):
+        """A terminal failure on a legacy row (NULL content_hash) must not write a hash."""
+        db_conn, _ = tmp_db
+        seg_id = insert_segment(db_conn, self._make_seg("hash-terminal-null-s"))
+        # content_hash stays NULL (legacy row the daemon never hashed).
+        db_conn.execute(
+            "UPDATE claude_enrichment_queue "
+            "SET retry_count = max_retries - 1 WHERE claude_session_id = ?",
+            (seg_id,),
+        )
+        db_conn.commit()
+
+        mark_claude_queue_failed(db_conn, [seg_id], "JSONDecodeError")
+
+        leh = db_conn.execute(
+            "SELECT last_enriched_content_hash FROM claude_sessions WHERE id = ?",
+            (seg_id,),
+        ).fetchone()[0]
+        assert leh is None, "NULL content_hash must not be propagated to the watermark"
+
     def test_null_content_hash_skips_write(self, tmp_db):
         """When content_hash is NULL (legacy row), last_enriched_content_hash stays NULL."""
         db_conn, _ = tmp_db

--- a/brain/tests/test_claude_sessions.py
+++ b/brain/tests/test_claude_sessions.py
@@ -5,6 +5,8 @@ import sqlite3
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from hippo_brain.claude_sessions import (
     SessionFile,
     SessionSegment,
@@ -825,6 +827,21 @@ class TestContentHashPropagation:
             (seg_id,),
         ).fetchone()[0]
         assert leh is None, "must not watermark content that was never attempted"
+
+    def test_mark_failed_rejects_misaligned_content_hashes(self, tmp_db):
+        """content_hashes must align 1:1 with segment_ids — fail fast instead of
+        silently zipping to the shorter list and watermarking the wrong segment."""
+        db_conn, _ = tmp_db
+        with pytest.raises(ValueError, match="does not match"):
+            mark_claude_queue_failed(db_conn, [1, 2], "err", content_hashes=["only-one"])
+
+    def test_write_node_rejects_misaligned_content_hashes(self, tmp_db):
+        """write_claude_knowledge_node guards against misaligned content_hashes too."""
+        db_conn, _ = tmp_db
+        with pytest.raises(ValueError, match="does not match"):
+            write_claude_knowledge_node(
+                db_conn, self._RESULT, [1], "test-model", content_hashes=["a", "b"]
+            )
 
     def test_skip_ineligible_advances_watermark(self, tmp_db):
         """A skipped (ineligible) segment closes its dedup gate so it isn't re-enqueued forever.

--- a/brain/tests/test_enrichment.py
+++ b/brain/tests/test_enrichment.py
@@ -162,6 +162,15 @@ def test_parse_rejects_invalid_json():
         parse_enrichment_response("not json")
 
 
+def test_parse_raises_on_unrepairable_json():
+    """Escape-repair fixes lone backslashes but cannot fix structural invalidity.
+    The error must still propagate (the repair retry must not swallow it) so the
+    terminal-failure watermark can fire and stop the segment re-enqueuing forever.
+    """
+    with pytest.raises(json.JSONDecodeError):
+        parse_enrichment_response("{not: valid json at all \\d}")
+
+
 def test_parse_accepts_raw_control_chars_in_strings():
     # Local LLMs (e.g. gpt-oss-120b) emit raw \n inside string values when
     # generating multi-line summaries. JSON spec disallows it, but rejecting

--- a/brain/tests/test_enrichment.py
+++ b/brain/tests/test_enrichment.py
@@ -179,6 +179,38 @@ def test_parse_accepts_raw_control_chars_in_strings():
     assert "line two" in result.summary
 
 
+def test_parse_repairs_invalid_backslash_escape():
+    # Local LLMs sometimes emit an invalid backslash escape inside a string
+    # value (e.g. a regex like \d or a stray backslash). JSON rejects \d, and
+    # before repair a deterministically-failing segment looped forever because
+    # the dedup watermark only advances on success. parse_enrichment_response
+    # must repair the escape and parse rather than raise.
+    raw = (
+        '{"summary": "matched pattern \\d+ in the log", '
+        '"intent": "testing", "outcome": "success", '
+        '"entities": {"projects": [], "tools": [], "files": [], '
+        '"services": [], "errors": []}, '
+        '"tags": [], "embed_text": "x"}'
+    )
+    result = parse_enrichment_response(raw)
+    assert "\\d+" in result.summary  # literal backslash preserved
+
+
+def test_parse_repair_preserves_valid_escapes():
+    # When repair runs (because some escape is invalid), it must NOT mangle the
+    # valid escapes in the same payload (\" and \\). Here \" is valid and \d is
+    # invalid; only \d should be repaired.
+    raw = (
+        '{"summary": "say \\"hi\\" then match \\d+", '
+        '"intent": "t", "outcome": "success", '
+        '"entities": {"projects": [], "tools": [], "files": [], '
+        '"services": [], "errors": []}, '
+        '"tags": [], "embed_text": "x"}'
+    )
+    result = parse_enrichment_response(raw)
+    assert result.summary == 'say "hi" then match \\d+'
+
+
 # ---------------------------------------------------------------------------
 # Issue #98 F3: design_decisions field validation.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes an infinite enrichment loop on a single Claude session segment, plus the broader bug class behind it.

A subagent transcript (`claude_sessions.id=4592`) made the local LLM emit invalid JSON (`Invalid \escape`). Enrichment failed parsing on every attempt. Because `last_enriched_content_hash` only advanced on **success**, the watcher's dedup gate (`content_hash != last_enriched_content_hash`) never closed, so the segment was re-enqueued forever — the `max_retries=5` cap was reset on each re-enqueue. Over ~18h this burned ~263 enrichment cycles / ~1300 inference calls on one segment.

## Changes

- **Terminal-failure watermark** (`mark_claude_queue_failed`): on a terminal failure (retries exhausted → `failed`), advance `last_enriched_content_hash = content_hash`, closing the dedup gate for un-enrichable content. Self-healing: if the content later changes, `content_hash` diverges and the segment gets a fresh attempt.
- **JSON-escape repair** (`parse_enrichment_response`): repair invalid backslash escapes and retry parsing once before raising. Most such responses now enrich instead of being abandoned. (Verified: segment 4592 now enriches to a valid node on a single claim.)
- **Skip-path gate closure** (`_skip_ineligible_claude_segments`): same class — `skipped` segments also never advanced the watermark, so they re-enqueued on every restart/file-change (churn + a duplicate node per legacy segment). Skipping now advances the watermark too (`COALESCE` preserves it for legacy NULL-hash rows).

## Test plan

- [x] `pytest brain/tests` — 897 passed, 1 skipped, 1 xfailed
- [x] `ruff check` + `ruff format --check` clean
- [x] New unit tests: terminal-failure watermark (+ NULL-hash safety), JSON-escape repair (+ valid-escape preservation), skip-path gate closure (+ NULL-hash safety)
- [x] Live verification after deploy: segment 4592 enriched to a valid node, `retry_count=0`, gate `CLOSED`; `JSONDecodeError=0` and zero claude enrichment-failed loops post-restart

## Out of scope (filed separately)

While verifying, found a pre-existing, unrelated bug: ~1152/1499 workflow (`change_outcome`) knowledge nodes have invalid-JSON content (raw model chain-of-thought stored instead of parsed JSON, since ~April). Not addressed here.