### PR TITLE
otel: per-source visibility for opencode/codex/cursor sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.27.0"
+version = "0.27.1"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.27.0"
+version = "0.27.1"
 requires-python = ">=3.14"
 dependencies = [
   "httpx>=0.28",

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -783,6 +783,7 @@ pub async fn run_with_mode(config: HippoConfig, bench_mode: bool) -> Result<()> 
 
         crate::process_metrics::register();
         crate::health_score::register(state.config.db_path());
+        crate::source_health_metric::register(state.config.db_path());
 
         let state_ref = Arc::clone(&state);
         let _ = meter

--- a/crates/hippo-daemon/src/lib.rs
+++ b/crates/hippo-daemon/src/lib.rs
@@ -19,6 +19,8 @@ pub mod probe;
 pub mod process_metrics;
 pub mod schema_handshake;
 #[cfg(feature = "otel")]
+pub mod source_health_metric;
+#[cfg(feature = "otel")]
 pub mod telemetry;
 pub mod watch_claude_sessions;
 pub mod watchdog;

--- a/crates/hippo-daemon/src/source_health_metric.rs
+++ b/crates/hippo-daemon/src/source_health_metric.rs
@@ -28,26 +28,37 @@
 //!   the dashboard show a per-source canary status without parsing the
 //!   `capture_alarms` table.
 
+use crate::is_missing_source_health_table_error;
 use opentelemetry::KeyValue;
 use opentelemetry::global;
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use std::path::PathBuf;
 use std::time::Duration;
 use tracing::debug;
 
 /// Open the operator DB read-only with the standard `busy_timeout` so the
-/// observer never starves a concurrent writer. Returns `None` on any error so
-/// the gauges fail open (omit the tick) rather than fail loud — a transient
-/// SQLITE_BUSY against the watchdog would otherwise blank the dashboard.
+/// observer never starves a concurrent writer, and never creates a stray
+/// file if the path is missing (the OTel callback runs on its own thread —
+/// fail open, don't pollute the data dir). Returns `None` on any error so
+/// the gauges omit the tick rather than fail loud — a transient SQLITE_BUSY
+/// against the watchdog would otherwise blank the dashboard.
 fn open_conn(db_path: &std::path::Path) -> Option<Connection> {
-    let conn = Connection::open(db_path).ok()?;
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
     conn.busy_timeout(Duration::from_millis(5000)).ok()?;
     Some(conn)
 }
 
-/// One row's worth of derived gauge state. Populated by a single
-/// `SELECT … FROM source_health` so we never read the table more than once
-/// per export tick, no matter how many gauges are registered.
+/// One row's worth of derived gauge state, populated by a single
+/// `SELECT … FROM source_health`. Three observable gauges are registered
+/// from this module and each runs its own callback (the OTel API binds one
+/// callback per instrument), so the table is read up to three times per
+/// export tick. That's accepted on purpose: the query is an indexed scan of
+/// a ~10-row table and the connection is read-only + NO_MUTEX, so the cost
+/// is negligible compared to the complexity of a shared TTL cache.
 struct Row {
     source: String,
     lag_ms: Option<u64>,
@@ -64,6 +75,10 @@ fn read_rows(db_path: &std::path::Path, now_ms: i64) -> Vec<Row> {
            FROM source_health",
     ) {
         Ok(s) => s,
+        // Pre-migration DBs lack `source_health`; this is the expected steady
+        // state until the schema migration runs, so don't log on every tick.
+        // Any other prepare error is genuinely surprising — keep that visible.
+        Err(e) if is_missing_source_health_table_error(&e) => return Vec::new(),
         Err(e) => {
             debug!(error = %e, "source_health_metric: prepare failed");
             return Vec::new();

--- a/crates/hippo-daemon/src/source_health_metric.rs
+++ b/crates/hippo-daemon/src/source_health_metric.rs
@@ -1,0 +1,287 @@
+//! Per-source freshness gauge sourced from the `source_health` table.
+//!
+//! The table is the single SQL ground truth for "did the event land?" per
+//! capture source — every capture path updates its row in the same transaction
+//! as the event insert. This module exposes that ground truth to OTel as
+//! `hippo.daemon.source_health.lag` so dashboards can show one line per source
+//! ("how stale am I, in ms?") without enumerating sources by hand.
+//!
+//! Why this matters: counters like `hippo.daemon.events.ingested` only cover
+//! sources that flow through the Unix socket (shell, browser, claude-tool).
+//! Session pollers (opencode/codex/cursor) write directly to SQLite and never
+//! increment a daemon counter — so their visibility came purely from the
+//! brain's enrichment metrics, which fire *after* inference. This gauge closes
+//! the gap: every source with a `source_health` row gets a freshness line on
+//! every export tick, with no per-source instrumentation in the polling code.
+//!
+//! ## Companion gauges
+//!
+//! Three observable gauges are registered together because they all derive
+//! from the same `source_health` row read:
+//!
+//! - `hippo.daemon.source_health.lag` (ms) — `now - max(last_event_ts,
+//!   last_heartbeat_ts)`. The primary freshness signal.
+//! - `hippo.daemon.source_health.consecutive_failures` (count) — value of the
+//!   `consecutive_failures` column. Spikes when a source's writes start
+//!   erroring; useful as an "alarm leading indicator."
+//! - `hippo.daemon.source_health.probe_ok` (0/1) — last probe verdict. Lets
+//!   the dashboard show a per-source canary status without parsing the
+//!   `capture_alarms` table.
+
+use opentelemetry::KeyValue;
+use opentelemetry::global;
+use rusqlite::Connection;
+use std::path::PathBuf;
+use std::time::Duration;
+use tracing::debug;
+
+/// Open the operator DB read-only with the standard `busy_timeout` so the
+/// observer never starves a concurrent writer. Returns `None` on any error so
+/// the gauges fail open (omit the tick) rather than fail loud — a transient
+/// SQLITE_BUSY against the watchdog would otherwise blank the dashboard.
+fn open_conn(db_path: &std::path::Path) -> Option<Connection> {
+    let conn = Connection::open(db_path).ok()?;
+    conn.busy_timeout(Duration::from_millis(5000)).ok()?;
+    Some(conn)
+}
+
+/// One row's worth of derived gauge state. Populated by a single
+/// `SELECT … FROM source_health` so we never read the table more than once
+/// per export tick, no matter how many gauges are registered.
+struct Row {
+    source: String,
+    lag_ms: Option<u64>,
+    consecutive_failures: u64,
+    probe_ok: Option<u8>,
+}
+
+fn read_rows(db_path: &std::path::Path, now_ms: i64) -> Vec<Row> {
+    let Some(conn) = open_conn(db_path) else {
+        return Vec::new();
+    };
+    let mut stmt = match conn.prepare(
+        "SELECT source, last_event_ts, last_heartbeat_ts, consecutive_failures, probe_ok
+           FROM source_health",
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            debug!(error = %e, "source_health_metric: prepare failed");
+            return Vec::new();
+        }
+    };
+    let rows = stmt.query_map([], |r| {
+        let source: String = r.get(0)?;
+        let last_event_ts: Option<i64> = r.get(1)?;
+        let last_heartbeat_ts: Option<i64> = r.get(2)?;
+        let consecutive_failures: i64 = r.get(3)?;
+        let probe_ok: Option<i64> = r.get(4)?;
+
+        // Freshness is the more-recent of the two liveness signals. A source
+        // with only heartbeats (no events yet — fresh install) still gets a
+        // bounded lag instead of NULL, which would silently drop from the
+        // dashboard.
+        let latest = match (last_event_ts, last_heartbeat_ts) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+        let lag_ms = latest.map(|ts| (now_ms - ts).max(0) as u64);
+
+        Ok(Row {
+            source,
+            lag_ms,
+            consecutive_failures: consecutive_failures.max(0) as u64,
+            probe_ok: probe_ok.map(|n| if n != 0 { 1u8 } else { 0u8 }),
+        })
+    });
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            debug!(error = %e, "source_health_metric: query failed");
+            return Vec::new();
+        }
+    };
+    rows.filter_map(|r| r.ok()).collect()
+}
+
+/// Register the per-source observable gauges. Call once from `daemon::run`
+/// after telemetry init, under `cfg(feature = "otel")`.
+pub fn register(db_path: PathBuf) {
+    let meter = global::meter("hippo-daemon");
+
+    // Build three callbacks that each re-read the table. Cheap (indexed PK,
+    // ~10 rows on a healthy install) and avoids a separate refresh task.
+    let dbp = db_path.clone();
+    let _ = meter
+        .u64_observable_gauge("hippo.daemon.source_health.lag")
+        .with_description(
+            "Per-source freshness: now - max(last_event_ts, last_heartbeat_ts). \
+             A line per source means OTel sees that source as captured.",
+        )
+        .with_unit("ms")
+        .with_callback(move |g| {
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            for row in read_rows(&dbp, now_ms) {
+                if let Some(lag) = row.lag_ms {
+                    g.observe(lag, &[KeyValue::new("source", row.source)]);
+                }
+            }
+        })
+        .build();
+
+    let dbp = db_path.clone();
+    let _ = meter
+        .u64_observable_gauge("hippo.daemon.source_health.consecutive_failures")
+        .with_description("Per-source consecutive_failures counter from source_health.")
+        .with_unit("1")
+        .with_callback(move |g| {
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            for row in read_rows(&dbp, now_ms) {
+                g.observe(
+                    row.consecutive_failures,
+                    &[KeyValue::new("source", row.source)],
+                );
+            }
+        })
+        .build();
+
+    let dbp = db_path;
+    let _ = meter
+        .u64_observable_gauge("hippo.daemon.source_health.probe_ok")
+        .with_description(
+            "Per-source last probe verdict (0 = fail, 1 = ok). \
+             Sources without probe coverage emit nothing.",
+        )
+        .with_unit("1")
+        .with_callback(move |g| {
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            for row in read_rows(&dbp, now_ms) {
+                if let Some(ok) = row.probe_ok {
+                    g.observe(ok.into(), &[KeyValue::new("source", row.source)]);
+                }
+            }
+        })
+        .build();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection as RConn;
+
+    struct FixtureRow {
+        source: &'static str,
+        last_event_ts: Option<i64>,
+        last_heartbeat_ts: Option<i64>,
+        consecutive_failures: i64,
+        probe_ok: Option<i64>,
+    }
+
+    fn fixture(rows: &[FixtureRow]) -> tempfile::NamedTempFile {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let conn = RConn::open(tmp.path()).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE source_health (
+                 source TEXT PRIMARY KEY,
+                 last_event_ts INTEGER,
+                 last_heartbeat_ts INTEGER,
+                 consecutive_failures INTEGER NOT NULL DEFAULT 0,
+                 probe_ok INTEGER
+             );",
+        )
+        .unwrap();
+        for r in rows {
+            conn.execute(
+                "INSERT INTO source_health \
+                 (source, last_event_ts, last_heartbeat_ts, consecutive_failures, probe_ok) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![
+                    r.source,
+                    r.last_event_ts,
+                    r.last_heartbeat_ts,
+                    r.consecutive_failures,
+                    r.probe_ok,
+                ],
+            )
+            .unwrap();
+        }
+        tmp
+    }
+
+    #[test]
+    fn lag_uses_more_recent_of_event_and_heartbeat() {
+        let now = 10_000i64;
+        let db = fixture(&[
+            FixtureRow {
+                source: "shell",
+                last_event_ts: Some(9_000),
+                last_heartbeat_ts: Some(8_000),
+                consecutive_failures: 0,
+                probe_ok: Some(1),
+            },
+            FixtureRow {
+                source: "browser",
+                last_event_ts: Some(7_000),
+                last_heartbeat_ts: Some(9_500),
+                consecutive_failures: 1,
+                probe_ok: Some(1),
+            },
+            FixtureRow {
+                source: "cursor",
+                last_event_ts: None,
+                last_heartbeat_ts: Some(9_900),
+                consecutive_failures: 0,
+                probe_ok: None,
+            },
+        ]);
+        let mut got: Vec<_> = read_rows(db.path(), now)
+            .into_iter()
+            .map(|r| (r.source, r.lag_ms))
+            .collect();
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("browser".into(), Some(500)),
+                ("cursor".into(), Some(100)),
+                ("shell".into(), Some(1_000)),
+            ]
+        );
+    }
+
+    #[test]
+    fn null_event_and_heartbeat_emit_no_lag() {
+        let db = fixture(&[FixtureRow {
+            source: "never-seen",
+            last_event_ts: None,
+            last_heartbeat_ts: None,
+            consecutive_failures: 0,
+            probe_ok: None,
+        }]);
+        let rows = read_rows(db.path(), 1_000);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].lag_ms.is_none());
+    }
+
+    #[test]
+    fn missing_db_yields_empty_rows() {
+        let rows = read_rows(std::path::Path::new("/nonexistent/db"), 0);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn consecutive_failures_and_probe_ok_pass_through() {
+        let db = fixture(&[FixtureRow {
+            source: "codex",
+            last_event_ts: Some(100),
+            last_heartbeat_ts: None,
+            consecutive_failures: 7,
+            probe_ok: Some(0),
+        }]);
+        let rows = read_rows(db.path(), 200);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].consecutive_failures, 7);
+        assert_eq!(rows[0].probe_ok, Some(0));
+    }
+}

--- a/otel/grafana/dashboards/hippo-enrichment.json
+++ b/otel/grafana/dashboards/hippo-enrichment.json
@@ -20,6 +20,7 @@
     {
       "id": 1,
       "title": "Queue Depth by Source & Status",
+      "description": "Auto-aggregated by source label. Any new source the brain emits appears here automatically \u2014 no dashboard edit required.",
       "type": "timeseries",
       "gridPos": {
         "x": 0,
@@ -38,57 +39,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hippo_brain_enrichment_queue_depth{service_namespace!~\".+\",source=\"shell\"}",
-          "legendFormat": "{{source}} \u00b7 {{status}}",
-          "editorMode": "code"
-        },
-        {
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hippo_brain_enrichment_queue_depth{service_namespace!~\".+\",source=\"claude\"}",
-          "legendFormat": "{{source}} \u00b7 {{status}}",
-          "editorMode": "code"
-        },
-        {
-          "refId": "C",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hippo_brain_enrichment_queue_depth{service_namespace!~\".+\",source=\"browser\"}",
-          "legendFormat": "{{source}} \u00b7 {{status}}",
-          "editorMode": "code"
-        },
-        {
-          "refId": "D",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hippo_brain_enrichment_queue_depth{service_namespace!~\".+\",source=\"codex\"}",
-          "legendFormat": "{{source}} \u00b7 {{status}}",
-          "editorMode": "code"
-        },
-        {
-          "refId": "E",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hippo_brain_enrichment_queue_depth{service_namespace!~\".+\",source=\"workflow\"}",
-          "legendFormat": "{{source}} \u00b7 {{status}}",
-          "editorMode": "code"
-        },
-        {
-          "refId": "F",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hippo_brain_enrichment_queue_depth{service_namespace!~\".+\",source=\"opencode\"}",
+          "expr": "sum by (source, status) (hippo_brain_enrichment_queue_depth{service_namespace!~\".+\"})",
           "legendFormat": "{{source}} \u00b7 {{status}}",
           "editorMode": "code"
         }
@@ -171,6 +122,7 @@
     {
       "id": 3,
       "title": "Events Claimed / min",
+      "description": "Auto-aggregated by source label. Any new source the brain emits appears here automatically — no dashboard edit required.",
       "type": "timeseries",
       "gridPos": {
         "x": 12,
@@ -189,58 +141,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hippo_brain_enrichment_events_claimed_total{service_namespace!~\".+\",source=\"shell\"}[5m]) * 60",
-          "legendFormat": "shell",
-          "editorMode": "code"
-        },
-        {
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(hippo_brain_enrichment_events_claimed_total{service_namespace!~\".+\",source=\"claude\"}[5m]) * 60",
-          "legendFormat": "claude",
-          "editorMode": "code"
-        },
-        {
-          "refId": "C",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(hippo_brain_enrichment_events_claimed_total{service_namespace!~\".+\",source=\"browser\"}[5m]) * 60",
-          "legendFormat": "browser",
-          "editorMode": "code"
-        },
-        {
-          "refId": "D",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(hippo_brain_enrichment_events_claimed_total{service_namespace!~\".+\",source=\"codex\"}[5m]) * 60",
-          "legendFormat": "codex",
-          "editorMode": "code"
-        },
-        {
-          "refId": "E",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(hippo_brain_enrichment_events_claimed_total{service_namespace!~\".+\",source=\"workflow\"}[5m]) * 60",
-          "legendFormat": "workflow",
-          "editorMode": "code"
-        },
-        {
-          "refId": "F",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(hippo_brain_enrichment_events_claimed_total{service_namespace!~\".+\",source=\"opencode\"}[5m]) * 60",
-          "legendFormat": "opencode",
+          "expr": "sum by (source) (rate(hippo_brain_enrichment_events_claimed_total{service_namespace!~\".+\"}[5m])) * 60",
+          "legendFormat": "{{source}}",
           "editorMode": "code"
         }
       ],

--- a/otel/grafana/dashboards/hippo-overview.json
+++ b/otel/grafana/dashboards/hippo-overview.json
@@ -574,8 +574,8 @@
     },
     {
       "id": 9,
-      "title": "Watchdog Invariant Violations by Source",
-      "description": "Cumulative count of capture-invariant violations the watchdog has fired, sliced by source. A flat line means that source is healthy; a rising line means an invariant (I-1..I-15) is currently failing for that source. Pair with the Capture Lag panel: rising violations + rising lag = capture is broken for that source right now.",
+      "title": "Watchdog Invariant Violations by Source (per min)",
+      "description": "Per-minute rate (5m average) of capture-invariant violations the watchdog has fired, sliced by source. A line at zero means that source is healthy; any positive value means an invariant (I-1..I-15) is currently failing for that source. Pair with the Capture Lag panel: nonzero violations + rising lag = capture is broken for that source right now.",
       "type": "timeseries",
       "gridPos": {
         "x": 12,

--- a/otel/grafana/dashboards/hippo-overview.json
+++ b/otel/grafana/dashboards/hippo-overview.json
@@ -505,6 +505,121 @@
         "dedupStrategy": "none",
         "sortOrder": "Descending"
       }
+    },
+    {
+      "id": 8,
+      "title": "Capture Lag by Source",
+      "description": "Seconds since each capture source produced any signal of life (event or heartbeat). One line per source means OTel sees that source. Sourced from the source_health table — the same SQL ground truth the watchdog evaluates invariants against. Sources with no rows ever (NULL last_event_ts AND last_heartbeat_ts) intentionally emit nothing rather than spike to infinity.",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hippo_daemon_source_health_lag_milliseconds{service_namespace!~\".+\"} / 1000",
+          "legendFormat": "{{source}}",
+          "editorMode": "code"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 1800
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Watchdog Invariant Violations by Source",
+      "description": "Cumulative count of capture-invariant violations the watchdog has fired, sliced by source. A flat line means that source is healthy; a rising line means an invariant (I-1..I-15) is currently failing for that source. Pair with the Capture Lag panel: rising violations + rising lag = capture is broken for that source right now.",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (source) (rate(hippo_watchdog_invariant_violation_total{service_namespace!~\".+\"}[5m])) * 60",
+          "legendFormat": "{{source}}",
+          "editorMode": "code"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Why

Cursor was missing from Grafana even though the brain has been emitting
`hippo_brain_enrichment_queue_depth{source="cursor"}` and related counters all
along. Live Prometheus confirmed the data was there — the dashboard simply
didn't query for it. Opencode and codex had a separate gap: their session
pollers write directly to SQLite, bypassing the daemon's event-ingestion path,
so no daemon-side metric carried their freshness.

## What changed

### Dashboard panels (zero risk, source-agnostic)

`otel/grafana/dashboards/hippo-enrichment.json` panels 1 ("Queue Depth by
Source & Status") and 3 ("Events Claimed / min") now use
`sum by (source[, status]) (...)` instead of one refId per source. Any future
source the brain emits appears automatically — no dashboard edit required.
That's the same pattern `hippo-daemon.json` panel 1 already uses for
`events_ingested`, and the reason that one didn't drift while the enrichment
one did.

### New `source_health_metric` module

`crates/hippo-daemon/src/source_health_metric.rs` registers three observable
gauges sourced from the `source_health` table — the same SQL ground truth the
watchdog evaluates invariants against:

- `hippo.daemon.source_health.lag` (ms) — `now - max(last_event_ts, last_heartbeat_ts)`, per source
- `hippo.daemon.source_health.consecutive_failures` — per source
- `hippo.daemon.source_health.probe_ok` (0/1) — per source

Sources with both timestamps NULL emit nothing rather than spiking to infinity
(claude-session-watcher and watchdog are orchestration sources without their
own capture timestamp, so they're correctly omitted). Cheap synchronous SQLite
read inside the OTel callback — same pattern `brain/server.py:_observe_queue_depths`
uses. Module gated behind `feature = "otel"` to match the rest of the
observability stack.

### Overview dashboard

Two new panels at the bottom of `hippo-overview.json`:

- **"Capture Lag by Source"** — green ≤5min, yellow 5–30min, red >30min
- **"Watchdog Invariant Violations by Source"** — `sum by (source) (rate(...))` over `hippo_watchdog_invariant_violation_total`

Together these give one-glance answers to "is hippo capturing source X right
now?" and "is any source actively tripping invariants?".

## Out of scope (filed as #181)

`hippo probe` currently doesn't have `probe_opencode` or `probe_codex` —
synthetic round-trip canary verification for those pipelines. The valid-source
list at `probe.rs:130` rejects both. That's a meaningful gap (catches "pipeline
broke and no user is active") but it's ~150 lines of careful Rust per probe
with its own correctness surface, especially for opencode which needs to read
opencode's own SQLite store. The visibility gap this PR fixes is resolved
independently by the new source_health gauge — every source with a row gets a
freshness line whether it has a probe or not.

## Verification

- `cargo build --release` clean
- `cargo test --features otel -p hippo-daemon` — 281 existing + 4 new lib tests pass
- `cargo clippy --all-targets --features otel -- -D warnings` clean
- `cargo fmt --check` clean
- Both dashboard JSON files validate as JSON
- **Live:** Rebuild + `mise run restart` produced `hippo_daemon_source_health_lag_milliseconds`
  in Prometheus within one export interval, with 8 source labels including
  cursor, opencode, and codex. Lag values match `hippo doctor` freshness output
  exactly.

## Test plan

- [ ] Open Grafana → Hippo Overview. Confirm "Capture Lag by Source" panel
      shows one line per source, color-thresholded correctly.
- [ ] Open Grafana → Hippo Enrichment Pipeline. Confirm Queue Depth and
      Events Claimed panels include cursor.
- [ ] Watch "Watchdog Invariant Violations by Source" for a few hours; it
      should stay flat unless a source actually trips an invariant.
- [ ] Verify the new gauge survives a brain restart (the source_health rows
      persist; the gauge re-reads on each export tick).