### PR TITLE
release: hippo 0.26.3 — capture-reliability migration & watchdog fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.26.2"
+version = "0.26.3"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.26.2"
+version = "0.26.3"
 requires-python = ">=3.14"
 dependencies = [
   "httpx>=0.28",

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.26.2"
+version = "0.26.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Patch release rolling up the `source_health` capture-reliability batch that has accumulated on `main` since 0.26.2:

- **#174** — unify the Claude session `source_health` key on `agentic-session-claude` (retire the stale legacy `claude-session` orphan row).
- **#175** — watchdog I-11/I-13 now alarm on first-run coverage failures (`last_event_ts` NULL no longer suppresses).
- **#178** — preserve the full probe/heartbeat column set in the Claude health migration (was dropping `probe_last_run_ts`/`last_heartbeat_ts`/`expected_min_per_hour`); merge probe results as a coherent triple; clamp watchdog `since_ms` under clock skew.

No schema change — `PRAGMA user_version` stays at **v15**; every change is a fix within the existing schema, so this is a patch bump.

Bumps `Cargo.toml`, `Cargo.lock`, `brain/pyproject.toml`, `brain/uv.lock` from 0.26.2 → 0.26.3.

## Test plan
- [x] `cargo check --workspace` clean at new version
- [x] `uv lock` re-resolved (hippo-brain 0.26.2 → 0.26.3, no other changes)
- [x] Lock diffs are version-only