### PR TITLE
fix(brain): workflow enrichment writes validated JSON + records model

### DIFF
--- a/brain/src/hippo_brain/workflow_enrichment.py
+++ b/brain/src/hippo_brain/workflow_enrichment.py
@@ -9,6 +9,7 @@ For each completed workflow run in the enrichment queue:
 6. For each failing annotation, call lessons.upsert_cluster
 """
 
+import json
 import logging
 import sqlite3
 import time
@@ -16,12 +17,31 @@ import uuid
 from pathlib import Path
 
 from hippo_brain.client import InferenceClient
+from hippo_brain.enrichment import parse_enrichment_response
 from hippo_brain.lessons import ClusterKey, upsert_cluster
 from hippo_brain.watchdog import DEFAULT_LOCK_TIMEOUT_MS
 
 logger = logging.getLogger("hippo_brain")
 
 CORRELATION_WINDOW_MS = 15 * 60 * 1000  # ±15 minutes
+
+WORKFLOW_SYSTEM_PROMPT = """You are a CI/CD activity analyst. You receive a summary of a GitHub Actions workflow run and the developer activity around it.
+
+Produce structured enrichment data capturing what changed, whether it succeeded, and — if it failed — the root cause and a one-line fix suggestion.
+
+Be specific: use actual tool names, rule IDs, file paths, and error messages from the run data. Generic descriptions are unacceptable. If you are unsure of an exact identifier, omit it rather than guess.
+
+Output a JSON object with these fields:
+- summary: Specific description of what the run did and its outcome (include root cause + one-line fix if it failed)
+- intent: The goal of the change under test (e.g., "ci debugging", "feature development", "dependency bump")
+- outcome: One of "success", "partial", "failure", "unknown"
+- key_decisions: List of notable decisions (empty list if none)
+- problems_encountered: List of failures/errors and how they were (or should be) resolved
+- entities: An object with lists of strings: projects, tools, files, services, errors, env_vars
+- tags: Descriptive, specific tags
+- embed_text: A detailed, identifier-dense paragraph optimized for keyword retrieval (tool names, rule IDs, file paths, error strings)
+
+Output ONLY valid JSON, no markdown fences or extra text."""
 
 
 def enrich_one(
@@ -238,31 +258,50 @@ async def enrich_one_async(
             (run_id,),
         ).fetchall()
 
-        # Build prompt and call LLM (async)
+        # Build prompt and call LLM (async). The system prompt demands a JSON
+        # object; parse_enrichment_response validates it (and repairs stray
+        # escapes). Storing the raw reply — as this path used to — let a
+        # reasoning model's chain-of-thought land in `content`, producing
+        # invalid-JSON nodes. On un-parseable output it raises, so no garbage
+        # node is written and the caller marks the run failed.
         prompt = _build_prompt(run, shell_rows, claude_rows, ann_rows)
-        summary = await inference.chat(
+        raw = await inference.chat(
             messages=[
-                {
-                    "role": "user",
-                    "content": prompt,
-                }
+                {"role": "system", "content": WORKFLOW_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
             ],
             model=query_model,
-            max_tokens=300,
+            max_tokens=600,
+        )
+        result = parse_enrichment_response(raw)
+        content = json.dumps(
+            {
+                "summary": result.summary,
+                "intent": result.intent,
+                "outcome": result.outcome,
+                "entities": result.entities,
+                "tags": result.tags,
+                "key_decisions": result.key_decisions,
+                "problems_encountered": result.problems_encountered,
+                "design_decisions": result.design_decisions,
+            }
         )
 
         node_uuid = str(uuid.uuid4())
         title = f"{repo_name}@{head_sha[:7]} — {run['conclusion']}"
-        # Write knowledge node
+        # Write knowledge node. `outcome` column keeps the authoritative GitHub
+        # conclusion; embed_text stays the title (repo@sha) for retrieval.
         cur = conn.execute(
             """INSERT INTO knowledge_nodes
-               (uuid, content, embed_text, node_type, outcome, created_at, updated_at)
-               VALUES (?, ?, ?, 'change_outcome', ?, ?, ?)""",
+               (uuid, content, embed_text, node_type, outcome, enrichment_model,
+                created_at, updated_at)
+               VALUES (?, ?, ?, 'change_outcome', ?, ?, ?, ?)""",
             (
                 node_uuid,
-                summary,
+                content,
                 title,
                 run["conclusion"],
+                query_model,
                 now,
                 now,
             ),

--- a/brain/src/hippo_brain/workflow_enrichment.py
+++ b/brain/src/hippo_brain/workflow_enrichment.py
@@ -151,9 +151,12 @@ async def enrich_one_async(
 
         node_uuid = str(uuid.uuid4())
         # Write knowledge node, mirroring the claude path's columns. The `outcome`
-        # column keeps the authoritative GitHub conclusion; embed_text uses the
-        # LLM's identifier-dense embed_text so workflow nodes are actually
-        # searchable (the old repo@sha title gave the vector store almost no signal).
+        # column intentionally holds the raw GitHub conclusion (success/failure/
+        # cancelled/timed_out/…), which differs from content.outcome (the LLM's
+        # constrained success/partial/failure/unknown vocab) — so e.g. training.py's
+        # `outcome IN ('success','partial')` filter never sees a workflow 'partial'.
+        # embed_text uses the LLM's identifier-dense embed_text so workflow nodes are
+        # actually searchable (the old repo@sha title gave the vector store no signal).
         cur = conn.execute(
             """INSERT INTO knowledge_nodes
                (uuid, content, embed_text, node_type, outcome, tags,

--- a/brain/src/hippo_brain/workflow_enrichment.py
+++ b/brain/src/hippo_brain/workflow_enrichment.py
@@ -17,7 +17,7 @@ import uuid
 from pathlib import Path
 
 from hippo_brain.client import InferenceClient
-from hippo_brain.enrichment import parse_enrichment_response
+from hippo_brain.enrichment import CURRENT_ENRICHMENT_VERSION, parse_enrichment_response
 from hippo_brain.lessons import ClusterKey, upsert_cluster
 from hippo_brain.watchdog import DEFAULT_LOCK_TIMEOUT_MS
 
@@ -44,146 +44,6 @@ Output a JSON object with these fields:
 Output ONLY valid JSON, no markdown fences or extra text."""
 
 
-def enrich_one(
-    db_path: str,
-    run_id: int,
-    inference: InferenceClient,
-    query_model: str,
-    *,
-    path_prefix_segments: int = 2,
-    min_occurrences: int = 2,
-) -> None:
-    """Enrich a single workflow run: create knowledge node + update lessons."""
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    try:
-        run = conn.execute("SELECT * FROM workflow_runs WHERE id = ?", (run_id,)).fetchone()
-        if run is None:
-            return
-
-        now = int(time.time() * 1000)
-        started = run["started_at"] or now
-
-        # Co-temporal shell events: prefer exact SHA match; only fall back to time
-        # window for push-related commands from the same repo.
-        head_sha = run["head_sha"]
-        repo_name = run["repo"]
-
-        shell_rows = conn.execute(
-            """SELECT id, command, git_commit FROM events
-               WHERE git_commit = ?
-                 AND probe_tag IS NULL
-               LIMIT 20""",
-            (head_sha,),
-        ).fetchall()
-
-        if not shell_rows:
-            shell_rows = conn.execute(
-                """SELECT id, command, git_commit FROM events
-                   WHERE timestamp BETWEEN ? AND ?
-                     AND command LIKE '%git push%'
-                     AND (git_repo IS NULL OR git_repo = ?)
-                     AND probe_tag IS NULL
-                   LIMIT 20""",
-                (
-                    started - CORRELATION_WINDOW_MS,
-                    started + CORRELATION_WINDOW_MS,
-                    repo_name,
-                ),
-            ).fetchall()
-
-        # Co-temporal Claude sessions
-        claude_rows = conn.execute(
-            """SELECT id, session_id, summary_text FROM claude_sessions
-               WHERE start_time <= ? AND end_time >= ?
-                 AND probe_tag IS NULL
-               LIMIT 10""",
-            (
-                started + CORRELATION_WINDOW_MS,
-                started - CORRELATION_WINDOW_MS,
-            ),
-        ).fetchall()
-
-        # Top failing annotations (up to 10)
-        ann_rows = conn.execute(
-            """SELECT a.tool, a.rule_id, a.path, a.start_line, a.message
-               FROM workflow_annotations a
-               JOIN workflow_jobs j ON j.id = a.job_id
-               WHERE j.run_id = ? AND a.level = 'failure'
-               ORDER BY a.id LIMIT 10""",
-            (run_id,),
-        ).fetchall()
-
-        # Build and run enrichment prompt
-        prompt = _build_prompt(run, shell_rows, claude_rows, ann_rows)
-        summary = inference.complete(model=query_model, prompt=prompt, max_tokens=300)
-
-        node_uuid = str(uuid.uuid4())
-        title = f"{repo_name}@{head_sha[:7]} — {run['conclusion']}"
-        # Write knowledge node
-        cur = conn.execute(
-            """INSERT INTO knowledge_nodes
-               (uuid, content, embed_text, node_type, outcome, created_at, updated_at)
-               VALUES (?, ?, ?, 'change_outcome', ?, ?, ?)""",
-            (
-                node_uuid,
-                summary,
-                title,
-                run["conclusion"],
-                now,
-                now,
-            ),
-        )
-        node_id = cur.lastrowid
-
-        # Link to workflow run
-        conn.execute(
-            "INSERT INTO knowledge_node_workflow_runs (knowledge_node_id, run_id) VALUES (?,?)",
-            (node_id, run_id),
-        )
-
-        # Link to shell events
-        for s in shell_rows:
-            conn.execute(
-                "INSERT OR IGNORE INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (?,?)",
-                (node_id, s["id"]),
-            )
-
-        # Link to Claude sessions
-        for c in claude_rows:
-            conn.execute(
-                "INSERT OR IGNORE INTO knowledge_node_claude_sessions (knowledge_node_id, claude_session_id) VALUES (?,?)",
-                (node_id, c["id"]),
-            )
-
-        # Mark run enriched + queue done
-        conn.execute("UPDATE workflow_runs SET enriched = 1 WHERE id = ?", (run_id,))
-        conn.execute(
-            "UPDATE workflow_enrichment_queue SET status='done', updated_at=? WHERE run_id=?",
-            (now, run_id),
-        )
-        conn.commit()
-
-        # Lesson clustering for each failing annotation
-        for a in ann_rows:
-            path_prefix = _path_prefix(a["path"], path_prefix_segments)
-            upsert_cluster(
-                db_path,
-                ClusterKey(
-                    repo=repo_name,
-                    tool=a["tool"] or "",
-                    rule_id=a["rule_id"] or "",
-                    path_prefix=path_prefix or "",
-                ),
-                min_occurrences=min_occurrences,
-                summary_fn=lambda k: f"{k.tool}:{k.rule_id} in {k.path_prefix}",
-                now_ms=now,
-            )
-
-    finally:
-        conn.close()
-
-
 async def enrich_one_async(
     db_path: str,
     run_id: int,
@@ -193,7 +53,7 @@ async def enrich_one_async(
     path_prefix_segments: int = 2,
     min_occurrences: int = 2,
 ) -> tuple[int, dict] | None:
-    """Async wrapper around enrich_one for use in the enrichment scheduler.
+    """Enrich a single workflow run into a knowledge node (async; scheduler entry point).
 
     Returns ``(node_id, node_dict)`` for the created knowledge node so the
     caller can schedule embedding, or ``None`` when ``run_id`` does not exist.
@@ -265,13 +125,15 @@ async def enrich_one_async(
         # invalid-JSON nodes. On un-parseable output it raises, so no garbage
         # node is written and the caller marks the run failed.
         prompt = _build_prompt(run, shell_rows, claude_rows, ann_rows)
+        # No max_tokens cap: a full EnrichmentResult JSON object can exceed a
+        # few hundred tokens, and truncation mid-JSON would fail parsing on every
+        # run. Use the client default, like the claude/shell paths.
         raw = await inference.chat(
             messages=[
                 {"role": "system", "content": WORKFLOW_SYSTEM_PROMPT},
                 {"role": "user", "content": prompt},
             ],
             model=query_model,
-            max_tokens=600,
         )
         result = parse_enrichment_response(raw)
         content = json.dumps(
@@ -288,20 +150,23 @@ async def enrich_one_async(
         )
 
         node_uuid = str(uuid.uuid4())
-        title = f"{repo_name}@{head_sha[:7]} — {run['conclusion']}"
-        # Write knowledge node. `outcome` column keeps the authoritative GitHub
-        # conclusion; embed_text stays the title (repo@sha) for retrieval.
+        # Write knowledge node, mirroring the claude path's columns. The `outcome`
+        # column keeps the authoritative GitHub conclusion; embed_text uses the
+        # LLM's identifier-dense embed_text so workflow nodes are actually
+        # searchable (the old repo@sha title gave the vector store almost no signal).
         cur = conn.execute(
             """INSERT INTO knowledge_nodes
-               (uuid, content, embed_text, node_type, outcome, enrichment_model,
-                created_at, updated_at)
-               VALUES (?, ?, ?, 'change_outcome', ?, ?, ?, ?)""",
+               (uuid, content, embed_text, node_type, outcome, tags,
+                enrichment_model, enrichment_version, created_at, updated_at)
+               VALUES (?, ?, ?, 'change_outcome', ?, ?, ?, ?, ?, ?)""",
             (
                 node_uuid,
                 content,
-                title,
+                result.embed_text,
                 run["conclusion"],
+                json.dumps(result.tags),
                 query_model,
+                CURRENT_ENRICHMENT_VERSION,
                 now,
                 now,
             ),
@@ -363,7 +228,7 @@ async def enrich_one_async(
             )
 
         assert node_id is not None  # INSERT always populates lastrowid
-        return node_id, {"id": node_id, "embed_text": title, "commands_raw": ""}
+        return node_id, {"id": node_id, "embed_text": result.embed_text, "commands_raw": ""}
     finally:
         conn.close()
 

--- a/brain/src/hippo_brain/workflow_enrichment.py
+++ b/brain/src/hippo_brain/workflow_enrichment.py
@@ -119,11 +119,11 @@ async def enrich_one_async(
         ).fetchall()
 
         # Build prompt and call LLM (async). The system prompt demands a JSON
-        # object; parse_enrichment_response validates it (and repairs stray
-        # escapes). Storing the raw reply — as this path used to — let a
-        # reasoning model's chain-of-thought land in `content`, producing
-        # invalid-JSON nodes. On un-parseable output it raises, so no garbage
-        # node is written and the caller marks the run failed.
+        # object; parse_enrichment_response strips fences and validates it as
+        # JSON. Storing the raw reply — as this path used to — let a reasoning
+        # model's chain-of-thought land in `content`, producing invalid-JSON
+        # nodes. On un-parseable output it raises, so no garbage node is written
+        # and the caller marks the run failed.
         prompt = _build_prompt(run, shell_rows, claude_rows, ann_rows)
         # No max_tokens cap: a full EnrichmentResult JSON object can exceed a
         # few hundred tokens, and truncation mid-JSON would fail parsing on every

--- a/brain/tests/test_server_extended.py
+++ b/brain/tests/test_server_extended.py
@@ -489,7 +489,14 @@ async def test_workflow_enrichment_schedules_embedding(tmp_db):
 
     server = _make_server(str(db_path), embedding_model="fake-embed")
     server.poll_interval_secs = 0
-    server.client.chat = AsyncMock(return_value="CI run completed successfully")
+    server.client.chat = AsyncMock(
+        return_value=(
+            '{"summary": "CI run completed successfully", "intent": "ci", '
+            '"outcome": "success", "entities": {"projects": [], "tools": [], '
+            '"files": [], "services": [], "errors": []}, "tags": [], '
+            '"embed_text": "ci run org/repo abc123 success"}'
+        )
+    )
 
     embed_calls: list[tuple[int, str]] = []
 

--- a/brain/tests/test_workflow_enrichment.py
+++ b/brain/tests/test_workflow_enrichment.py
@@ -1,6 +1,7 @@
 """Tests for workflow_enrichment.enrich_one."""
 
 import asyncio
+import json
 import sqlite3
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -226,7 +227,7 @@ def test_enrich_one_links_claude_sessions(enrichment_db):
 def test_enrich_one_async_creates_knowledge_node(enrichment_db):
     """enrich_one_async creates knowledge node, links run, marks queue done."""
     fake_lm = MagicMock()
-    fake_lm.chat = AsyncMock(return_value="Async enrichment summary")
+    fake_lm.chat = AsyncMock(return_value=_VALID_WORKFLOW_JSON)
 
     asyncio.run(
         enrich_one_async(enrichment_db, run_id=1, inference=fake_lm, query_model="test-model")
@@ -256,6 +257,71 @@ def test_enrich_one_async_creates_knowledge_node(enrichment_db):
     conn.close()
 
 
+_VALID_WORKFLOW_JSON = json.dumps(
+    {
+        "summary": "CI failed: ruff F401 unused import in brain/x.py",
+        "intent": "ci debugging",
+        "outcome": "failure",
+        "entities": {
+            "projects": ["hippo"],
+            "tools": ["ruff"],
+            "files": ["brain/x.py"],
+            "services": [],
+            "errors": ["F401"],
+        },
+        "tags": ["ci", "ruff"],
+        "embed_text": "ruff F401 brain/x.py unused import workflow failure",
+    }
+)
+
+
+def test_enrich_one_async_stores_valid_json_and_model(enrichment_db):
+    """Workflow nodes must persist validated JSON content and record the model.
+
+    Regression: the path stored the raw LLM string (often a reasoning model's
+    chain-of-thought) directly into content with a blank enrichment_model,
+    producing thousands of invalid-JSON nodes.
+    """
+    fake_lm = MagicMock()
+    fake_lm.chat = AsyncMock(return_value=_VALID_WORKFLOW_JSON)
+
+    asyncio.run(
+        enrich_one_async(enrichment_db, run_id=1, inference=fake_lm, query_model="test-model")
+    )
+
+    conn = sqlite3.connect(enrichment_db)
+    row = conn.execute(
+        "SELECT content, enrichment_model, json_valid(content) FROM knowledge_nodes"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert row[2] == 1, "workflow node content must be valid JSON"
+    assert json.loads(row[0])["summary"].startswith("CI failed")
+    assert row[1] == "test-model", "enrichment_model must be recorded on the node"
+
+
+def test_enrich_one_async_rejects_non_json_output(enrichment_db):
+    """A reasoning model emitting chain-of-thought must NOT create a garbage node.
+
+    Better to fail the enrichment (so it can retry / go terminal) than to persist
+    an invalid-JSON node that breaks RAG/search.
+    """
+    fake_lm = MagicMock()
+    fake_lm.chat = AsyncMock(
+        return_value="Here's a thinking process:\n1. Analyze the run. The branch is main..."
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        asyncio.run(
+            enrich_one_async(enrichment_db, run_id=1, inference=fake_lm, query_model="test-model")
+        )
+
+    conn = sqlite3.connect(enrichment_db)
+    n = conn.execute("SELECT COUNT(*) FROM knowledge_nodes").fetchone()[0]
+    conn.close()
+    assert n == 0, "no node should be written when model output isn't valid JSON"
+
+
 def test_enrich_one_async_links_claude_sessions(enrichment_db):
     """enrich_one_async links co-temporal Claude sessions."""
     conn = sqlite3.connect(enrichment_db)
@@ -270,7 +336,7 @@ def test_enrich_one_async_links_claude_sessions(enrichment_db):
     conn.close()
 
     fake_lm = MagicMock()
-    fake_lm.chat = AsyncMock(return_value="Summary")
+    fake_lm.chat = AsyncMock(return_value=_VALID_WORKFLOW_JSON)
 
     asyncio.run(
         enrich_one_async(enrichment_db, run_id=1, inference=fake_lm, query_model="test-model")
@@ -302,7 +368,7 @@ def test_enrich_one_async_survives_clustering_failure(enrichment_db):
     error (which would mark it failed, re-enrich, and duplicate the node).
     """
     fake_lm = MagicMock()
-    fake_lm.chat = AsyncMock(return_value="Async enrichment summary")
+    fake_lm.chat = AsyncMock(return_value=_VALID_WORKFLOW_JSON)
 
     with patch(
         "hippo_brain.workflow_enrichment.upsert_cluster",

--- a/brain/tests/test_workflow_enrichment.py
+++ b/brain/tests/test_workflow_enrichment.py
@@ -261,6 +261,31 @@ def test_enrich_one_async_rejects_non_json_output(enrichment_db):
     assert n == 0, "no node should be written when model output isn't valid JSON"
 
 
+def test_enrich_one_async_rejects_invalid_field(enrichment_db):
+    """Valid JSON but a bad field (out-of-vocab outcome) must also fail the run via
+    validate_enrichment_data — not write a node. Covers the ValueError branch, the
+    most common local-LLM failure after raw chain-of-thought.
+    """
+    fake_lm = MagicMock()
+    fake_lm.chat = AsyncMock(
+        return_value=(
+            '{"summary": "ran", "intent": "ci", "outcome": "flaky", '
+            '"entities": {"projects": [], "tools": [], "files": [], '
+            '"services": [], "errors": []}, "tags": [], "embed_text": "x"}'
+        )
+    )
+
+    with pytest.raises(ValueError):
+        asyncio.run(
+            enrich_one_async(enrichment_db, run_id=1, inference=fake_lm, query_model="test-model")
+        )
+
+    conn = sqlite3.connect(enrichment_db)
+    n = conn.execute("SELECT COUNT(*) FROM knowledge_nodes").fetchone()[0]
+    conn.close()
+    assert n == 0, "no node should be written when validation fails"
+
+
 def test_enrich_one_async_links_claude_sessions(enrichment_db):
     """enrich_one_async links co-temporal Claude sessions."""
     conn = sqlite3.connect(enrichment_db)

--- a/brain/tests/test_workflow_enrichment.py
+++ b/brain/tests/test_workflow_enrichment.py
@@ -1,4 +1,4 @@
-"""Tests for workflow_enrichment.enrich_one."""
+"""Tests for workflow_enrichment.enrich_one_async."""
 
 import asyncio
 import json
@@ -8,9 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from hippo_brain.enrichment import CURRENT_ENRICHMENT_VERSION
 from hippo_brain.workflow_enrichment import (
     _path_prefix,
-    enrich_one,
     enrich_one_async,
     mark_workflow_queue_failed,
 )
@@ -149,76 +149,6 @@ def enrichment_db(tmp_path: Path) -> str:
     return str(db)
 
 
-def test_enrich_one_creates_knowledge_node(enrichment_db):
-    fake_lm = MagicMock()
-    fake_lm.complete.return_value = "Push failed due to ruff F401 unused import in brain/x.py"
-
-    enrich_one(enrichment_db, run_id=1, inference=fake_lm, query_model="test-model")
-
-    conn = sqlite3.connect(enrichment_db)
-    # Knowledge node created
-    node = conn.execute(
-        "SELECT node_type, embed_text, content, outcome FROM knowledge_nodes"
-    ).fetchone()
-    assert node is not None
-    assert node[0] == "change_outcome"
-    assert "abc123" in node[1]  # SHA in embed_text (title)
-    assert "ruff" in node[2].lower() or "F401" in node[2]  # LLM summary in content
-
-    # Linked to workflow run
-    link = conn.execute("SELECT * FROM knowledge_node_workflow_runs").fetchone()
-    assert link is not None
-
-    # Linked to shell event
-    event_link = conn.execute("SELECT * FROM knowledge_node_events").fetchone()
-    assert event_link is not None
-
-    # Queue marked done
-    q = conn.execute("SELECT status FROM workflow_enrichment_queue WHERE run_id=1").fetchone()
-    assert q[0] == "done"
-
-    # Run marked enriched
-    r = conn.execute("SELECT enriched FROM workflow_runs WHERE id=1").fetchone()
-    assert r[0] == 1
-
-    # Lesson pending created (first occurrence — not promoted yet)
-    pending = conn.execute("SELECT count FROM lesson_pending WHERE tool='ruff'").fetchone()
-    assert pending is not None and pending[0] == 1
-
-    conn.close()
-
-
-def test_enrich_one_skips_missing_run(enrichment_db):
-    fake_lm = MagicMock()
-    enrich_one(enrichment_db, run_id=999, inference=fake_lm, query_model="test-model")
-    fake_lm.complete.assert_not_called()
-
-
-def test_enrich_one_links_claude_sessions(enrichment_db):
-    """enrich_one links co-temporal Claude sessions to the knowledge node (line 106)."""
-    conn = sqlite3.connect(enrichment_db)
-    # start_time=100 <= started+window, end_time=2000 >= started-window → within ±15min
-    conn.execute("""
-        INSERT INTO claude_sessions
-          (id, session_id, project_dir, cwd, segment_index, start_time, end_time,
-           summary_text, message_count, source_file, enriched, created_at)
-        VALUES (200, 'sess-abc', '/hippo', '/hippo', 0, 100, 2000,
-                'Worked on CI fix', 1, 'sess.jsonl', 0, 1000)
-    """)
-    conn.commit()
-    conn.close()
-
-    fake_lm = MagicMock()
-    fake_lm.complete.return_value = "Summary with session context"
-
-    enrich_one(enrichment_db, run_id=1, inference=fake_lm, query_model="test-model")
-
-    conn = sqlite3.connect(enrichment_db)
-    link = conn.execute("SELECT * FROM knowledge_node_claude_sessions").fetchone()
-    assert link is not None
-    conn.close()
-
-
 # ---------------------------------------------------------------------------
 # enrich_one_async tests
 # ---------------------------------------------------------------------------
@@ -237,7 +167,7 @@ def test_enrich_one_async_creates_knowledge_node(enrichment_db):
     node = conn.execute("SELECT node_type, embed_text, content FROM knowledge_nodes").fetchone()
     assert node is not None
     assert node[0] == "change_outcome"
-    assert "abc123" in node[1]  # SHA in embed_text
+    assert "ruff" in node[1]  # LLM embed_text (identifier-dense), not the title
 
     link = conn.execute("SELECT * FROM knowledge_node_workflow_runs").fetchone()
     assert link is not None
@@ -291,13 +221,22 @@ def test_enrich_one_async_stores_valid_json_and_model(enrichment_db):
 
     conn = sqlite3.connect(enrichment_db)
     row = conn.execute(
-        "SELECT content, enrichment_model, json_valid(content) FROM knowledge_nodes"
+        "SELECT content, enrichment_model, json_valid(content), embed_text, tags, "
+        "enrichment_version FROM knowledge_nodes"
     ).fetchone()
     conn.close()
     assert row is not None
     assert row[2] == 1, "workflow node content must be valid JSON"
     assert json.loads(row[0])["summary"].startswith("CI failed")
     assert row[1] == "test-model", "enrichment_model must be recorded on the node"
+    # embed_text is the LLM's identifier-dense field, not the weak repo@sha title.
+    assert row[3] == "ruff F401 brain/x.py unused import workflow failure"
+    # tags column + enrichment_version mirror the claude path (not left NULL/stale).
+    assert json.loads(row[4]) == ["ci", "ruff"]
+    assert row[5] == CURRENT_ENRICHMENT_VERSION
+    # A full EnrichmentResult JSON can't fit in a few hundred tokens — no tiny cap.
+    max_tokens = fake_lm.chat.call_args.kwargs.get("max_tokens")
+    assert max_tokens is None or max_tokens >= 2048
 
 
 def test_enrich_one_async_rejects_non_json_output(enrichment_db):


### PR DESCRIPTION
## Summary

Fixes a pre-existing, ongoing data-quality bug: workflow (`change_outcome`) knowledge nodes stored raw LLM output instead of validated JSON.

`enrich_one_async` wrote the raw `inference.chat(...)` reply straight into `knowledge_nodes.content` with no parse/validate, and omitted `enrichment_model` from the INSERT. A reasoning model's chain-of-thought ("Here's a thinking process: ...") therefore landed verbatim in `content`. Live DB shows **~1152/1499 (77%)** of `change_outcome` nodes have invalid-JSON content (dating to ~April), which breaks `json_extract` in RAG/search.

## Changes

- New `WORKFLOW_SYSTEM_PROMPT` instructs a JSON object (mirrors the claude path's schema).
- `enrich_one_async` now sends `[system, user]` messages and routes the reply through `parse_enrichment_response` (validate + escape-repair), serializing the validated `EnrichmentResult` into `content`.
- On un-parseable output it raises → **no garbage node** is written and the run is marked failed (retryable) instead.
- `enrichment_model` is now recorded on the INSERT. `embed_text` (the `repo@sha` title) and the authoritative `outcome` column are unchanged.

## Test plan

- [x] `pytest brain/tests` — 893 passed, 1 skipped, 1 xfailed
- [x] New tests: stores valid JSON + records model; rejects non-JSON output (no node written)
- [x] Updated existing workflow/server tests whose mocks returned non-JSON
- [x] `ruff check` + `ruff format --check` clean

## Notes / follow-ups (not in this PR)

- **Backfill** of the existing ~1152 invalid nodes is intentionally separate (needs signoff): delete bad nodes (FTS auto-cleans via trigger; `knowledge_vectors` vec0 needs a manual `DELETE` first — no cascade), then reset `workflow_runs.enriched=0` + queue→`pending` to re-enrich.
- **Dead code**: the sync `enrich_one` calls `inference.complete`, which `InferenceClient` does not implement — it's broken/dead and only referenced by tests. Left for separate removal.
- Composes with #176 (escape-repair in `parse_enrichment_response`); no overlapping files.