### PR TITLE
otel: tier dashboard auto-refresh — 10s live, 1m bench

### DIFF
--- a/otel/grafana/dashboards/bench-model-comparison.json
+++ b/otel/grafana/dashboards/bench-model-comparison.json
@@ -15,7 +15,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "refresh": "30s",
+  "refresh": "1m",
   "templating": {
     "list": [
       {

--- a/otel/grafana/dashboards/bench-model-drilldown.json
+++ b/otel/grafana/dashboards/bench-model-drilldown.json
@@ -15,7 +15,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "refresh": "30s",
+  "refresh": "1m",
   "templating": {
     "list": [
       {

--- a/otel/grafana/dashboards/bench-run-overview.json
+++ b/otel/grafana/dashboards/bench-run-overview.json
@@ -15,7 +15,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "refresh": "30s",
+  "refresh": "1m",
   "templating": {
     "list": [
       {

--- a/otel/grafana/dashboards/hippo-daemon.json
+++ b/otel/grafana/dashboards/hippo-daemon.json
@@ -14,7 +14,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "refresh": "30s",
+  "refresh": "10s",
   "panels": [
     {
       "id": 1,

--- a/otel/grafana/dashboards/hippo-enrichment.json
+++ b/otel/grafana/dashboards/hippo-enrichment.json
@@ -15,7 +15,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "refresh": "30s",
+  "refresh": "10s",
   "panels": [
     {
       "id": 1,

--- a/otel/grafana/dashboards/hippo-overview.json
+++ b/otel/grafana/dashboards/hippo-overview.json
@@ -14,7 +14,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "refresh": "30s",
+  "refresh": "10s",
   "panels": [
     {
       "id": 100,

--- a/otel/grafana/dashboards/hippo-processes.json
+++ b/otel/grafana/dashboards/hippo-processes.json
@@ -15,7 +15,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "refresh": "30s",
+  "refresh": "10s",
   "panels": [
     {
       "id": 1,


### PR DESCRIPTION
## Summary

- Live dashboards (`hippo-overview`, `hippo-daemon`, `hippo-enrichment`, `hippo-processes`) → `refresh: "10s"` for snappy feedback on a local daemon
- Bench dashboards (`hippo-bench-run-overview`, `hippo-bench-model-comparison`, `hippo-bench-model-drilldown`) → `refresh: "1m"` since bench runs are episodic
- Previously all seven dashboards used a uniform `30s` — both too slow for live signals and unnecessarily frequent for episodic bench data

## Why tiered

The four live dashboards surface continuously-changing OTel signals (event ingest rate, enrichment queue depth, daemon CPU/memory, source health). At 30s the UI feels stale when you're actively debugging the daemon; at 10s the latest data point lands before your eye can track to it.

The three bench dashboards visualise discrete benchmark runs — once a run is complete, the data doesn't change. 30s was burning Prometheus queries for no gain; 1m matches the cadence of real interaction.

## What was *not* changed

- `timepicker: {}` left empty — Grafana's built-in `refresh_intervals` dropdown (`5s, 10s, 30s, 1m, 5m, 15m, 30m, 1h, 2h, 1d`) already exposes every reasonable cadence
- Panel-level `"refresh": 2` (inside `templating.list[]`) intentionally untouched — that field controls variable-query re-fetch trigger, not dashboard cadence
- Dashboard `version: 1` not bumped — provisioned dashboards rely on git for history, not Grafana's UI version stack
- Time ranges (`now-1h` live, `now-6h` bench) unchanged

## Test plan

- [ ] Bring up the OTel stack: `docker compose -f otel/docker-compose.yml up -d`
- [ ] Open each dashboard in Grafana and confirm the refresh dropdown shows the correct default (10s for live, 1m for bench)
- [ ] Watch a live dashboard for >30s to confirm the data actually advances every 10s (look for the timestamp under each panel ticking forward)
- [ ] Confirm bench dashboards still load run/model variables correctly (regression check on the untouched `templating.list[].refresh` fields)