### PR TITLE
fix(doctor): repoint Claude/Codex/Cursor session checks from frozen claude_sessions to agentic_sessions

### DIFF
--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -3062,7 +3062,7 @@ fn collect_active_jsonls(
 }
 
 /// Check 5: Recursively find active Claude session JSONL files under
-/// `projects_dir` and verify each has a matching row in `claude_sessions`.
+/// `projects_dir` and verify each has a matching real row in `agentic_sessions`.
 ///
 /// `projects_dir` is `~/.claude/projects` (injectable for tests).
 /// A session file is "active" if its mtime is < 5 minutes old.
@@ -3105,7 +3105,8 @@ pub fn check_claude_session_db(
         let exists = db
             .query_row(
                 "SELECT 1 FROM agentic_sessions \
-                 WHERE session_id = ? AND harness = 'claude-code' LIMIT 1",
+                 WHERE session_id = ? AND harness = 'claude-code' \
+                 AND probe_tag IS NULL LIMIT 1",
                 rusqlite::params![session_id],
                 |_| Ok(()),
             )
@@ -3196,7 +3197,7 @@ fn count_hook_invocations_in_last_1h(log_path: &std::path::Path) -> i64 {
 ///
 /// Counts `"hook invoked"` entries in the last hour (capped at 10 000 log
 /// lines) and compares to `agentic_sessions` rows (harness = 'claude-code')
-/// created in the same window.
+/// created in the same window, excluding synthetic probe rows.
 ///
 /// `log_path` = `$DATA_DIR/session-hook-debug.log` (injectable for tests).
 pub fn check_session_hook_log(
@@ -3213,7 +3214,7 @@ pub fn check_session_hook_log(
     let db_rows: i64 = db
         .query_row(
             "SELECT COUNT(*) FROM agentic_sessions \
-             WHERE harness = 'claude-code' AND created_at >= ?",
+             WHERE harness = 'claude-code' AND probe_tag IS NULL AND created_at >= ?",
             rusqlite::params![one_hour_ago_ms],
             |row| row.get(0),
         )

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -1357,19 +1357,15 @@ pub fn source_freshness_probes() -> Vec<SourceFreshnessProbe> {
                 hard_ms: 7 * DAY_MS,
             },
         },
-        // Exclude Codex rows (source_file under .codex/ or Xcode CodingAssistant)
-        // and Cursor rows (source_file under .cursor/) — those are counted by their
-        // own dedicated probes below. Without these filters a machine that only runs
-        // Cursor or Codex would show a false-green "claude-session: OK".
+        // Claude Code sessions live in `agentic_sessions` keyed by
+        // `harness = 'claude-code'` (post v17→v18 agentic unification). The
+        // harness column separates Codex/Cursor/opencode cleanly, so no
+        // source_file path exclusions are needed. Probe rows excluded per AP-6.
         SourceFreshnessProbe {
             name: "claude-session (main)",
-            query: "SELECT COUNT(*), MAX(end_time) FROM claude_sessions \
-                    WHERE is_subagent = 0 \
-                    AND (source_file IS NULL OR ( \
-                        source_file NOT LIKE '%/.codex/%' \
-                        AND source_file NOT LIKE '%/CodingAssistant/codex/%' \
-                        AND source_file NOT LIKE '%/.cursor/%' \
-                    ))",
+            query: "SELECT COUNT(*), MAX(end_time) FROM agentic_sessions \
+                    WHERE harness = 'claude-code' AND is_subagent = 0 \
+                    AND probe_tag IS NULL",
             thresholds: FreshnessThresholds {
                 soft_ms: 12 * HOUR_MS,
                 hard_ms: 7 * DAY_MS,
@@ -1377,13 +1373,9 @@ pub fn source_freshness_probes() -> Vec<SourceFreshnessProbe> {
         },
         SourceFreshnessProbe {
             name: "claude-session (subagent)",
-            query: "SELECT COUNT(*), MAX(end_time) FROM claude_sessions \
-                    WHERE is_subagent = 1 \
-                    AND (source_file IS NULL OR ( \
-                        source_file NOT LIKE '%/.codex/%' \
-                        AND source_file NOT LIKE '%/CodingAssistant/codex/%' \
-                        AND source_file NOT LIKE '%/.cursor/%' \
-                    ))",
+            query: "SELECT COUNT(*), MAX(end_time) FROM agentic_sessions \
+                    WHERE harness = 'claude-code' AND is_subagent = 1 \
+                    AND probe_tag IS NULL",
             thresholds: FreshnessThresholds {
                 soft_ms: 7 * DAY_MS,
                 hard_ms: 30 * DAY_MS,
@@ -1417,27 +1409,24 @@ pub fn source_freshness_probes() -> Vec<SourceFreshnessProbe> {
                 hard_ms: 30 * DAY_MS,
             },
         },
-        // Codex rows stored in `claude_sessions` (distinguished by .codex/ path in
-        // source_file). Probe rows excluded per AP-6. Thresholds mirror opencode:
-        // Codex is bursty — sessions only land when the user actively codes with it.
+        // Codex rows in `agentic_sessions` keyed by `harness = 'codex'`. Probe
+        // rows excluded per AP-6. Thresholds mirror opencode: Codex is bursty —
+        // sessions only land when the user actively codes with it.
         SourceFreshnessProbe {
             name: "agentic-session-codex",
-            query: "SELECT COUNT(*), MAX(end_time) FROM claude_sessions \
-                    WHERE (source_file LIKE '%/.codex/%' \
-                        OR source_file LIKE '%/CodingAssistant/codex/%') \
-                    AND probe_tag IS NULL",
+            query: "SELECT COUNT(*), MAX(end_time) FROM agentic_sessions \
+                    WHERE harness = 'codex' AND probe_tag IS NULL",
             thresholds: FreshnessThresholds {
                 soft_ms: 3 * DAY_MS,
                 hard_ms: 30 * DAY_MS,
             },
         },
-        // Cursor rows stored in `claude_sessions` (distinguished by .cursor/ path in
-        // source_file). Probe rows excluded per AP-6. Thresholds mirror opencode.
+        // Cursor rows in `agentic_sessions` keyed by `harness = 'cursor'`. Probe
+        // rows excluded per AP-6. Thresholds mirror opencode.
         SourceFreshnessProbe {
             name: "agentic-session-cursor",
-            query: "SELECT COUNT(*), MAX(end_time) FROM claude_sessions \
-                    WHERE source_file LIKE '%/.cursor/%' \
-                    AND probe_tag IS NULL",
+            query: "SELECT COUNT(*), MAX(end_time) FROM agentic_sessions \
+                    WHERE harness = 'cursor' AND probe_tag IS NULL",
             thresholds: FreshnessThresholds {
                 soft_ms: 3 * DAY_MS,
                 hard_ms: 30 * DAY_MS,
@@ -3115,7 +3104,8 @@ pub fn check_claude_session_db(
 
         let exists = db
             .query_row(
-                "SELECT 1 FROM claude_sessions WHERE session_id = ? LIMIT 1",
+                "SELECT 1 FROM agentic_sessions \
+                 WHERE session_id = ? AND harness = 'claude-code' LIMIT 1",
                 rusqlite::params![session_id],
                 |_| Ok(()),
             )
@@ -3205,8 +3195,8 @@ fn count_hook_invocations_in_last_1h(log_path: &std::path::Path) -> i64 {
 /// Check 6: Session-hook debug log vs DB reconciliation.
 ///
 /// Counts `"hook invoked"` entries in the last hour (capped at 10 000 log
-/// lines) and compares to `claude_sessions.created_at` rows in the same
-/// window.
+/// lines) and compares to `agentic_sessions` rows (harness = 'claude-code')
+/// created in the same window.
 ///
 /// `log_path` = `$DATA_DIR/session-hook-debug.log` (injectable for tests).
 pub fn check_session_hook_log(
@@ -3222,7 +3212,8 @@ pub fn check_session_hook_log(
     let one_hour_ago_ms = chrono::Utc::now().timestamp_millis() - 3_600_000i64;
     let db_rows: i64 = db
         .query_row(
-            "SELECT COUNT(*) FROM claude_sessions WHERE created_at >= ?",
+            "SELECT COUNT(*) FROM agentic_sessions \
+             WHERE harness = 'claude-code' AND created_at >= ?",
             rusqlite::params![one_hour_ago_ms],
             |row| row.get(0),
         )
@@ -3257,7 +3248,7 @@ pub fn check_session_hook_log(
         if explain {
             let watcher_log = data_dir.join("claude-session-watcher.log");
             println!(
-                "     CAUSE:  Hook is firing but the watcher is not producing claude_sessions rows"
+                "     CAUSE:  Hook is firing but the watcher is not producing agentic_sessions rows"
             );
             println!(
                 "     FIX:    launchctl print gui/$(id -u)/com.hippo.claude-session-watcher; tail -f {}",
@@ -4660,5 +4651,80 @@ replacement = "***"
             "version": "0.16.0",
         });
         assert_eq!(check_brain_telemetry_status(Some(&json)), 0);
+    }
+
+    // ─── Agentic-unification repoint: doctor must read agentic_sessions, ────────
+    //     not the frozen claude_sessions table (v17→v18 unification debt).
+
+    #[test]
+    fn check_claude_session_db_finds_session_in_agentic_sessions() {
+        let dir = tempdir().unwrap();
+        let conn = coverage_test_db(dir.path());
+
+        // Active JSONL whose stem is the session_id.
+        let projects = dir.path().join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
+        let session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        std::fs::write(
+            projects.join(format!("{session_id}.jsonl")),
+            "{\"type\":\"user\"}\n",
+        )
+        .unwrap();
+
+        // Post-unification the session lives in agentic_sessions (harness =
+        // 'claude-code'), NOT the frozen claude_sessions table.
+        insert_agentic_row(&conn, session_id, "claude-code");
+
+        assert_eq!(
+            check_claude_session_db(&projects, dir.path(), &conn, false),
+            0,
+            "active session present in agentic_sessions must not be reported missing"
+        );
+    }
+
+    #[test]
+    fn check_session_hook_log_counts_agentic_sessions_rows() {
+        let dir = tempdir().unwrap();
+        let conn = coverage_test_db(dir.path());
+
+        // Three "hook invoked" entries within the past hour.
+        let now = chrono::Utc::now();
+        let log = dir.path().join("session-hook-debug.log");
+        std::fs::write(
+            &log,
+            format!("{} hook invoked\n", now.to_rfc3339()).repeat(3),
+        )
+        .unwrap();
+
+        // A claude-code session recorded this hour lives in agentic_sessions.
+        let now_ms = now.timestamp_millis();
+        conn.execute(
+            "INSERT INTO agentic_sessions
+                 (session_id, harness, segment_index, project_dir, cwd, summary_text,
+                  tool_calls_json, user_prompts_json, message_count, source_file,
+                  is_subagent, start_time, end_time, created_at)
+             VALUES ('s1','claude-code',0,'p','/w','sum','[]','[]',1,'/x.jsonl',0,?1,?1,?1)",
+            rusqlite::params![now_ms],
+        )
+        .unwrap();
+
+        // invocations > 0 AND db_rows > 0 → OK (0), not a false [!!] FAIL.
+        assert_eq!(
+            check_session_hook_log(&log, dir.path(), &conn, false),
+            0,
+            "hook invocations matched by agentic_sessions rows must report OK"
+        );
+    }
+
+    #[test]
+    fn source_freshness_probes_never_read_frozen_claude_sessions() {
+        for probe in source_freshness_probes() {
+            assert!(
+                !probe.query.contains("claude_sessions"),
+                "freshness probe {:?} still reads the frozen claude_sessions table; \
+                 repoint it to agentic_sessions (harness-keyed)",
+                probe.name
+            );
+        }
     }
 }

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -584,10 +584,10 @@ async fn recompute_rolling_counts(state: Arc<DaemonState>) {
                         "SELECT COUNT(*) FROM events WHERE source_kind='claude-tool' AND timestamp>(unixepoch('now')-86400)*1000",
                     )?,
                     session_1h: read(
-                        "SELECT COUNT(*) FROM claude_sessions WHERE start_time>(unixepoch('now')-3600)*1000",
+                        "SELECT COUNT(*) FROM agentic_sessions WHERE harness='claude-code' AND start_time>(unixepoch('now')-3600)*1000",
                     )?,
                     session_24h: read(
-                        "SELECT COUNT(*) FROM claude_sessions WHERE start_time>(unixepoch('now')-86400)*1000",
+                        "SELECT COUNT(*) FROM agentic_sessions WHERE harness='claude-code' AND start_time>(unixepoch('now')-86400)*1000",
                     )?,
                     browser_1h: read(
                         "SELECT COUNT(*) FROM browser_events WHERE timestamp>(unixepoch('now')-3600)*1000",

--- a/crates/hippo-daemon/src/daemon.rs
+++ b/crates/hippo-daemon/src/daemon.rs
@@ -561,6 +561,36 @@ struct RollingCounts {
     browser_24h: i64,
 }
 
+fn read_rolling_counts(db: &rusqlite::Connection) -> rusqlite::Result<RollingCounts> {
+    let read = |sql: &str| -> rusqlite::Result<i64> { db.query_row(sql, [], |r| r.get(0)) };
+    Ok(RollingCounts {
+        shell_1h: read(
+            "SELECT COUNT(*) FROM events WHERE source_kind='shell' AND timestamp>(unixepoch('now')-3600)*1000",
+        )?,
+        shell_24h: read(
+            "SELECT COUNT(*) FROM events WHERE source_kind='shell' AND timestamp>(unixepoch('now')-86400)*1000",
+        )?,
+        tool_1h: read(
+            "SELECT COUNT(*) FROM events WHERE source_kind='claude-tool' AND timestamp>(unixepoch('now')-3600)*1000",
+        )?,
+        tool_24h: read(
+            "SELECT COUNT(*) FROM events WHERE source_kind='claude-tool' AND timestamp>(unixepoch('now')-86400)*1000",
+        )?,
+        session_1h: read(
+            "SELECT COUNT(*) FROM agentic_sessions WHERE harness='claude-code' AND probe_tag IS NULL AND start_time>(unixepoch('now')-3600)*1000",
+        )?,
+        session_24h: read(
+            "SELECT COUNT(*) FROM agentic_sessions WHERE harness='claude-code' AND probe_tag IS NULL AND start_time>(unixepoch('now')-86400)*1000",
+        )?,
+        browser_1h: read(
+            "SELECT COUNT(*) FROM browser_events WHERE timestamp>(unixepoch('now')-3600)*1000",
+        )?,
+        browser_24h: read(
+            "SELECT COUNT(*) FROM browser_events WHERE timestamp>(unixepoch('now')-86400)*1000",
+        )?,
+    })
+}
+
 async fn recompute_rolling_counts(state: Arc<DaemonState>) {
     let mut interval = tokio::time::interval(Duration::from_secs(300));
     interval.tick().await; // discard first immediate tick so we start ~5 min after daemon start
@@ -568,35 +598,7 @@ async fn recompute_rolling_counts(state: Arc<DaemonState>) {
         interval.tick().await;
         let counts = {
             let db = state.read_db.lock().await;
-            let read = |sql: &str| -> rusqlite::Result<i64> { db.query_row(sql, [], |r| r.get(0)) };
-            let result: rusqlite::Result<RollingCounts> = (|| {
-                Ok(RollingCounts {
-                    shell_1h: read(
-                        "SELECT COUNT(*) FROM events WHERE source_kind='shell' AND timestamp>(unixepoch('now')-3600)*1000",
-                    )?,
-                    shell_24h: read(
-                        "SELECT COUNT(*) FROM events WHERE source_kind='shell' AND timestamp>(unixepoch('now')-86400)*1000",
-                    )?,
-                    tool_1h: read(
-                        "SELECT COUNT(*) FROM events WHERE source_kind='claude-tool' AND timestamp>(unixepoch('now')-3600)*1000",
-                    )?,
-                    tool_24h: read(
-                        "SELECT COUNT(*) FROM events WHERE source_kind='claude-tool' AND timestamp>(unixepoch('now')-86400)*1000",
-                    )?,
-                    session_1h: read(
-                        "SELECT COUNT(*) FROM agentic_sessions WHERE harness='claude-code' AND start_time>(unixepoch('now')-3600)*1000",
-                    )?,
-                    session_24h: read(
-                        "SELECT COUNT(*) FROM agentic_sessions WHERE harness='claude-code' AND start_time>(unixepoch('now')-86400)*1000",
-                    )?,
-                    browser_1h: read(
-                        "SELECT COUNT(*) FROM browser_events WHERE timestamp>(unixepoch('now')-3600)*1000",
-                    )?,
-                    browser_24h: read(
-                        "SELECT COUNT(*) FROM browser_events WHERE timestamp>(unixepoch('now')-86400)*1000",
-                    )?,
-                })
-            })();
+            let result = read_rolling_counts(&db);
             match result {
                 Ok(v) => v,
                 Err(e) => {
@@ -1095,6 +1097,37 @@ mod tests {
             DaemonResponse::Status(status) => status,
             other => panic!("expected status response, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_rolling_counts_ignore_probe_agentic_sessions() {
+        let config = test_config();
+        let db = storage::open_db(&config.db_path()).unwrap();
+        let now_ms = chrono::Utc::now().timestamp_millis();
+
+        db.execute(
+            "INSERT INTO agentic_sessions
+                 (session_id, harness, segment_index, project_dir, cwd, summary_text,
+                  tool_calls_json, user_prompts_json, message_count, source_file,
+                  is_subagent, start_time, end_time, created_at, probe_tag)
+             VALUES ('real-session','claude-code',0,'p','/w','sum','[]','[]',1,'/real.jsonl',0,?1,?1,?1,NULL)",
+            rusqlite::params![now_ms],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO agentic_sessions
+                 (session_id, harness, segment_index, project_dir, cwd, summary_text,
+                  tool_calls_json, user_prompts_json, message_count, source_file,
+                  is_subagent, start_time, end_time, created_at, probe_tag)
+             VALUES ('probe-session','claude-code',0,'p','/w','sum','[]','[]',1,'/probe.jsonl',0,?1,?1,?1,'probe-test')",
+            rusqlite::params![now_ms],
+        )
+        .unwrap();
+
+        let counts = read_rolling_counts(&db).unwrap();
+
+        assert_eq!(counts.session_1h, 1, "1h count must exclude probe rows");
+        assert_eq!(counts.session_24h, 1, "24h count must exclude probe rows");
     }
 
     #[tokio::test]

--- a/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
+++ b/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
@@ -63,13 +63,15 @@ mod doctor {
             file.set_times(times).expect("set_times");
         }
 
-        /// Insert a `claude_sessions` row for the given session_id.
+        /// Insert an `agentic_sessions` row (harness='claude-code') for the
+        /// given session_id — the post-unification home for Claude Code sessions
+        /// that doctor's checks 5/6 reconcile against.
         fn insert_session_row(conn: &rusqlite::Connection, session_id: &str) {
             conn.execute(
-                "INSERT OR IGNORE INTO claude_sessions \
-                 (session_id, project_dir, cwd, segment_index, start_time, end_time, \
+                "INSERT OR IGNORE INTO agentic_sessions \
+                 (session_id, harness, segment_index, project_dir, cwd, start_time, end_time, \
                   summary_text, message_count, source_file, is_subagent, created_at) \
-                 VALUES (?, '', '/', 0, unixepoch('now')*1000, unixepoch('now')*1000, \
+                 VALUES (?, 'claude-code', 0, '', '/', unixepoch('now')*1000, unixepoch('now')*1000, \
                          '', 0, '', 0, unixepoch('now')*1000)",
                 rusqlite::params![session_id],
             )
@@ -189,7 +191,7 @@ mod doctor {
             fs::write(&jsonl, "{}\n").unwrap();
             // File is fresh (just written) — mtime < 5min by default.
 
-            // Do NOT insert any row into claude_sessions — session is "missing".
+            // Do NOT insert any row into agentic_sessions — session is "missing".
             let fail =
                 check_claude_session_db(&tmp.path().join("projects"), tmp.path(), &conn, false);
             assert_eq!(fail, 1, "active session absent from DB must yield fail=1");
@@ -266,7 +268,7 @@ mod doctor {
         fn check_5_subagent_jsonl_detected_recursively() {
             // Regression test for the P1 bug: subagent transcripts at
             // `<proj>/<parent-uuid>/subagents/<id>.jsonl` must be found by the
-            // recursive walk and reconciled against claude_sessions.
+            // recursive walk and reconciled against agentic_sessions.
             let tmp = tempdir().unwrap();
             let conn = open_test_db(tmp.path());
 
@@ -330,7 +332,7 @@ mod doctor {
             // 3 recent hook invocations, none older than 1h.
             write_hook_log(&log, &[10, 60, 120]);
 
-            // No claude_sessions rows → 0 DB rows in last 1h.
+            // No agentic_sessions rows → 0 DB rows in last 1h.
             let fail = check_session_hook_log(&log, tmp.path(), &conn, false);
             assert_eq!(fail, 1, "≥3 invocations with 0 DB rows must fail");
         }

--- a/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
+++ b/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
@@ -78,6 +78,20 @@ mod doctor {
             .unwrap();
         }
 
+        /// Insert a synthetic probe `agentic_sessions` row. Probe rows exercise
+        /// AP-6: diagnostics must not treat them as real user sessions.
+        fn insert_probe_session_row(conn: &rusqlite::Connection, session_id: &str) {
+            conn.execute(
+                "INSERT OR IGNORE INTO agentic_sessions \
+                 (session_id, harness, segment_index, project_dir, cwd, start_time, end_time, \
+                  summary_text, message_count, source_file, is_subagent, created_at, probe_tag) \
+                 VALUES (?, 'claude-code', 0, '', '/', unixepoch('now')*1000, unixepoch('now')*1000, \
+                         '', 0, '', 0, unixepoch('now')*1000, 'probe-test')",
+                rusqlite::params![session_id],
+            )
+            .unwrap();
+        }
+
         // ── Check 2: NM manifest ───────────────────────────────────────────
 
         #[test]
@@ -213,6 +227,27 @@ mod doctor {
             let fail =
                 check_claude_session_db(&tmp.path().join("projects"), tmp.path(), &conn, false);
             assert_eq!(fail, 0, "active session in DB must pass");
+        }
+
+        #[test]
+        fn check_5_probe_session_row_does_not_satisfy_active_jsonl() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let projects = tmp.path().join("projects/abc");
+            fs::create_dir_all(&projects).unwrap();
+            let session_id = "probe-only-session";
+            let jsonl = projects.join(format!("{session_id}.jsonl"));
+            fs::write(&jsonl, "{}\n").unwrap();
+
+            insert_probe_session_row(&conn, session_id);
+
+            let fail =
+                check_claude_session_db(&tmp.path().join("projects"), tmp.path(), &conn, false);
+            assert_eq!(
+                fail, 1,
+                "synthetic probe rows must not satisfy active JSONL reconciliation"
+            );
         }
 
         #[test]
@@ -375,6 +410,23 @@ mod doctor {
 
             let fail = check_session_hook_log(&log, tmp.path(), &conn, false);
             assert_eq!(fail, 0, "invocations + DB rows → [OK]");
+        }
+
+        #[test]
+        fn check_6_probe_session_rows_do_not_satisfy_hook_reconciliation() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let log = tmp.path().join("session-hook-debug.log");
+            write_hook_log(&log, &[10, 60, 120]);
+
+            insert_probe_session_row(&conn, "probe-only-hook-row");
+
+            let fail = check_session_hook_log(&log, tmp.path(), &conn, false);
+            assert_eq!(
+                fail, 1,
+                "synthetic probe rows must not make hook reconciliation look healthy"
+            );
         }
 
         #[test]


### PR DESCRIPTION
This pull request migrates all database queries and tests in the doctor and daemon code from the legacy `claude_sessions` table to the unified `agentic_sessions` table, specifically keyed by the `harness` column. This is part of the v17→v18 agentic unification, ensuring that all session checks, freshness probes, and rolling counts are performed against the correct, up-to-date table. The change also updates test helpers and comments to reflect this migration, and adds new tests to prevent regressions.

**Migration to agentic_sessions (agentic unification):**
* All session-related queries in `commands.rs` (doctor checks, freshness probes, and log reconciliation) now use the `agentic_sessions` table with appropriate `harness` filters, replacing any usage of the old `claude_sessions` table. [[1]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aL1360-R1378) [[2]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aL1420-R1429) [[3]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aL3118-R3108) [[4]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aL3208-R3199) [[5]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aL3225-R3216) [[6]](diffhunk://#diff-55b5ee6efd96e52056e164785025e9e6a3d75edef8ecdacdc9c015b691fe9e2aL3260-R3251)
* Rolling session counts in `daemon.rs` are updated to read from `agentic_sessions` where `harness='claude-code'`.

**Test updates and new safeguards:**
* Test helpers and comments in `doctor_checks_2_5_6_9_10.rs` are updated to insert and check against `agentic_sessions` instead of `claude_sessions`, ensuring tests reflect the new unified schema. [[1]](diffhunk://#diff-f4ffd15a852adab313272c3053e6dc8afd3dbdce507bce52d23fff32efb72504L66-R74) [[2]](diffhunk://#diff-f4ffd15a852adab313272c3053e6dc8afd3dbdce507bce52d23fff32efb72504L192-R194) [[3]](diffhunk://#diff-f4ffd15a852adab313272c3053e6dc8afd3dbdce507bce52d23fff32efb72504L269-R271) [[4]](diffhunk://#diff-f4ffd15a852adab313272c3053e6dc8afd3dbdce507bce52d23fff32efb72504L333-R335)
* New tests are added to guarantee that no freshness probes or doctor checks accidentally reference the deprecated `claude_sessions` table.

These changes ensure that all session tracking and health checks are consistent with the unified agentic session model, preventing regressions and aligning with the current database schema.