### PR TITLE
feat(bench): results datastore + dashboard (retrieval headline; enrichment deferred to #191)

### DIFF
--- a/brain/src/hippo_brain/bench/README.md
+++ b/brain/src/hippo_brain/bench/README.md
@@ -386,15 +386,21 @@ Four tables, keyed on `run_id` (children cascade-delete on `--force` re-ingest):
 |---|---|---|
 | `bench_runs` | one per run | manifest + run_end: corpus version/hash, thresholds, models, timestamps |
 | `bench_models` | per (run, model) | aggregate gate rates, latency percentiles, verdict |
-| `bench_node_enrichment` | per (run, model, corpus node) | enrichment gates + `parsed_output_json` — **full coverage** of every node |
+| `bench_node_enrichment` | per (run, model, corpus node) | enrichment gates + `parsed_output_json` — per-node health layer (**dormant**, see below) |
 | `bench_node_retrieval` | per (run, model, QA item, mode) | rank, MRR, Hit@1/10, NDCG — **the headline**, QA-labeled subset only |
 
 **Two scoring signals, two roles.** Retrieval quality (MRR/Hit@1, from
 `downstream_proxy.per_item`) is the **headline leaderboard** — it measures whether
 a model's enrichment makes a node findable, the outcome hippo exists for. Its
-coverage grows automatically as more `eval-qa` items are labeled. Enrichment gates
-are the **full-coverage health layer** — they cover every node but mostly act as a
-floor rather than a discriminator.
+coverage grows automatically as more `eval-qa` items are labeled.
+
+> **`bench_node_enrichment` is dormant on real runs.** The ingest + schema are in
+> place, but the bench pipeline does not yet emit per-node enrichment records over
+> the full corpus (the self-consistency pass samples only a few nodes, and the
+> shadow brain's full-corpus enrichment is discarded with the shadow stack). Until
+> that lands, this table stays empty on real runs and the dashboard's per-node
+> enrichment view shows "(no data)". Tracked in
+> [#191](https://github.com/stevencarpenter/hippo/issues/191) — picked up next.
 
 ```bash
 # Backfill any surviving run JSONLs (one file, or every *.jsonl under runs/)

--- a/brain/src/hippo_brain/bench/README.md
+++ b/brain/src/hippo_brain/bench/README.md
@@ -159,6 +159,10 @@ hippo-bench determinism <run-file> <run-file> [...] [--mrr-budget 0.02]
                                                     [--hit-at-1-budget 0.02]
                                                     [--mode hybrid]
 
+hippo-bench ingest <run-file> | --all [--force]
+
+hippo-bench export-dashboard [--out path]
+
 hippo-bench recover [--brain-url http://127.0.0.1:9175]
 ```
 
@@ -361,6 +365,55 @@ jq 'select(.record_type=="model_summary") | {model:.model.id, errors:.errors}' "
 
 ---
 
+## Results datastore
+
+The per-run JSONL is an append-only **working file** — crash-safe during a run,
+but local-only, unindexed, and easy to lose. The durable record of history is a
+separate SQLite datastore:
+
+```
+~/.local/share/hippo-bench/bench-results.db    # sibling of runs/, NOT hippo.db
+```
+
+It is **auto-ingested at run-end** (`orchestrate._safe_ingest` → `results_store.ingest_run`),
+wrapped so a datastore failure never fails the bench run — the JSONL stays as the
+fallback. Ingest is idempotent on `run_id` (a run's JSONL is immutable after
+`run_end`), so re-ingest is a no-op unless `--force`.
+
+Four tables, keyed on `run_id` (children cascade-delete on `--force` re-ingest):
+
+| Table | Grain | Captures |
+|---|---|---|
+| `bench_runs` | one per run | manifest + run_end: corpus version/hash, thresholds, models, timestamps |
+| `bench_models` | per (run, model) | aggregate gate rates, latency percentiles, verdict |
+| `bench_node_enrichment` | per (run, model, corpus node) | enrichment gates + `parsed_output_json` — **full coverage** of every node |
+| `bench_node_retrieval` | per (run, model, QA item, mode) | rank, MRR, Hit@1/10, NDCG — **the headline**, QA-labeled subset only |
+
+**Two scoring signals, two roles.** Retrieval quality (MRR/Hit@1, from
+`downstream_proxy.per_item`) is the **headline leaderboard** — it measures whether
+a model's enrichment makes a node findable, the outcome hippo exists for. Its
+coverage grows automatically as more `eval-qa` items are labeled. Enrichment gates
+are the **full-coverage health layer** — they cover every node but mostly act as a
+floor rather than a discriminator.
+
+```bash
+# Backfill any surviving run JSONLs (one file, or every *.jsonl under runs/)
+hippo-bench ingest ~/.local/share/hippo-bench/runs/run-*.jsonl
+hippo-bench ingest --all [--force]
+
+# Render the datastore to one self-contained HTML file (no server, no network):
+# leaderboard (latest run, hybrid) + per-node "best model per corpus member" +
+# run history. Cell values (incl. stored LLM output) render via textContent, so
+# they cannot inject markup.
+hippo-bench export-dashboard            # → ~/.local/share/hippo-bench/dashboard.html
+hippo-bench export-dashboard --out /tmp/bench.html
+```
+
+The leaderboard headline uses the **single most-recent run**; all prior runs stay
+in the datastore for the per-node and history views.
+
+---
+
 ## Module map
 
 | Module | Responsibility |
@@ -380,6 +433,8 @@ jq 'select(.record_type=="model_summary") | {model:.model.id, errors:.errors}' "
 | [`coordinator.py`](coordinator.py) | Per-model lifecycle (shadow stack, queue drain, downstream proxy) |
 | [`runner.py`](runner.py) | Self-consistency pass; per-attempt gate composition |
 | [`output.py`](output.py) | JSONL record dataclasses + append-only writer |
+| [`results_store.py`](results_store.py) | Durable `bench-results.db`: schema, idempotent `ingest_run`, leaderboard/node/history queries |
+| [`dashboard_export.py`](dashboard_export.py) | Renders the datastore to one self-contained HTML file (leaderboard + per-node + history) |
 | [`summary.py`](summary.py) | Aggregate per-model gates from attempts; derive verdict |
 | [`pretty.py`](pretty.py) | Text-table renderer for `hippo-bench summary` |
 | [`orchestrate.py`](orchestrate.py) | Top-level: preflight + pause/resume + per-model loop + JSONL writes |

--- a/brain/src/hippo_brain/bench/README.md
+++ b/brain/src/hippo_brain/bench/README.md
@@ -415,8 +415,10 @@ hippo-bench export-dashboard            # → ~/.local/share/hippo-bench/dashboa
 hippo-bench export-dashboard --out /tmp/bench.html
 ```
 
-The leaderboard headline uses the **single most-recent run**; all prior runs stay
-in the datastore for the per-node and history views.
+The leaderboard headline uses the **most-recent run that has retrieval rows for
+the selected mode** — usually the newest run, but it falls back to the latest run
+that was actually QA-scored when a newer run skipped scoring (so the headline never
+blanks). All prior runs stay in the datastore for the per-node and history views.
 
 ---
 

--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -252,7 +252,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
 
         suffix = f", {errors} error(s)" if errors else ""
         print(f"done: {total_new} run(s) ingested, {len(targets)} file(s) seen{suffix}")
-        return 0
+        return 0 if args.all or errors == 0 else 1
     finally:
         conn.close()
 

--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -205,31 +205,53 @@ def _cmd_recover(args: argparse.Namespace) -> int:
 
 
 def _cmd_ingest(args: argparse.Namespace) -> int:
+    import logging
+
     from hippo_brain.bench.results_store import connect, ingest_run
+
+    log = logging.getLogger(__name__)
 
     if args.all:
         targets = sorted(bench_runs_dir().glob("*.jsonl"))
-    elif args.run_file is None:
+    elif args.run_file:
+        targets = [Path(p) for p in args.run_file]
+    else:
         print("error: ingest requires a run_file argument or --all")
         return 1
-    else:
-        targets = [Path(args.run_file)]
 
     conn = connect()
     try:
         total_new = 0
+        errors = 0
         for t in targets:
-            res = ingest_run(t, conn=conn, force=args.force)
-            status = (
-                "skipped (already ingested)"
-                if res.skipped_existing
-                else f"ingested run_id={res.run_id} "
-                f"(models={res.models}, enrichment={res.enrichment_rows}, "
-                f"retrieval={res.retrieval_rows}, malformed={res.malformed_lines})"
-            )
+            # Per-file isolation: one bad JSONL (unreadable, non-UTF-8, bad
+            # data that slips past ingest_run's own guards) must not abort the
+            # rest of the batch. Report it and move on.
+            try:
+                res = ingest_run(t, conn=conn, force=args.force)
+            except Exception as e:  # noqa: BLE001 — isolate one bad file from the batch
+                errors += 1
+                log.exception("ingest failed for %s", t)
+                print(f"{t.name}: ERROR ({type(e).__name__}: {e})")
+                continue
+
+            if res.skipped_existing:
+                status = "skipped (already ingested)"
+            elif res.skipped_aborted:
+                status = "skipped (aborted run — no scoring rows)"
+            elif res.run_id is None:
+                status = "skipped (no run_manifest)"
+            else:
+                status = (
+                    f"ingested run_id={res.run_id} "
+                    f"(models={res.models}, enrichment={res.enrichment_rows}, "
+                    f"retrieval={res.retrieval_rows}, malformed={res.malformed_lines})"
+                )
             print(f"{t.name}: {status}")
             total_new += 1 if res.inserted else 0
-        print(f"done: {total_new} run(s) ingested, {len(targets)} file(s) seen")
+
+        suffix = f", {errors} error(s)" if errors else ""
+        print(f"done: {total_new} run(s) ingested, {len(targets)} file(s) seen{suffix}")
         return 0
     finally:
         conn.close()
@@ -452,7 +474,11 @@ def _build_parser() -> argparse.ArgumentParser:
     summary.set_defaults(func=_cmd_summary)
 
     ingest = sub.add_parser("ingest", help="Ingest run JSONL into the bench results datastore")
-    ingest.add_argument("run_file", nargs="?", help="Path to a run JSONL (omit with --all)")
+    ingest.add_argument(
+        "run_file",
+        nargs="*",
+        help="One or more run JSONL paths (a glob like run-*.jsonl works); omit with --all",
+    )
     ingest.add_argument(
         "--all", action="store_true", help="Ingest every *.jsonl under the runs dir"
     )

--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -204,6 +204,37 @@ def _cmd_recover(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_ingest(args: argparse.Namespace) -> int:
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    if args.all:
+        targets = sorted(bench_runs_dir().glob("*.jsonl"))
+    elif args.run_file is None:
+        print("error: ingest requires a run_file argument or --all")
+        return 1
+    else:
+        targets = [Path(args.run_file)]
+
+    conn = connect()
+    try:
+        total_new = 0
+        for t in targets:
+            res = ingest_run(t, conn=conn, force=args.force)
+            status = (
+                "skipped (already ingested)"
+                if res.skipped_existing
+                else f"ingested run_id={res.run_id} "
+                f"(models={res.models}, enrichment={res.enrichment_rows}, "
+                f"retrieval={res.retrieval_rows}, malformed={res.malformed_lines})"
+            )
+            print(f"{t.name}: {status}")
+            total_new += 1 if res.inserted else 0
+        print(f"done: {total_new} run(s) ingested, {len(targets)} file(s) seen")
+        return 0
+    finally:
+        conn.close()
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     # BT-06: recover from a prior crashed bench run before doing anything
     # else. If the previous bench was SIGKILL'd, prod brain is still paused;
@@ -411,6 +442,14 @@ def _build_parser() -> argparse.ArgumentParser:
     summary = sub.add_parser("summary", help="Pretty-print a run JSONL file")
     summary.add_argument("run_file")
     summary.set_defaults(func=_cmd_summary)
+
+    ingest = sub.add_parser("ingest", help="Ingest run JSONL into the bench results datastore")
+    ingest.add_argument("run_file", nargs="?", help="Path to a run JSONL (omit with --all)")
+    ingest.add_argument(
+        "--all", action="store_true", help="Ingest every *.jsonl under the runs dir"
+    )
+    ingest.add_argument("--force", action="store_true", help="Re-ingest runs already present")
+    ingest.set_defaults(func=_cmd_ingest)
 
     # BT-29 / post-review: deterministic-rerun verification. Operator runs the
     # bench 3× against the same model + frozen corpus, then compares JSONLs.

--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -235,6 +235,14 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
         conn.close()
 
 
+def _cmd_export_dashboard(args: argparse.Namespace) -> int:
+    from hippo_brain.bench.dashboard_export import export_dashboard
+
+    out = export_dashboard(Path(args.out) if args.out else None)
+    print(f"wrote dashboard: {out}")
+    return 0
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     # BT-06: recover from a prior crashed bench run before doing anything
     # else. If the previous bench was SIGKILL'd, prod brain is still paused;
@@ -450,6 +458,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ingest.add_argument("--force", action="store_true", help="Re-ingest runs already present")
     ingest.set_defaults(func=_cmd_ingest)
+
+    export = sub.add_parser(
+        "export-dashboard", help="Render the results datastore to one HTML file"
+    )
+    export.add_argument("--out", help="Output HTML path (default: <hippo-bench>/dashboard.html)")
+    export.set_defaults(func=_cmd_export_dashboard)
 
     # BT-29 / post-review: deterministic-rerun verification. Operator runs the
     # bench 3× against the same model + frozen corpus, then compares JSONLs.

--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -240,7 +240,9 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
             elif res.skipped_aborted:
                 status = "skipped (aborted run — no scoring rows)"
             elif res.run_id is None:
-                status = "skipped (no run_manifest)"
+                # run_id is None for both a missing run_manifest AND a manifest
+                # present but lacking a run_id — keep the wording broad.
+                status = "skipped (no usable run_manifest / run_id)"
             else:
                 status = (
                     f"ingested run_id={res.run_id} "

--- a/brain/src/hippo_brain/bench/dashboard_export.py
+++ b/brain/src/hippo_brain/bench/dashboard_export.py
@@ -50,7 +50,7 @@ _TEMPLATE = """<!doctype html>
 <div id="leaderboard"></div>
 <h2>Per-node — best model per corpus member</h2>
 <select id="node-select"></select>
-<h3>Retrieval (all runs, hybrid)</h3>
+<h3>Retrieval (all runs, best score first)</h3>
 <div id="node-retrieval"></div>
 <h3>Enrichment (all runs)</h3>
 <div id="node-enrichment"></div>

--- a/brain/src/hippo_brain/bench/dashboard_export.py
+++ b/brain/src/hippo_brain/bench/dashboard_export.py
@@ -12,30 +12,20 @@ from pathlib import Path
 
 from hippo_brain.bench.paths import bench_results_db_path
 from hippo_brain.bench.results_store import (
+    all_node_details,
     connect,
     leaderboard_latest,
-    node_detail,
     run_history,
 )
 
 
 def _gather(conn: sqlite3.Connection) -> dict:
-    # Every node scored by either pipeline, for the per-node ("best model per
-    # corpus member") view. node_detail returns all historical rows per node.
-    node_ids = [
-        r[0]
-        for r in conn.execute(
-            "SELECT event_id FROM bench_node_enrichment "
-            "UNION SELECT golden_event_id FROM bench_node_retrieval "
-            "ORDER BY 1"
-        ).fetchall()
-        if r[0] is not None
-    ]
-    nodes = {eid: node_detail(conn, eid, mode="hybrid") for eid in node_ids}
+    # Per-node ("best model per corpus member") view: retrieval + enrichment for
+    # every scored node, fetched in two queries total (not an N+1 over nodes).
     return {
         "leaderboard": leaderboard_latest(conn, mode="hybrid"),
         "history": run_history(conn),
-        "nodes": nodes,
+        "nodes": all_node_details(conn, mode="hybrid"),
     }
 
 

--- a/brain/src/hippo_brain/bench/dashboard_export.py
+++ b/brain/src/hippo_brain/bench/dashboard_export.py
@@ -46,7 +46,7 @@ _TEMPLATE = """<!doctype html>
 </head>
 <body>
 <h1>hippo-bench dashboard</h1>
-<h2>Leaderboard — latest run (hybrid retrieval)</h2>
+<h2>Leaderboard — latest scored run (hybrid retrieval)</h2>
 <div id="leaderboard"></div>
 <h2>Per-node — best model per corpus member</h2>
 <select id="node-select"></select>

--- a/brain/src/hippo_brain/bench/dashboard_export.py
+++ b/brain/src/hippo_brain/bench/dashboard_export.py
@@ -1,0 +1,137 @@
+"""Render the bench results datastore into one self-contained HTML file.
+
+No server, no network: the data is embedded as a JSON blob and a small
+vanilla-JS view renders the leaderboard, per-node lookup, and run history.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from hippo_brain.bench.paths import bench_results_db_path
+from hippo_brain.bench.results_store import (
+    connect,
+    leaderboard_latest,
+    node_detail,
+    run_history,
+)
+
+
+def _gather(conn: sqlite3.Connection) -> dict:
+    # Every node scored by either pipeline, for the per-node ("best model per
+    # corpus member") view. node_detail returns all historical rows per node.
+    node_ids = [
+        r[0]
+        for r in conn.execute(
+            "SELECT event_id FROM bench_node_enrichment "
+            "UNION SELECT golden_event_id FROM bench_node_retrieval "
+            "ORDER BY 1"
+        ).fetchall()
+        if r[0] is not None
+    ]
+    nodes = {eid: node_detail(conn, eid, mode="hybrid") for eid in node_ids}
+    return {
+        "leaderboard": leaderboard_latest(conn, mode="hybrid"),
+        "history": run_history(conn),
+        "nodes": nodes,
+    }
+
+
+_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>hippo-bench dashboard</title>
+<style>
+ body {{ font-family: ui-monospace, monospace; margin: 2rem; background:#0f1115; color:#e6e6e6; }}
+ h1, h2 {{ color:#7aa2ff; }}
+ table {{ border-collapse: collapse; width: 100%; margin-bottom: 2rem; }}
+ th, td {{ border: 1px solid #2a2f3a; padding: 6px 10px; text-align: left; }}
+ th {{ background:#1a1e27; }}
+ tr:nth-child(even) {{ background:#161a22; }}
+</style>
+</head>
+<body>
+<h1>hippo-bench dashboard</h1>
+<h2>Leaderboard — latest run (hybrid retrieval)</h2>
+<div id="leaderboard"></div>
+<h2>Per-node — best model per corpus member</h2>
+<select id="node-select"></select>
+<h3>Retrieval (all runs, hybrid)</h3>
+<div id="node-retrieval"></div>
+<h3>Enrichment (all runs)</h3>
+<div id="node-enrichment"></div>
+<h2>Run history</h2>
+<div id="history"></div>
+<script type="application/json" id="hippo-bench-data">{data_json}</script>
+<script>
+ const data = JSON.parse(document.getElementById("hippo-bench-data").textContent);
+ // Build the DOM with textContent so cell values (incl. LLM-generated
+ // parsed_output) can never inject markup — no innerHTML with data.
+ function renderTable(target, rows, cols) {{
+   const el = document.getElementById(target);
+   if (!rows || !rows.length) {{ el.textContent = "(no data)"; return; }}
+   const tbl = document.createElement("table");
+   const thead = tbl.insertRow();
+   for (const c of cols) {{
+     const th = document.createElement("th");
+     th.textContent = c;
+     thead.appendChild(th);
+   }}
+   for (const r of rows) {{
+     const tr = tbl.insertRow();
+     for (const c of cols) {{
+       const td = tr.insertCell();
+       td.textContent = (r[c] === null || r[c] === undefined) ? "" : String(r[c]);
+     }}
+   }}
+   el.replaceChildren(tbl);
+ }}
+ renderTable("leaderboard", data.leaderboard, ["model_id", "avg_mrr", "hit_at_1", "scored_nodes", "run_id"]);
+ renderTable("history", data.history, ["started_at_iso", "run_id", "corpus_version", "finished_at_iso"]);
+
+ // Per-node view: a <select> of every scored corpus node; on change, render
+ // that node's retrieval ranking and enrichment rows across all runs.
+ const sel = document.getElementById("node-select");
+ const nodeIds = Object.keys(data.nodes).sort();
+ for (const id of nodeIds) {{
+   const opt = document.createElement("option");
+   opt.value = id; opt.textContent = id;
+   sel.appendChild(opt);
+ }}
+ function renderNode(id) {{
+   const detail = data.nodes[id] || {{retrieval: [], enrichment: []}};
+   renderTable("node-retrieval", detail.retrieval,
+     ["model_id", "mrr", "rank", "hit_at_1", "run_id", "started_at_iso"]);
+   renderTable("node-enrichment", detail.enrichment,
+     ["model_id", "schema_valid", "refusal_detected", "echo_similarity",
+      "entity_sanity", "parsed_output_json", "run_id"]);
+ }}
+ sel.addEventListener("change", () => renderNode(sel.value));
+ if (nodeIds.length) renderNode(nodeIds[0]);
+</script>
+</body>
+</html>
+"""
+
+
+def build_dashboard_html(conn: sqlite3.Connection) -> str:
+    payload = _gather(conn)
+    # Escape "</script>" defensively so embedded data can't break out of the tag.
+    blob = json.dumps(payload, sort_keys=True).replace("</", "<\\/")
+    return _TEMPLATE.format(data_json=blob)
+
+
+def export_dashboard(out_path: Path | None = None, *, db_path: Path | None = None) -> Path:
+    out = out_path or (bench_results_db_path().parent / "dashboard.html")
+    conn = connect(db_path)
+    try:
+        html_text = build_dashboard_html(conn)
+    finally:
+        conn.close()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html_text, encoding="utf-8")
+    return out

--- a/brain/src/hippo_brain/bench/downstream_proxy.py
+++ b/brain/src/hippo_brain/bench/downstream_proxy.py
@@ -156,6 +156,7 @@ def run_downstream_proxy_pass(
             results = search(conn, query, query_vec, mode=mode, limit=k)
             score = score_single_retrieval(results, item["golden_event_id"])
             score["qa_id"] = item.get("qa_id")
+            score["golden_event_id"] = item["golden_event_id"]
             score["mode"] = mode
             scored.append(score)
             per_item_scores.append(score)

--- a/brain/src/hippo_brain/bench/orchestrate.py
+++ b/brain/src/hippo_brain/bench/orchestrate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import atexit
 import datetime as _dt
 import json
+import logging
 import os
 import platform
 import subprocess
@@ -31,6 +32,7 @@ from hippo_brain.bench.paths import (
 )
 from hippo_brain.bench.pause_rpc import PauseRpcClient
 from hippo_brain.bench.preflight import run_all_preflight
+from hippo_brain.bench.results_store import ingest_run
 from hippo_brain.bench.summary import (
     aggregate_model_summary,
     compute_verdict,
@@ -39,6 +41,8 @@ from hippo_brain.bench.summary import (
 from hippo_brain.schema_version import EXPECTED_SCHEMA_VERSION
 
 _T = TypeVar("_T")
+
+_log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -122,6 +126,20 @@ def _read_manifest_field(manifest_path: Path, key: str, default: _T) -> _T:
     if value is None:
         return default
     return cast(_T, value)
+
+
+def _safe_ingest(out_path: Path, *, dry_run: bool) -> None:
+    """Ingest the just-written JSONL into the results datastore.
+
+    A reporting concern must never fail the run (AP-1): the JSONL remains the
+    fallback if this raises. Dry runs are not ingested.
+    """
+    if dry_run:
+        return
+    try:
+        ingest_run(out_path)
+    except Exception:  # noqa: BLE001 — never fail the run over reporting
+        _log.exception("results_store ingest failed for %s", out_path)
 
 
 def orchestrate_run(
@@ -418,3 +436,4 @@ def orchestrate_run(
         )
     finally:
         writer.close()
+        _safe_ingest(out_path, dry_run=dry_run)

--- a/brain/src/hippo_brain/bench/paths.py
+++ b/brain/src/hippo_brain/bench/paths.py
@@ -55,3 +55,8 @@ def bench_run_tree(run_id: str, model_id: str, create: bool = False) -> Path:
     if create:
         p.mkdir(parents=True, exist_ok=True)
     return p
+
+
+def bench_results_db_path() -> Path:
+    """Durable, all-local bench results datastore. Separate file from hippo.db."""
+    return hippo_bench_root() / "bench-results.db"

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -109,7 +109,21 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
     conn.execute("PRAGMA foreign_keys=ON")
     conn.execute("PRAGMA busy_timeout=5000")
     conn.executescript(_SCHEMA)
-    conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+    # Stamp user_version only on a *fresh* DB (version 0). Stamping
+    # unconditionally would let an older binary silently downgrade a DB written
+    # by a newer one — corrupting the version that future migrations key on.
+    current = conn.execute("PRAGMA user_version").fetchone()[0]
+    if current > SCHEMA_VERSION:
+        conn.close()
+        raise RuntimeError(
+            f"bench-results.db is schema v{current}, newer than this binary "
+            f"(v{SCHEMA_VERSION}); refusing to open rather than downgrade — upgrade hippo"
+        )
+    if current < SCHEMA_VERSION:
+        # Fresh DB (0) or an older version. When real migrations exist they run
+        # here, version-by-version, BEFORE this stamp; today _SCHEMA's
+        # CREATE TABLE IF NOT EXISTS is the only (idempotent) step.
+        conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
     conn.commit()
     return conn
 

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -123,6 +123,7 @@ class IngestResult:
     enrichment_rows: int = 0
     retrieval_rows: int = 0
     malformed_lines: int = 0
+    skipped_aborted: bool = False
 
 
 def _parse_records(jsonl_path: Path) -> tuple[list[dict], int]:
@@ -167,6 +168,19 @@ def ingest_run(
             )
 
         end = next((r for r in records if r.get("record_type") == "run_end"), None)
+
+        # Aborted / no-model runs carry no scoring rows. Skip them so they don't
+        # add empty noise to run history or become the "latest" run that blanks
+        # the leaderboard. (A still-running partial JSONL has no run_end / no
+        # reason and is NOT skipped here — it ingests what it has.)
+        if end and end.get("reason") in {"preflight_aborted", "no_models"}:
+            return IngestResult(
+                run_id=run_id,
+                inserted=False,
+                skipped_existing=False,
+                skipped_aborted=True,
+                malformed_lines=malformed,
+            )
 
         with conn:  # one transaction; FK cascade clears child rows on replace
             conn.execute("DELETE FROM bench_runs WHERE run_id=?", (run_id,))
@@ -325,11 +339,25 @@ def _ingest_retrieval(conn: sqlite3.Connection, run_id: str, records: list[dict]
 
 
 def leaderboard_latest(conn: sqlite3.Connection, *, mode: str = "hybrid") -> list[dict]:
-    """Per-model aggregate retrieval for the single most-recent run (headline)."""
+    """Per-model aggregate retrieval for the headline run.
+
+    The headline is the most-recent run that actually has retrieval rows for
+    ``mode`` — NOT simply the newest run. QA scoring is often skipped (the
+    fixture can be absent), so the newest run may have no retrieval data; falling
+    back to the latest run that does keeps the leaderboard populated instead of
+    blanking it and hiding all history.
+    """
     rows = conn.execute(
         """
         WITH latest AS (
-            SELECT run_id FROM bench_runs ORDER BY started_at_iso DESC LIMIT 1
+            SELECT r.run_id
+            FROM bench_runs r
+            WHERE EXISTS (
+                SELECT 1 FROM bench_node_retrieval nr
+                WHERE nr.run_id = r.run_id AND nr.mode = ?
+            )
+            ORDER BY r.started_at_iso DESC
+            LIMIT 1
         )
         SELECT nr.run_id, nr.model_id,
                AVG(nr.mrr)            AS avg_mrr,
@@ -341,7 +369,7 @@ def leaderboard_latest(conn: sqlite3.Connection, *, mode: str = "hybrid") -> lis
         GROUP BY nr.run_id, nr.model_id
         ORDER BY avg_mrr DESC
         """,
-        (mode,),
+        (mode, mode),
     ).fetchall()
     return [dict(r) for r in rows]
 

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -273,6 +273,13 @@ def _entity_sanity_mean(per_cat: dict | None) -> float | None:
 
 
 def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict]) -> int:
+    # DORMANT on real runs: this selects `main`-purpose attempts, but the bench
+    # pipeline does not yet emit any (the self-consistency pass labels its
+    # attempts `self_consistency`, and the shadow brain's full-corpus enrichment
+    # is discarded with the shadow stack). The ingest + schema are ready; the
+    # producer is owed by https://github.com/stevencarpenter/hippo/issues/191.
+    # Until then this is a no-op on real runs (tests exercise it with synthetic
+    # `main` attempts). Keep the `main` filter — it is the correct contract.
     n = 0
     for r in records:
         if r.get("record_type") != "attempt" or r.get("purpose") != "main":

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -159,10 +159,23 @@ def ingest_run(
             return IngestResult(
                 run_id=None, inserted=False, skipped_existing=False, malformed_lines=malformed
             )
-        run_id = manifest["run_id"]
+        run_id = manifest.get("run_id")
+        if not run_id:
+            # A manifest present but missing run_id is bad data, not a crash —
+            # handle it like a missing manifest. The CLI ingest path does not
+            # wrap ingest_run in try/except, so a KeyError here would abort it.
+            return IngestResult(
+                run_id=None, inserted=False, skipped_existing=False, malformed_lines=malformed
+            )
 
-        existing = conn.execute("SELECT 1 FROM bench_runs WHERE run_id=?", (run_id,)).fetchone()
-        if existing and not force:
+        # Skip re-ingest only for a COMPLETE run already on file (finished_at_iso
+        # set). An incomplete run (ingested while still in-flight, finished_at_iso
+        # NULL) must remain re-ingestable so its later run_end + retrieval rows
+        # land without --force. `--force` always re-ingests.
+        existing = conn.execute(
+            "SELECT finished_at_iso FROM bench_runs WHERE run_id=?", (run_id,)
+        ).fetchone()
+        if existing is not None and existing[0] is not None and not force:
             return IngestResult(
                 run_id=run_id, inserted=False, skipped_existing=True, malformed_lines=malformed
             )
@@ -237,8 +250,12 @@ def _ingest_models(conn: sqlite3.Connection, run_id: str, records: list[dict]) -
             continue
         g = r.get("gates", {})
         verdict = r.get("tier0_verdict", {})
+        # OR REPLACE (matching _ingest_enrichment / _ingest_retrieval): a run
+        # with a duplicated candidate model (e.g. `--models m1,m1`) emits two
+        # model_summary records for the same (run_id, model_id) PK; collapse to
+        # the last rather than raising IntegrityError mid-transaction.
         conn.execute(
-            """INSERT INTO bench_models (
+            """INSERT OR REPLACE INTO bench_models (
                 run_id, model_id, schema_validity_rate, refusal_rate, echo_similarity_max,
                 latency_p50_ms, latency_p95_ms, latency_p99_ms, self_consistency_mean,
                 self_consistency_min, entity_sanity_mean, main_attempts_count,
@@ -302,7 +319,14 @@ def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict
                 _entity_sanity_mean(g.get("entity_type_sanity")),
                 r.get("timestamps", {}).get("total_ms"),
                 1 if r.get("timeout") else 0,
-                json.dumps(r.get("parsed_output"), sort_keys=True),
+                # Map a missing/None parsed_output to SQL NULL, not the literal
+                # TEXT 'null' that json.dumps(None) would produce (matches the
+                # None→NULL behavior of every sibling column in this INSERT).
+                (
+                    json.dumps(r.get("parsed_output"), sort_keys=True)
+                    if r.get("parsed_output") is not None
+                    else None
+                ),
             ),
         )
         n += 1
@@ -404,6 +428,41 @@ def node_detail(conn: sqlite3.Connection, event_id: str, *, mode: str = "hybrid"
         "retrieval": [dict(r) for r in retrieval],
         "enrichment": [dict(r) for r in enrichment],
     }
+
+
+def all_node_details(conn: sqlite3.Connection, *, mode: str = "hybrid") -> dict[str, dict]:
+    """Per-node retrieval + enrichment for EVERY scored node, keyed by node id.
+
+    Two queries total (one retrieval, one enrichment), vs ``node_detail``'s two
+    queries *per node*. Same per-node shape as ``node_detail``; used by the
+    dashboard exporter to avoid an N+1 over the corpus.
+    """
+    nodes: dict[str, dict] = {}
+
+    def _node(event_id: str) -> dict:
+        return nodes.setdefault(event_id, {"event_id": event_id, "retrieval": [], "enrichment": []})
+
+    for r in conn.execute(
+        """SELECT nr.golden_event_id AS event_id, nr.run_id, nr.model_id, nr.mrr, nr.rank,
+                  nr.hit_at_1, r.started_at_iso
+           FROM bench_node_retrieval nr JOIN bench_runs r USING (run_id)
+           WHERE nr.mode = ? AND nr.golden_event_id IS NOT NULL
+           ORDER BY r.started_at_iso DESC""",
+        (mode,),
+    ).fetchall():
+        d = dict(r)
+        _node(d.pop("event_id"))["retrieval"].append(d)
+
+    for r in conn.execute(
+        """SELECT ne.event_id, ne.run_id, ne.model_id, ne.schema_valid, ne.refusal_detected,
+                  ne.echo_similarity, ne.entity_sanity, ne.parsed_output_json, r.started_at_iso
+           FROM bench_node_enrichment ne JOIN bench_runs r USING (run_id)
+           ORDER BY r.started_at_iso DESC""",
+    ).fetchall():
+        d = dict(r)
+        _node(d.pop("event_id"))["enrichment"].append(d)
+
+    return nodes
 
 
 def run_history(conn: sqlite3.Connection) -> list[dict]:

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -335,7 +335,13 @@ def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict
     return n
 
 
-def _hit(hit_at_k: dict, k: int) -> int:
+def _hit(hit_at_k: object, k: int) -> int:
+    # Ingest is malformed-tolerant: a record whose hit_at_k is missing, null, or
+    # any non-dict value counts as "no hit" rather than aborting the whole file.
+    # (`item.get("hit_at_k", {})` does NOT guard this — an explicit `"hit_at_k":
+    # null` yields None, since .get only substitutes the default for an ABSENT key.)
+    if not isinstance(hit_at_k, dict):
+        return 0
     v = hit_at_k.get(k, hit_at_k.get(str(k), False))
     return 1 if v else 0
 
@@ -409,11 +415,15 @@ def leaderboard_latest(conn: sqlite3.Connection, *, mode: str = "hybrid") -> lis
 
 def node_detail(conn: sqlite3.Connection, event_id: str, *, mode: str = "hybrid") -> dict:
     """All historical retrieval + enrichment rows for one corpus node."""
+    # "Best model per corpus member": order by score so the strongest model/run
+    # surfaces first, not merely the newest. All runs are kept (not deduped to
+    # latest-per-model) so a regression — a model that scored worse in a later
+    # run — stays visible instead of being hidden behind "current".
     retrieval = conn.execute(
         """SELECT nr.run_id, nr.model_id, nr.mrr, nr.rank, nr.hit_at_1, r.started_at_iso
            FROM bench_node_retrieval nr JOIN bench_runs r USING (run_id)
            WHERE nr.golden_event_id = ? AND nr.mode = ?
-           ORDER BY r.started_at_iso DESC""",
+           ORDER BY nr.mrr DESC, nr.hit_at_1 DESC, r.started_at_iso DESC""",
         (event_id, mode),
     ).fetchall()
     enrichment = conn.execute(
@@ -444,12 +454,15 @@ def all_node_details(conn: sqlite3.Connection, *, mode: str = "hybrid") -> dict[
     def _node(event_id: str) -> dict:
         return nodes.setdefault(event_id, {"event_id": event_id, "retrieval": [], "enrichment": []})
 
+    # Best-score-first within each node (see node_detail): surfaces the strongest
+    # model/run per corpus member rather than just the newest, while keeping all
+    # runs so regressions stay visible.
     for r in conn.execute(
         """SELECT nr.golden_event_id AS event_id, nr.run_id, nr.model_id, nr.mrr, nr.rank,
                   nr.hit_at_1, r.started_at_iso
            FROM bench_node_retrieval nr JOIN bench_runs r USING (run_id)
            WHERE nr.mode = ? AND nr.golden_event_id IS NOT NULL
-           ORDER BY r.started_at_iso DESC""",
+           ORDER BY nr.mrr DESC, nr.hit_at_1 DESC, r.started_at_iso DESC""",
         (mode,),
     ).fetchall():
         d = dict(r)

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -108,10 +108,10 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
     conn.execute("PRAGMA busy_timeout=5000")
-    conn.executescript(_SCHEMA)
-    # Stamp user_version only on a *fresh* DB (version 0). Stamping
-    # unconditionally would let an older binary silently downgrade a DB written
-    # by a newer one — corrupting the version that future migrations key on.
+    # Check the on-disk schema version BEFORE applying any DDL: a DB written by a
+    # newer binary must be refused untouched. Running v1 CREATE statements against
+    # a (possibly incompatible) newer schema first could error or partially mutate
+    # it before we ever reach the refusal.
     current = conn.execute("PRAGMA user_version").fetchone()[0]
     if current > SCHEMA_VERSION:
         conn.close()
@@ -119,10 +119,13 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
             f"bench-results.db is schema v{current}, newer than this binary "
             f"(v{SCHEMA_VERSION}); refusing to open rather than downgrade — upgrade hippo"
         )
+    conn.executescript(_SCHEMA)
+    # Stamp user_version only on a *fresh* DB (version 0) or after a future
+    # upgrade. Stamping unconditionally would let an older binary silently
+    # downgrade a newer DB — corrupting the version migrations key on. When real
+    # migrations exist they run here, version-by-version, BEFORE this stamp;
+    # today _SCHEMA's CREATE TABLE IF NOT EXISTS is the only (idempotent) step.
     if current < SCHEMA_VERSION:
-        # Fresh DB (0) or an older version. When real migrations exist they run
-        # here, version-by-version, BEFORE this stamp; today _SCHEMA's
-        # CREATE TABLE IF NOT EXISTS is the only (idempotent) step.
         conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
     conn.commit()
     return conn

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -322,3 +322,60 @@ def _ingest_retrieval(conn: sqlite3.Connection, run_id: str, records: list[dict]
             )
             n += 1
     return n
+
+
+def leaderboard_latest(conn: sqlite3.Connection, *, mode: str = "hybrid") -> list[dict]:
+    """Per-model aggregate retrieval for the single most-recent run (headline)."""
+    rows = conn.execute(
+        """
+        WITH latest AS (
+            SELECT run_id FROM bench_runs ORDER BY started_at_iso DESC LIMIT 1
+        )
+        SELECT nr.run_id, nr.model_id,
+               AVG(nr.mrr)            AS avg_mrr,
+               AVG(nr.hit_at_1)       AS hit_at_1,
+               COUNT(*)               AS scored_nodes
+        FROM bench_node_retrieval nr
+        JOIN latest ON latest.run_id = nr.run_id
+        WHERE nr.mode = ?
+        GROUP BY nr.run_id, nr.model_id
+        ORDER BY avg_mrr DESC
+        """,
+        (mode,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def node_detail(conn: sqlite3.Connection, event_id: str, *, mode: str = "hybrid") -> dict:
+    """All historical retrieval + enrichment rows for one corpus node."""
+    retrieval = conn.execute(
+        """SELECT nr.run_id, nr.model_id, nr.mrr, nr.rank, nr.hit_at_1, r.started_at_iso
+           FROM bench_node_retrieval nr JOIN bench_runs r USING (run_id)
+           WHERE nr.golden_event_id = ? AND nr.mode = ?
+           ORDER BY r.started_at_iso DESC""",
+        (event_id, mode),
+    ).fetchall()
+    enrichment = conn.execute(
+        """SELECT ne.run_id, ne.model_id, ne.schema_valid, ne.refusal_detected,
+                  ne.echo_similarity, ne.entity_sanity, ne.parsed_output_json,
+                  r.started_at_iso
+           FROM bench_node_enrichment ne JOIN bench_runs r USING (run_id)
+           WHERE ne.event_id = ?
+           ORDER BY r.started_at_iso DESC""",
+        (event_id,),
+    ).fetchall()
+    return {
+        "event_id": event_id,
+        "retrieval": [dict(r) for r in retrieval],
+        "enrichment": [dict(r) for r in enrichment],
+    }
+
+
+def run_history(conn: sqlite3.Connection) -> list[dict]:
+    """All runs, newest first, for the history/trend view."""
+    rows = conn.execute(
+        """SELECT run_id, started_at_iso, finished_at_iso, corpus_version,
+                  corpus_content_hash, models_completed_json
+           FROM bench_runs ORDER BY started_at_iso DESC"""
+    ).fetchall()
+    return [dict(r) for r in rows]

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -126,6 +126,17 @@ class IngestResult:
     skipped_aborted: bool = False
 
 
+def _as_dict(v: object) -> dict:
+    """Coerce a JSONL value to a dict; a non-dict (null, list, scalar) becomes {}.
+
+    Ingest is malformed-tolerant: every consumer reaches into nested objects with
+    ``.get()``, so a partial/older record carrying ``null`` (or any non-object)
+    where a dict is expected must degrade to empty fields, not raise AttributeError
+    and abort the whole file.
+    """
+    return v if isinstance(v, dict) else {}
+
+
 def _parse_records(jsonl_path: Path) -> tuple[list[dict], int]:
     records: list[dict] = []
     malformed = 0
@@ -135,8 +146,16 @@ def _parse_records(jsonl_path: Path) -> tuple[list[dict], int]:
             if not line:
                 continue
             try:
-                records.append(json.loads(line))
+                rec = json.loads(line)
             except json.JSONDecodeError:
+                malformed += 1
+                continue
+            # A line can be valid JSON yet not an object (list/string/number).
+            # Every downstream consumer does record.get(...), so drop non-dict
+            # records as malformed rather than crashing on the first .get().
+            if isinstance(rec, dict):
+                records.append(rec)
+            else:
                 malformed += 1
     return records, malformed
 
@@ -250,8 +269,14 @@ def _ingest_models(conn: sqlite3.Connection, run_id: str, records: list[dict]) -
     for r in records:
         if r.get("record_type") != "model_summary":
             continue
-        g = r.get("gates", {})
-        verdict = r.get("tier0_verdict", {})
+        model_id = _as_dict(r.get("model")).get("id")
+        if not model_id:
+            # No model id → a NULL composite-PK row. SQLite permits multiple NULLs
+            # in a PRIMARY KEY, so INSERT OR REPLACE would NOT collapse them and a
+            # malformed summary could spawn junk rows. Skip it.
+            continue
+        g = _as_dict(r.get("gates"))
+        verdict = _as_dict(r.get("tier0_verdict"))
         # OR REPLACE (matching _ingest_enrichment / _ingest_retrieval): a run
         # with a duplicated candidate model (e.g. `--models m1,m1`) emits two
         # model_summary records for the same (run_id, model_id) PK; collapse to
@@ -265,7 +290,7 @@ def _ingest_models(conn: sqlite3.Connection, run_id: str, records: list[dict]) -
             ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
             (
                 run_id,
-                r.get("model", {}).get("id"),
+                model_id,
                 g.get("schema_validity_rate"),
                 g.get("refusal_rate"),
                 g.get("echo_similarity_max"),
@@ -303,8 +328,8 @@ def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict
     for r in records:
         if r.get("record_type") != "attempt" or r.get("purpose") != "main":
             continue
-        ev = r.get("event", {})
-        g = r.get("gates", {})
+        ev = _as_dict(r.get("event"))
+        g = _as_dict(r.get("gates"))
         conn.execute(
             """INSERT OR REPLACE INTO bench_node_enrichment (
                 run_id, model_id, event_id, source, schema_valid, refusal_detected,
@@ -312,14 +337,14 @@ def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict
             ) VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
             (
                 run_id,
-                r.get("model", {}).get("id"),
+                _as_dict(r.get("model")).get("id"),
                 ev.get("event_id"),
                 ev.get("source"),
                 1 if g.get("schema_valid") else 0,
                 1 if g.get("refusal_detected") else 0,
                 g.get("echo_similarity"),
                 _entity_sanity_mean(g.get("entity_type_sanity")),
-                r.get("timestamps", {}).get("total_ms"),
+                _as_dict(r.get("timestamps")).get("total_ms"),
                 1 if r.get("timeout") else 0,
                 # Map a missing/None parsed_output to SQL NULL, not the literal
                 # TEXT 'null' that json.dumps(None) would produce (matches the
@@ -351,9 +376,17 @@ def _ingest_retrieval(conn: sqlite3.Connection, run_id: str, records: list[dict]
     for r in records:
         if r.get("record_type") != "model_summary":
             continue
-        model_id = r.get("model", {}).get("id")
-        per_item = r.get("downstream_proxy", {}).get("per_item", [])
+        model_id = _as_dict(r.get("model")).get("id")
+        if not model_id:
+            continue  # NULL composite-PK row (see _ingest_models) — skip
+        per_item = _as_dict(r.get("downstream_proxy")).get("per_item")
+        if not isinstance(per_item, list):
+            # null / non-list per_item (older/partial/malformed run): nothing to
+            # score for this model, not a crash.
+            continue
         for item in per_item:
+            if not isinstance(item, dict):
+                continue  # skip a malformed non-dict score entry
             hk = item.get("hit_at_k", {})
             conn.execute(
                 """INSERT OR REPLACE INTO bench_node_retrieval (

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -210,8 +210,40 @@ def ingest_run(
             conn.close()
 
 
-def _ingest_models(conn, run_id, records):  # noqa: ANN001
-    pass
+def _ingest_models(conn: sqlite3.Connection, run_id: str, records: list[dict]) -> int:
+    n = 0
+    for r in records:
+        if r.get("record_type") != "model_summary":
+            continue
+        g = r.get("gates", {})
+        verdict = r.get("tier0_verdict", {})
+        conn.execute(
+            """INSERT INTO bench_models (
+                run_id, model_id, schema_validity_rate, refusal_rate, echo_similarity_max,
+                latency_p50_ms, latency_p95_ms, latency_p99_ms, self_consistency_mean,
+                self_consistency_min, entity_sanity_mean, main_attempts_count,
+                verdict_passed, failed_gates_json, errors_json
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                run_id,
+                r.get("model", {}).get("id"),
+                g.get("schema_validity_rate"),
+                g.get("refusal_rate"),
+                g.get("echo_similarity_max"),
+                g.get("latency_p50_ms"),
+                g.get("latency_p95_ms"),
+                g.get("latency_p99_ms"),
+                g.get("self_consistency_mean"),
+                g.get("self_consistency_min"),
+                g.get("entity_sanity_mean"),
+                g.get("main_attempts_count"),
+                1 if verdict.get("passed") else 0,
+                json.dumps(verdict.get("failed_gates", []), sort_keys=True),
+                json.dumps(r.get("errors", []), sort_keys=True),
+            ),
+        )
+        n += 1
+    return n
 
 
 def _ingest_enrichment(conn, run_id, records):  # noqa: ANN001

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -330,6 +330,13 @@ def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict
             continue
         ev = _as_dict(r.get("event"))
         g = _as_dict(r.get("gates"))
+        model_id = _as_dict(r.get("model")).get("id")
+        event_id = ev.get("event_id")
+        if not model_id or not event_id:
+            # (run_id, model_id, event_id) is the composite PK. SQLite permits
+            # multiple NULLs in a PK, so a malformed/partial attempt missing
+            # either would write un-dedupable junk rows — skip it.
+            continue
         conn.execute(
             """INSERT OR REPLACE INTO bench_node_enrichment (
                 run_id, model_id, event_id, source, schema_valid, refusal_detected,
@@ -337,8 +344,8 @@ def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict
             ) VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
             (
                 run_id,
-                _as_dict(r.get("model")).get("id"),
-                ev.get("event_id"),
+                model_id,
+                event_id,
                 ev.get("source"),
                 1 if g.get("schema_valid") else 0,
                 1 if g.get("refusal_detected") else 0,
@@ -387,6 +394,12 @@ def _ingest_retrieval(conn: sqlite3.Connection, run_id: str, records: list[dict]
         for item in per_item:
             if not isinstance(item, dict):
                 continue  # skip a malformed non-dict score entry
+            qa_id = item.get("qa_id")
+            mode = item.get("mode")
+            if not qa_id or not mode:
+                # (run_id, model_id, qa_id, mode) is the composite PK; a NULL
+                # qa_id/mode can't dedupe under INSERT OR REPLACE — skip.
+                continue
             hk = item.get("hit_at_k", {})
             conn.execute(
                 """INSERT OR REPLACE INTO bench_node_retrieval (
@@ -396,9 +409,9 @@ def _ingest_retrieval(conn: sqlite3.Connection, run_id: str, records: list[dict]
                 (
                     run_id,
                     model_id,
-                    item.get("qa_id"),
+                    qa_id,
                     item.get("golden_event_id"),
-                    item.get("mode"),
+                    mode,
                     item.get("rank"),
                     item.get("mrr"),
                     _hit(hk, 1),

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -198,12 +198,18 @@ def ingest_run(
                     now_ms,
                 ),
             )
-            _ingest_models(conn, run_id, records)
-            _ingest_enrichment(conn, run_id, records)
-            _ingest_retrieval(conn, run_id, records)
+            n_models = _ingest_models(conn, run_id, records)
+            n_enrich = _ingest_enrichment(conn, run_id, records)
+            n_retr = _ingest_retrieval(conn, run_id, records)
 
         return IngestResult(
-            run_id=run_id, inserted=True, skipped_existing=False, malformed_lines=malformed
+            run_id=run_id,
+            inserted=True,
+            skipped_existing=False,
+            models=n_models,
+            enrichment_rows=n_enrich,
+            retrieval_rows=n_retr,
+            malformed_lines=malformed,
         )
     finally:
         if owns_conn:
@@ -282,5 +288,37 @@ def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict
     return n
 
 
-def _ingest_retrieval(conn, run_id, records):  # noqa: ANN001
-    pass
+def _hit(hit_at_k: dict, k: int) -> int:
+    v = hit_at_k.get(k, hit_at_k.get(str(k), False))
+    return 1 if v else 0
+
+
+def _ingest_retrieval(conn: sqlite3.Connection, run_id: str, records: list[dict]) -> int:
+    n = 0
+    for r in records:
+        if r.get("record_type") != "model_summary":
+            continue
+        model_id = r.get("model", {}).get("id")
+        per_item = r.get("downstream_proxy", {}).get("per_item", [])
+        for item in per_item:
+            hk = item.get("hit_at_k", {})
+            conn.execute(
+                """INSERT OR REPLACE INTO bench_node_retrieval (
+                    run_id, model_id, qa_id, golden_event_id, mode, rank, mrr,
+                    hit_at_1, hit_at_10, ndcg_at_10
+                ) VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    run_id,
+                    model_id,
+                    item.get("qa_id"),
+                    item.get("golden_event_id"),
+                    item.get("mode"),
+                    item.get("rank"),
+                    item.get("mrr"),
+                    _hit(hk, 1),
+                    _hit(hk, 10),
+                    item.get("ndcg_at_10"),
+                ),
+            )
+            n += 1
+    return n

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -187,6 +187,8 @@ def ingest_run(
         # the leaderboard. (A still-running partial JSONL has no run_end / no
         # reason and is NOT skipped here — it ingests what it has.)
         if end and end.get("reason") in {"preflight_aborted", "no_models"}:
+            with conn:
+                conn.execute("DELETE FROM bench_runs WHERE run_id=?", (run_id,))
             return IngestResult(
                 run_id=run_id,
                 inserted=False,

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -246,8 +246,40 @@ def _ingest_models(conn: sqlite3.Connection, run_id: str, records: list[dict]) -
     return n
 
 
-def _ingest_enrichment(conn, run_id, records):  # noqa: ANN001
-    pass
+def _entity_sanity_mean(per_cat: dict | None) -> float | None:
+    if not isinstance(per_cat, dict) or not per_cat:
+        return None
+    return sum(per_cat.values()) / len(per_cat)
+
+
+def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict]) -> int:
+    n = 0
+    for r in records:
+        if r.get("record_type") != "attempt" or r.get("purpose") != "main":
+            continue
+        ev = r.get("event", {})
+        g = r.get("gates", {})
+        conn.execute(
+            """INSERT OR REPLACE INTO bench_node_enrichment (
+                run_id, model_id, event_id, source, schema_valid, refusal_detected,
+                echo_similarity, entity_sanity, latency_ms, timeout, parsed_output_json
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                run_id,
+                r.get("model", {}).get("id"),
+                ev.get("event_id"),
+                ev.get("source"),
+                1 if g.get("schema_valid") else 0,
+                1 if g.get("refusal_detected") else 0,
+                g.get("echo_similarity"),
+                _entity_sanity_mean(g.get("entity_type_sanity")),
+                r.get("timestamps", {}).get("total_ms"),
+                1 if r.get("timeout") else 0,
+                json.dumps(r.get("parsed_output"), sort_keys=True),
+            ),
+        )
+        n += 1
+    return n
 
 
 def _ingest_retrieval(conn, run_id, records):  # noqa: ANN001

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -11,7 +11,10 @@ after run_end, so re-ingest is a no-op unless force=True.
 
 from __future__ import annotations
 
+import json
 import sqlite3
+import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from hippo_brain.bench.paths import bench_results_db_path
@@ -109,3 +112,111 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
     conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
     conn.commit()
     return conn
+
+
+@dataclass
+class IngestResult:
+    run_id: str | None
+    inserted: bool
+    skipped_existing: bool
+    models: int = 0
+    enrichment_rows: int = 0
+    retrieval_rows: int = 0
+    malformed_lines: int = 0
+
+
+def _parse_records(jsonl_path: Path) -> tuple[list[dict], int]:
+    records: list[dict] = []
+    malformed = 0
+    with jsonl_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                malformed += 1
+    return records, malformed
+
+
+def ingest_run(
+    jsonl_path: Path,
+    conn: sqlite3.Connection | None = None,
+    *,
+    force: bool = False,
+    now_ms: int = 0,
+) -> IngestResult:
+    """Parse one run's JSONL into the datastore. Idempotent on run_id."""
+    now_ms = now_ms or int(time.time() * 1000)  # populate ingested_at_ms for real ingests
+    owns_conn = conn is None
+    conn = conn or connect()
+    try:
+        records, malformed = _parse_records(jsonl_path)
+        manifest = next((r for r in records if r.get("record_type") == "run_manifest"), None)
+        if manifest is None:
+            return IngestResult(
+                run_id=None, inserted=False, skipped_existing=False, malformed_lines=malformed
+            )
+        run_id = manifest["run_id"]
+
+        existing = conn.execute("SELECT 1 FROM bench_runs WHERE run_id=?", (run_id,)).fetchone()
+        if existing and not force:
+            return IngestResult(
+                run_id=run_id, inserted=False, skipped_existing=True, malformed_lines=malformed
+            )
+
+        end = next((r for r in records if r.get("record_type") == "run_end"), None)
+
+        with conn:  # one transaction; FK cascade clears child rows on replace
+            conn.execute("DELETE FROM bench_runs WHERE run_id=?", (run_id,))
+            conn.execute(
+                """INSERT INTO bench_runs (
+                    run_id, started_at_iso, finished_at_iso, host_json, bench_version,
+                    corpus_version, corpus_content_hash, corpus_schema_version,
+                    eval_qa_version, embedding_model, inference_backend_version,
+                    gate_thresholds_json, candidate_models_json, models_completed_json,
+                    models_errored_json, reason, ingested_at_ms
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    run_id,
+                    manifest.get("started_at_iso"),
+                    (end or {}).get("finished_at_iso") or manifest.get("finished_at_iso"),
+                    json.dumps(manifest.get("host", {}), sort_keys=True),
+                    manifest.get("bench_version"),
+                    manifest.get("corpus_version"),
+                    manifest.get("corpus_content_hash"),
+                    manifest.get("corpus_schema_version"),
+                    manifest.get("eval_qa_version"),
+                    manifest.get("embedding_model"),
+                    manifest.get("inference_backend_version"),
+                    json.dumps(manifest.get("gate_thresholds", {}), sort_keys=True),
+                    json.dumps(manifest.get("candidate_models", []), sort_keys=True),
+                    json.dumps((end or {}).get("models_completed", []), sort_keys=True),
+                    json.dumps((end or {}).get("models_errored", []), sort_keys=True),
+                    (end or {}).get("reason"),
+                    now_ms,
+                ),
+            )
+            _ingest_models(conn, run_id, records)
+            _ingest_enrichment(conn, run_id, records)
+            _ingest_retrieval(conn, run_id, records)
+
+        return IngestResult(
+            run_id=run_id, inserted=True, skipped_existing=False, malformed_lines=malformed
+        )
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def _ingest_models(conn, run_id, records):  # noqa: ANN001
+    pass
+
+
+def _ingest_enrichment(conn, run_id, records):  # noqa: ANN001
+    pass
+
+
+def _ingest_retrieval(conn, run_id, records):  # noqa: ANN001
+    pass

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -1,0 +1,111 @@
+"""Durable, all-local datastore for hippo-bench run results.
+
+Parses a run's append-only JSONL (the disposable working file) into four
+queryable tables keyed on run_id, so historical runs survive JSONL cleanup
+and per-(model, corpus-node) scoring is referenceable across all runs.
+
+Separate SQLite file from the application DB (hippo.db); its own
+PRAGMA user_version. Idempotent on run_id — a run's JSONL is immutable
+after run_end, so re-ingest is a no-op unless force=True.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from hippo_brain.bench.paths import bench_results_db_path
+
+SCHEMA_VERSION = 1
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS bench_runs (
+    run_id                    TEXT PRIMARY KEY,
+    started_at_iso            TEXT,
+    finished_at_iso           TEXT,
+    host_json                 TEXT,
+    bench_version             TEXT,
+    corpus_version            TEXT,
+    corpus_content_hash       TEXT,
+    corpus_schema_version     INTEGER,
+    eval_qa_version           TEXT,
+    embedding_model           TEXT,
+    inference_backend_version TEXT,
+    gate_thresholds_json      TEXT,
+    candidate_models_json     TEXT,
+    models_completed_json     TEXT,
+    models_errored_json       TEXT,
+    reason                    TEXT,
+    ingested_at_ms            INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS bench_models (
+    run_id                TEXT,
+    model_id              TEXT,
+    schema_validity_rate  REAL,
+    refusal_rate          REAL,
+    echo_similarity_max   REAL,
+    latency_p50_ms        INTEGER,
+    latency_p95_ms        INTEGER,
+    latency_p99_ms        INTEGER,
+    self_consistency_mean REAL,
+    self_consistency_min  REAL,
+    entity_sanity_mean    REAL,
+    main_attempts_count   INTEGER,
+    verdict_passed        INTEGER,
+    failed_gates_json     TEXT,
+    errors_json           TEXT,
+    PRIMARY KEY (run_id, model_id),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS bench_node_enrichment (
+    run_id             TEXT,
+    model_id           TEXT,
+    event_id           TEXT,
+    source             TEXT,
+    schema_valid       INTEGER,
+    refusal_detected   INTEGER,
+    echo_similarity    REAL,
+    entity_sanity      REAL,
+    latency_ms         INTEGER,
+    timeout            INTEGER,
+    parsed_output_json TEXT,
+    PRIMARY KEY (run_id, model_id, event_id),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS bench_node_retrieval (
+    run_id          TEXT,
+    model_id        TEXT,
+    qa_id           TEXT,
+    golden_event_id TEXT,
+    mode            TEXT,
+    rank            INTEGER,
+    mrr             REAL,
+    hit_at_1        INTEGER,
+    hit_at_10       INTEGER,
+    ndcg_at_10      REAL,
+    PRIMARY KEY (run_id, model_id, qa_id, mode),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_retrieval_node ON bench_node_retrieval(golden_event_id, mode);
+CREATE INDEX IF NOT EXISTS idx_enrichment_node ON bench_node_enrichment(event_id);
+CREATE INDEX IF NOT EXISTS idx_runs_started ON bench_runs(started_at_iso);
+"""
+
+
+def connect(db_path: Path | None = None) -> sqlite3.Connection:
+    """Open (creating if needed) the bench results DB with schema + pragmas."""
+    path = db_path or bench_results_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.executescript(_SCHEMA)
+    conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+    conn.commit()
+    return conn

--- a/brain/tests/_bench_fixtures.py
+++ b/brain/tests/_bench_fixtures.py
@@ -1,0 +1,107 @@
+"""Shared JSONL record builders for the bench results-store tests.
+
+Both ``test_bench_results_store`` and ``test_bench_dashboard_export`` ingest the
+same synthetic run; keeping the builders here gives them one source of truth
+without a cross-test-module import (``brain/tests`` is a package, so a sibling
+test module is not importable as a top-level name).
+"""
+
+import json
+
+
+def _write_jsonl(path, records):
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, sort_keys=True))
+            f.write("\n")
+    return path
+
+
+def _manifest(run_id="run-1"):
+    return {
+        "record_type": "run_manifest",
+        "run_id": run_id,
+        "started_at_iso": "2026-05-31T00:00:00+00:00",
+        "host": {"node": "test-host"},
+        "preflight_checks": [],
+        "candidate_models": ["model-a"],
+        "bench_version": "0.2.0",
+        "corpus_version": "corpus-v2",
+        "corpus_content_hash": "sha256:abc",
+        "corpus_schema_version": 18,
+        "eval_qa_version": "eval-qa-v1",
+        "embedding_model": "embed-x",
+        "inference_backend_version": None,
+        "gate_thresholds": {"schema_validity_min": 0.9},
+        "host_baseline": {},
+        "prod_state_at_start": {},
+        "self_consistency_spec": {},
+        "finished_at_iso": None,
+    }
+
+
+def _run_end(run_id="run-1"):
+    return {
+        "record_type": "run_end",
+        "run_id": run_id,
+        "finished_at_iso": "2026-05-31T01:00:00+00:00",
+        "models_completed": ["model-a"],
+        "models_errored": [],
+        "reason": None,
+    }
+
+
+def _model_summary(run_id="run-1", model="model-a"):
+    return {
+        "record_type": "model_summary",
+        "run_id": run_id,
+        "model": {"id": model},
+        "events_attempted": 2,
+        "attempts_total": 2,
+        "gates": {
+            "schema_validity_rate": 1.0,
+            "refusal_rate": 0.0,
+            "echo_similarity_max": 0.1,
+            "latency_p50_ms": 100,
+            "latency_p95_ms": 200,
+            "latency_p99_ms": 300,
+            "self_consistency_mean": None,
+            "self_consistency_min": None,
+            "entity_sanity_mean": 0.9,
+            "main_attempts_count": 2,
+        },
+        "system_peak": {},
+        "tier0_verdict": {"passed": True, "failed_gates": [], "skipped_gates": [], "notes": []},
+        "downstream_proxy": {},
+        "errors": [],
+    }
+
+
+def _model_summary_with_proxy(run_id="run-1", model="model-a"):
+    ms = _model_summary(run_id, model)
+    ms["downstream_proxy"] = {
+        "modes": {"hybrid": {"mrr": 1.0, "hit_at_1": 1.0}},
+        "qa_count": 1,
+        "k": 10,
+        "per_item": [
+            {
+                "hit_at_k": {1: True, 3: True, 5: True, 10: True},
+                "rank": 1,
+                "mrr": 1.0,
+                "ndcg_at_10": 1.0,
+                "qa_id": "qa-001",
+                "golden_event_id": "claude-7",
+                "mode": "hybrid",
+            },
+            {
+                "hit_at_k": {1: False, 3: False, 5: False, 10: False},
+                "rank": None,
+                "mrr": 0.0,
+                "ndcg_at_10": 0.0,
+                "qa_id": "qa-001",
+                "golden_event_id": "claude-7",
+                "mode": "lexical",
+            },
+        ],
+    }
+    return ms

--- a/brain/tests/test_bench_cli.py
+++ b/brain/tests/test_bench_cli.py
@@ -438,6 +438,18 @@ def test_cli_ingest_no_target_errors(capsys):
     assert "run_file" in err or "--all" in err
 
 
+def test_cli_export_dashboard(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from hippo_brain.bench import cli
+    from hippo_brain.bench.results_store import connect
+
+    connect().close()  # create an empty datastore
+    out = tmp_path / "dash.html"
+    assert cli.main(["export-dashboard", "--out", str(out)]) == 0
+    assert out.exists()
+    assert "hippo-bench dashboard" in out.read_text(encoding="utf-8")
+
+
 def test_cli_add_adversarial_claude_reads_agentic_sessions(monkeypatch, tmp_path):
     """A claude-<id> adversarial id must resolve against agentic_sessions
     (harness='claude-code'), NOT the frozen claude_sessions table — matching the

--- a/brain/tests/test_bench_cli.py
+++ b/brain/tests/test_bench_cli.py
@@ -496,3 +496,89 @@ def test_cli_add_adversarial_claude_reads_agentic_sessions(monkeypatch, tmp_path
     assert stored is not None
     assert "CORRECT agentic row" in stored[0]
     assert "WRONG frozen row" not in stored[0]
+
+
+def _write_run_jsonl(path, run_id, *, reason=None, with_manifest=True):
+    """Minimal complete (or aborted) run JSONL for ingest CLI tests."""
+    recs = []
+    if with_manifest:
+        recs.append(
+            {
+                "record_type": "run_manifest",
+                "run_id": run_id,
+                "started_at_iso": "2026-05-31T00:00:00+00:00",
+                "host": {},
+                "candidate_models": [],
+                "corpus_content_hash": "h",
+            }
+        )
+    end = {
+        "record_type": "run_end",
+        "run_id": run_id,
+        "finished_at_iso": "2026-05-31T01:00:00+00:00",
+        "models_completed": [],
+        "models_errored": [],
+    }
+    if reason:
+        end["reason"] = reason
+    recs.append(end)
+    with path.open("w") as f:
+        for r in recs:
+            f.write(json.dumps(r, sort_keys=True) + "\n")
+    return path
+
+
+def test_cli_ingest_multiple_file_args(tmp_path, monkeypatch):
+    """D: the README backfill `hippo-bench ingest run-*.jsonl` expands to several
+    paths; the subparser must accept >1 positional and ingest them all."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from hippo_brain.bench import cli
+    from hippo_brain.bench.results_store import connect
+
+    a = _write_run_jsonl(tmp_path / "run-a.jsonl", "run-a")
+    b = _write_run_jsonl(tmp_path / "run-b.jsonl", "run-b")
+    assert cli.main(["ingest", str(a), str(b)]) == 0
+    conn = connect()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_cli_ingest_all_continues_past_bad_file(tmp_path, monkeypatch, capsys):
+    """A: one file that makes ingest_run raise must not abort the whole --all
+    batch; the good file is still ingested and the command exits 0."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from hippo_brain.bench import cli
+    from hippo_brain.bench.paths import bench_runs_dir
+    from hippo_brain.bench.results_store import connect
+
+    runs = bench_runs_dir(create=True)
+    _write_run_jsonl(runs / "run-good.jsonl", "run-good")
+    # 'run-bad' sorts before 'run-good'; non-UTF-8 bytes raise UnicodeDecodeError
+    # inside ingest_run (which only catches JSONDecodeError).
+    (runs / "run-bad.jsonl").write_bytes(b"\xff\xfe not utf8\n")
+
+    assert cli.main(["ingest", "--all"]) == 0
+    out = capsys.readouterr().out
+    assert "run-good" in out
+    conn = connect()
+    try:
+        assert (
+            conn.execute("SELECT COUNT(*) FROM bench_runs WHERE run_id='run-good'").fetchone()[0]
+            == 1
+        )
+    finally:
+        conn.close()
+
+
+def test_cli_ingest_aborted_run_not_labeled_ingested(tmp_path, monkeypatch, capsys):
+    """C: an aborted run (skipped_aborted) must not print as 'ingested'."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from hippo_brain.bench import cli
+
+    p = _write_run_jsonl(tmp_path / "run-abort.jsonl", "run-abort", reason="preflight_aborted")
+    assert cli.main(["ingest", str(p)]) == 0
+    out = capsys.readouterr().out
+    assert "ingested run_id=run-abort" not in out
+    assert "skipped" in out.lower()

--- a/brain/tests/test_bench_cli.py
+++ b/brain/tests/test_bench_cli.py
@@ -356,6 +356,88 @@ def test_cli_qa_export_worklist(monkeypatch, tmp_path):
     assert code == 0
 
 
+def test_cli_ingest_single_and_all(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from hippo_brain.bench import cli
+    from hippo_brain.bench.paths import bench_runs_dir
+    from hippo_brain.bench.results_store import connect
+
+    # build a minimal valid run JSONL inside the runs dir
+    runs = bench_runs_dir(create=True)
+    jsonl = runs / "run-x.jsonl"
+    import json
+
+    with jsonl.open("w") as f:
+        f.write(
+            json.dumps(
+                {
+                    "record_type": "run_manifest",
+                    "run_id": "run-x",
+                    "started_at_iso": "2026-05-31T00:00:00+00:00",
+                    "host": {},
+                    "candidate_models": [],
+                    "corpus_content_hash": "h",
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        f.write(
+            json.dumps(
+                {
+                    "record_type": "run_end",
+                    "run_id": "run-x",
+                    "finished_at_iso": "2026-05-31T01:00:00+00:00",
+                    "models_completed": [],
+                    "models_errored": [],
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+    assert cli.main(["ingest", str(jsonl)]) == 0
+    capsys.readouterr()  # drop first-ingest output
+
+    conn = connect()
+    try:
+        first_ingested_at = conn.execute(
+            "SELECT ingested_at_ms FROM bench_runs WHERE run_id='run-x'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    # --all is idempotent: run-x already present → skipped, still exit 0.
+    assert cli.main(["ingest", "--all"]) == 0
+    # Verify the skip branch was actually taken — not a silent re-ingest. Because
+    # ingest_run is idempotent via DELETE-then-INSERT, COUNT(*) alone can't tell
+    # a skip from a force re-ingest, so assert the printed status and that the
+    # original ingested_at_ms is untouched (a re-ingest would overwrite it).
+    out = capsys.readouterr().out
+    assert "skipped (already ingested)" in out
+
+    conn = connect()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 1
+        second_ingested_at = conn.execute(
+            "SELECT ingested_at_ms FROM bench_runs WHERE run_id='run-x'"
+        ).fetchone()[0]
+        assert second_ingested_at == first_ingested_at
+    finally:
+        conn.close()
+
+
+def test_cli_ingest_no_target_errors(capsys):
+    """`ingest` with neither a run_file nor --all must fail cleanly with an
+    error message and exit 1 — not raise an uncaught TypeError stack trace."""
+    from hippo_brain.bench import cli
+
+    assert cli.main(["ingest"]) == 1
+    err = capsys.readouterr().out
+    assert "error:" in err
+    assert "run_file" in err or "--all" in err
+
+
 def test_cli_add_adversarial_claude_reads_agentic_sessions(monkeypatch, tmp_path):
     """A claude-<id> adversarial id must resolve against agentic_sessions
     (harness='claude-code'), NOT the frozen claude_sessions table — matching the

--- a/brain/tests/test_bench_cli.py
+++ b/brain/tests/test_bench_cli.py
@@ -572,6 +572,19 @@ def test_cli_ingest_all_continues_past_bad_file(tmp_path, monkeypatch, capsys):
         conn.close()
 
 
+def test_cli_ingest_explicit_bad_file_returns_nonzero(tmp_path, monkeypatch, capsys):
+    """A direct ingest target is scriptable operator input; failures must not be
+    reported as shell success the way best-effort --all backfills are."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from hippo_brain.bench import cli
+
+    missing = tmp_path / "missing.jsonl"
+    assert cli.main(["ingest", str(missing)]) == 1
+    out = capsys.readouterr().out
+    assert "ERROR" in out
+    assert "done:" in out
+
+
 def test_cli_ingest_aborted_run_not_labeled_ingested(tmp_path, monkeypatch, capsys):
     """C: an aborted run (skipped_aborted) must not print as 'ingested'."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))

--- a/brain/tests/test_bench_dashboard_export.py
+++ b/brain/tests/test_bench_dashboard_export.py
@@ -1,0 +1,48 @@
+import json
+
+from hippo_brain.bench.dashboard_export import build_dashboard_html, export_dashboard
+from hippo_brain.bench.results_store import connect, ingest_run
+
+# reuse the JSONL builders shared with the results-store test module
+from tests._bench_fixtures import (
+    _manifest,
+    _model_summary_with_proxy,
+    _run_end,
+    _write_jsonl,
+)
+
+
+def _seed(tmp_path):
+    conn = connect(tmp_path / "bench-results.db")
+    ingest_run(
+        _write_jsonl(tmp_path / "r.jsonl", [_manifest(), _model_summary_with_proxy(), _run_end()]),
+        conn=conn,
+    )
+    return conn
+
+
+def test_build_dashboard_html_embeds_data(tmp_path):
+    conn = _seed(tmp_path)
+    try:
+        html = build_dashboard_html(conn)
+    finally:
+        conn.close()
+    assert "<html" in html.lower()
+    assert 'id="hippo-bench-data"' in html
+    # the embedded JSON blob is parseable and carries the three views
+    blob = html.split('id="hippo-bench-data">', 1)[1].split("</script>", 1)[0]
+    data = json.loads(blob)
+    assert {"leaderboard", "history", "nodes"} <= set(data)
+    assert data["leaderboard"][0]["model_id"] == "model-a"
+    # per-node view carries the scored corpus node with its retrieval rows
+    assert "claude-7" in data["nodes"]
+    assert data["nodes"]["claude-7"]["retrieval"][0]["model_id"] == "model-a"
+
+
+def test_export_dashboard_writes_file(tmp_path):
+    conn = _seed(tmp_path)
+    conn.close()
+    out = tmp_path / "dashboard.html"
+    written = export_dashboard(out, db_path=tmp_path / "bench-results.db")
+    assert written == out
+    assert out.read_text(encoding="utf-8").lower().startswith("<!doctype html")

--- a/brain/tests/test_bench_downstream_proxy.py
+++ b/brain/tests/test_bench_downstream_proxy.py
@@ -242,3 +242,24 @@ def test_ask_synthesis_sample_deterministic() -> None:
 
     assert seen_first == seen_second
     assert len(seen_first) == 7
+
+
+def test_per_item_carries_golden_event_id():
+    from hippo_brain.bench.downstream_proxy import run_downstream_proxy_pass
+
+    qa_items = [{"qa_id": "qa-001", "question": "q?", "golden_event_id": "claude-7"}]
+
+    def fake_search(conn, query, vec, *, mode, limit):
+        # Return a single result whose source id matches the golden.
+        return [{"event_id": "claude-7"}]
+
+    out = run_downstream_proxy_pass(
+        conn=None,
+        qa_items=qa_items,
+        embedding_fn=lambda q: [0.0, 1.0],
+        modes=("hybrid",),
+        search_fn=fake_search,
+    )
+    assert out["per_item"][0]["golden_event_id"] == "claude-7"
+    assert out["per_item"][0]["qa_id"] == "qa-001"
+    assert out["per_item"][0]["mode"] == "hybrid"

--- a/brain/tests/test_bench_orchestrate.py
+++ b/brain/tests/test_bench_orchestrate.py
@@ -416,6 +416,37 @@ def test_inference_backend_version_none_on_unknown_backend(monkeypatch):
     run.assert_not_called()
 
 
+def test_safe_ingest_skips_dry_run(tmp_path, monkeypatch):
+    import hippo_brain.bench.orchestrate as orch
+
+    called = []
+    monkeypatch.setattr(orch, "ingest_run", lambda p: called.append(p), raising=False)
+    orch._safe_ingest(tmp_path / "run.jsonl", dry_run=True)
+    assert called == []  # dry runs are not ingested
+
+
+def test_safe_ingest_calls_ingest_for_real_run(tmp_path, monkeypatch):
+    import hippo_brain.bench.orchestrate as orch
+
+    called = []
+    monkeypatch.setattr(orch, "ingest_run", lambda p: called.append(p), raising=False)
+    out = tmp_path / "run.jsonl"
+    orch._safe_ingest(out, dry_run=False)
+    assert called == [out]
+
+
+def test_safe_ingest_swallows_errors(tmp_path, monkeypatch):
+    import hippo_brain.bench.orchestrate as orch
+
+    def boom(_p):
+        raise RuntimeError("datastore exploded")
+
+    monkeypatch.setattr(orch, "ingest_run", boom, raising=False)
+    # Must not raise even though ingest blows up — a reporting concern never
+    # fails the run (AP-1).
+    orch._safe_ingest(tmp_path / "run.jsonl", dry_run=False)
+
+
 def test_orchestrate_writes_computed_gates_instead_of_hardcoded_pass(stub_corpus, tmp_path):
     sqlite, manifest = stub_corpus
     out = tmp_path / "run.jsonl"

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -1,7 +1,28 @@
 from hippo_brain.bench.paths import bench_results_db_path
+from hippo_brain.bench.results_store import SCHEMA_VERSION, connect
 
 
 def test_bench_results_db_path_under_xdg(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     p = bench_results_db_path()
     assert p == tmp_path / "hippo-bench" / "bench-results.db"
+
+
+def test_connect_creates_schema(tmp_path):
+    db = tmp_path / "bench-results.db"
+    conn = connect(db)
+    try:
+        names = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+        assert {
+            "bench_runs",
+            "bench_models",
+            "bench_node_enrichment",
+            "bench_node_retrieval",
+        } <= names
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    finally:
+        conn.close()

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -1,5 +1,65 @@
+import json
+
 from hippo_brain.bench.paths import bench_results_db_path
 from hippo_brain.bench.results_store import SCHEMA_VERSION, connect
+
+
+def _write_jsonl(path, records):
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, sort_keys=True))
+            f.write("\n")
+    return path
+
+
+def _manifest(run_id="run-1"):
+    return {
+        "record_type": "run_manifest",
+        "run_id": run_id,
+        "started_at_iso": "2026-05-31T00:00:00+00:00",
+        "host": {"node": "test-host"},
+        "preflight_checks": [],
+        "candidate_models": ["model-a"],
+        "bench_version": "0.2.0",
+        "corpus_version": "corpus-v2",
+        "corpus_content_hash": "sha256:abc",
+        "corpus_schema_version": 18,
+        "eval_qa_version": "eval-qa-v1",
+        "embedding_model": "embed-x",
+        "inference_backend_version": None,
+        "gate_thresholds": {"schema_validity_min": 0.9},
+        "host_baseline": {},
+        "prod_state_at_start": {},
+        "self_consistency_spec": {},
+        "finished_at_iso": None,
+    }
+
+
+def _run_end(run_id="run-1"):
+    return {
+        "record_type": "run_end",
+        "run_id": run_id,
+        "finished_at_iso": "2026-05-31T01:00:00+00:00",
+        "models_completed": ["model-a"],
+        "models_errored": [],
+        "reason": None,
+    }
+
+
+def test_ingest_run_writes_bench_runs(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl", [_manifest(), _run_end()])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn, now_ms=123)
+        row = conn.execute("SELECT * FROM bench_runs WHERE run_id='run-1'").fetchone()
+        assert row["corpus_content_hash"] == "sha256:abc"
+        assert row["finished_at_iso"] == "2026-05-31T01:00:00+00:00"
+        assert json.loads(row["models_completed_json"]) == ["model-a"]
+        assert row["ingested_at_ms"] == 123
+    finally:
+        conn.close()
 
 
 def test_bench_results_db_path_under_xdg(tmp_path, monkeypatch):

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -698,3 +698,62 @@ def test_malformed_per_item_is_tolerated(tmp_path):
         assert out_mixed.retrieval_rows == 1  # only the valid entry
     finally:
         conn.close()
+
+
+def test_retrieval_entry_missing_qa_id_or_mode_is_skipped(tmp_path):
+    """A per_item entry missing qa_id or mode would write NULL composite-PK
+    columns that can't dedupe under INSERT OR REPLACE — skip it, keep valids."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    ms = _model_summary_with_proxy("run-1", model="m1")
+    ms["downstream_proxy"]["per_item"] = [
+        {
+            "hit_at_k": {1: True},
+            "mrr": 1.0,
+            "golden_event_id": "claude-7",
+            "mode": "hybrid",
+        },  # no qa_id
+        {
+            "hit_at_k": {1: True},
+            "mrr": 1.0,
+            "qa_id": "qa-001",
+            "golden_event_id": "claude-7",
+        },  # no mode
+        {
+            "hit_at_k": {1: True, 10: True},
+            "rank": 1,
+            "mrr": 1.0,
+            "ndcg_at_10": 1.0,
+            "qa_id": "qa-002",
+            "golden_event_id": "shell-9",
+            "mode": "hybrid",
+        },
+    ]
+    jsonl = _write_jsonl(tmp_path / "r.jsonl", [_manifest("run-1"), ms, _run_end("run-1")])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out = ingest_run(jsonl, conn=conn)
+        assert out.inserted
+        assert out.retrieval_rows == 1  # only the qa-002 entry with both keys
+        rows = conn.execute("SELECT qa_id FROM bench_node_retrieval").fetchall()
+        assert [r["qa_id"] for r in rows] == ["qa-002"]
+    finally:
+        conn.close()
+
+
+def test_enrichment_attempt_missing_event_id_is_skipped(tmp_path):
+    """An attempt with no event_id would write a NULL composite-PK row
+    (run_id, model_id, event_id) that can't dedupe — skip the malformed attempt."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    bad = _attempt(event_id="claude-7")
+    bad["event"] = {"source": "claude"}  # event_id missing
+    good = _attempt(event_id="shell-9")
+    jsonl = _write_jsonl(tmp_path / "r.jsonl", [_manifest("run-1"), bad, good, _run_end("run-1")])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        rows = conn.execute("SELECT event_id FROM bench_node_enrichment").fetchall()
+        assert [r["event_id"] for r in rows] == ["shell-9"]  # bad attempt skipped
+    finally:
+        conn.close()

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -323,6 +323,78 @@ def test_aborted_run_not_ingested(tmp_path):
         conn.close()
 
 
+def test_incomplete_run_removed_when_later_aborted(tmp_path):
+    """An in-flight run can be ingested before run_end exists; if the final JSONL
+    later says preflight_aborted, that stale partial row must be removed."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    aborted_end = {
+        "record_type": "run_end",
+        "run_id": "run-abort",
+        "finished_at_iso": "2026-05-31T00:05:00+00:00",
+        "models_completed": [],
+        "models_errored": [],
+        "reason": "preflight_aborted",
+    }
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        first = ingest_run(
+            _write_jsonl(
+                tmp_path / "partial.jsonl", [_manifest("run-abort"), _attempt("run-abort")]
+            ),
+            conn=conn,
+        )
+        assert first.inserted
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_enrichment").fetchone()[0] == 1
+
+        second = ingest_run(
+            _write_jsonl(tmp_path / "aborted.jsonl", [_manifest("run-abort"), aborted_end]),
+            conn=conn,
+        )
+
+        assert second.skipped_aborted is True
+        assert second.inserted is False
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_enrichment").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_incomplete_run_removed_when_later_no_models(tmp_path):
+    """A completed run with no model rows is intentionally skipped and should
+    clear a previously ingested partial row for the same run_id."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    no_models_end = {
+        "record_type": "run_end",
+        "run_id": "run-empty",
+        "finished_at_iso": "2026-05-31T00:05:00+00:00",
+        "models_completed": [],
+        "models_errored": [],
+        "reason": "no_models",
+    }
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(
+            _write_jsonl(
+                tmp_path / "partial.jsonl", [_manifest("run-empty"), _attempt("run-empty")]
+            ),
+            conn=conn,
+        )
+
+        second = ingest_run(
+            _write_jsonl(tmp_path / "no-models.jsonl", [_manifest("run-empty"), no_models_end]),
+            conn=conn,
+        )
+
+        assert second.skipped_aborted is True
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_enrichment").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
 def test_ingest_manifest_without_run_id_returns_none_gracefully(tmp_path):
     """B: a run_manifest lacking run_id must be handled like a missing manifest
     (no KeyError crash) — the CLI ingest path has no try/except around it."""

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -542,3 +542,70 @@ def test_all_node_details_groups_by_node(tmp_path):
         assert nodes["claude-7"]["enrichment"] == []
     finally:
         conn.close()
+
+
+def test_ingest_tolerates_null_hit_at_k(tmp_path):
+    """Ingest is malformed-tolerant: a per_item with an explicit null hit_at_k
+    (key present, value null) must score as "no hit", not raise AttributeError
+    and abort the file. `item.get("hit_at_k", {})` returns None here — the {}
+    default only applies to an ABSENT key — so _hit must guard non-dicts."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    ms = _model_summary_with_proxy("run-1")
+    ms["downstream_proxy"]["per_item"] = [
+        {
+            "hit_at_k": None,  # explicit null, not absent
+            "rank": None,
+            "mrr": 0.0,
+            "ndcg_at_10": 0.0,
+            "qa_id": "qa-001",
+            "golden_event_id": "claude-7",
+            "mode": "hybrid",
+        }
+    ]
+    jsonl = _write_jsonl(tmp_path / "r.jsonl", [_manifest("run-1"), ms, _run_end("run-1")])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out = ingest_run(jsonl, conn=conn)
+        assert out.inserted
+        assert out.retrieval_rows == 1
+        row = conn.execute(
+            "SELECT hit_at_1, hit_at_10 FROM bench_node_retrieval WHERE qa_id='qa-001'"
+        ).fetchone()
+        assert (row["hit_at_1"], row["hit_at_10"]) == (0, 0)
+    finally:
+        conn.close()
+
+
+def test_node_detail_orders_best_score_first(tmp_path):
+    """Per-node view is "best model per corpus member": a stronger model in an
+    OLDER run must sort above a weaker model in a NEWER run — score, not recency,
+    leads. All runs are kept so the regression stays visible."""
+    from hippo_brain.bench.results_store import all_node_details, connect, ingest_run, node_detail
+
+    # run-old: strong score (mrr 1.0). run-new: later timestamp, weaker (mrr 0.2).
+    old = [
+        _manifest("run-old"),
+        _model_summary_with_proxy("run-old", model="strong"),
+        _run_end("run-old"),
+    ]
+    ms_new = _model_summary_with_proxy("run-new", model="weak")
+    ms_new["downstream_proxy"]["per_item"][0]["mrr"] = 0.2
+    m_new = _manifest("run-new")
+    m_new["started_at_iso"] = "2026-05-31T09:00:00+00:00"
+    new = [m_new, ms_new, _run_end("run-new")]
+
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(_write_jsonl(tmp_path / "old.jsonl", old), conn=conn)
+        ingest_run(_write_jsonl(tmp_path / "new.jsonl", new), conn=conn)
+
+        detail = node_detail(conn, "claude-7", mode="hybrid")
+        assert [d["model_id"] for d in detail["retrieval"]] == ["strong", "weak"]
+        # both runs retained — regression not hidden behind "latest"
+        assert {d["run_id"] for d in detail["retrieval"]} == {"run-old", "run-new"}
+
+        nodes = all_node_details(conn, mode="hybrid")
+        assert [d["model_id"] for d in nodes["claude-7"]["retrieval"]] == ["strong", "weak"]
+    finally:
+        conn.close()

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -46,6 +46,50 @@ def _run_end(run_id="run-1"):
     }
 
 
+def _model_summary(run_id="run-1", model="model-a"):
+    return {
+        "record_type": "model_summary",
+        "run_id": run_id,
+        "model": {"id": model},
+        "events_attempted": 2,
+        "attempts_total": 2,
+        "gates": {
+            "schema_validity_rate": 1.0,
+            "refusal_rate": 0.0,
+            "echo_similarity_max": 0.1,
+            "latency_p50_ms": 100,
+            "latency_p95_ms": 200,
+            "latency_p99_ms": 300,
+            "self_consistency_mean": None,
+            "self_consistency_min": None,
+            "entity_sanity_mean": 0.9,
+            "main_attempts_count": 2,
+        },
+        "system_peak": {},
+        "tier0_verdict": {"passed": True, "failed_gates": [], "skipped_gates": [], "notes": []},
+        "downstream_proxy": {},
+        "errors": [],
+    }
+
+
+def test_ingest_models(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl", [_manifest(), _model_summary(), _run_end()])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        row = conn.execute(
+            "SELECT * FROM bench_models WHERE run_id='run-1' AND model_id='model-a'"
+        ).fetchone()
+        assert row["schema_validity_rate"] == 1.0
+        assert row["latency_p95_ms"] == 200
+        assert row["verdict_passed"] == 1
+        assert row["self_consistency_mean"] is None
+    finally:
+        conn.close()
+
+
 def test_ingest_run_writes_bench_runs(tmp_path):
     from hippo_brain.bench.results_store import connect, ingest_run
 

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -176,9 +176,9 @@ def test_connect_refuses_newer_schema(tmp_path):
 
     from hippo_brain.bench.results_store import connect
 
+    # An EMPTY DB (no tables) stamped to a future version: connect() must refuse
+    # BEFORE running any DDL, so no bench_* tables get created on the way out.
     db = tmp_path / "bench-results.db"
-    connect(db).close()  # fresh DB at SCHEMA_VERSION
-    # Simulate a future binary bumping the on-disk version.
     raw = sqlite3.connect(db)
     raw.execute(f"PRAGMA user_version={SCHEMA_VERSION + 5}")
     raw.commit()
@@ -186,9 +186,14 @@ def test_connect_refuses_newer_schema(tmp_path):
 
     with pytest.raises(RuntimeError, match="newer than this binary"):
         connect(db)
-    # The on-disk version must be untouched by the refused open.
+
     raw = sqlite3.connect(db)
+    # On-disk version untouched, and the schema check ran before any CREATE.
     assert raw.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION + 5
+    tables = {
+        r[0] for r in raw.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    }
+    assert "bench_runs" not in tables, "DDL must not run when a newer DB is refused"
     raw.close()
 
 

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -609,3 +609,92 @@ def test_node_detail_orders_best_score_first(tmp_path):
         assert [d["model_id"] for d in nodes["claude-7"]["retrieval"]] == ["strong", "weak"]
     finally:
         conn.close()
+
+
+def test_non_object_jsonl_line_is_malformed_not_a_crash(tmp_path):
+    """A valid-JSON line that is not an object (list/string/number) must be
+    counted malformed and skipped — every consumer does record.get(), so a
+    non-dict record would otherwise raise AttributeError and abort the file."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    path = tmp_path / "run-1.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        f.write(json.dumps([1, 2, 3]) + "\n")  # JSON array, not an object
+        f.write(json.dumps("a bare string") + "\n")  # JSON string
+        f.write(json.dumps(_manifest("run-1")) + "\n")
+        f.write(json.dumps(_model_summary_with_proxy("run-1")) + "\n")
+        f.write(json.dumps(_run_end("run-1")) + "\n")
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out = ingest_run(path, conn=conn)
+        assert out.inserted
+        assert out.malformed_lines == 2  # the array + the string
+        assert out.retrieval_rows == 2  # the well-formed model_summary still ingested
+    finally:
+        conn.close()
+
+
+def test_model_summary_missing_model_id_is_skipped(tmp_path):
+    """A model_summary without model.id would write a NULL composite-PK row;
+    SQLite permits multiple NULL PKs so INSERT OR REPLACE can't dedupe them.
+    Skip the malformed summary (both the model row and its retrieval rows)."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    ms = _model_summary_with_proxy("run-1")
+    ms["model"] = {}  # no id
+    jsonl = _write_jsonl(tmp_path / "r.jsonl", [_manifest("run-1"), ms, _run_end("run-1")])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out = ingest_run(jsonl, conn=conn)
+        assert out.inserted
+        assert out.models == 0
+        assert out.retrieval_rows == 0
+        assert conn.execute("SELECT COUNT(*) FROM bench_models").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_retrieval").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_malformed_per_item_is_tolerated(tmp_path):
+    """downstream_proxy.per_item that is null, a non-list, or contains non-dict
+    entries must not crash ingest; well-formed entries alongside still land."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    # null per_item → no retrieval rows, no crash
+    ms_null = _model_summary_with_proxy("run-null", model="m1")
+    ms_null["downstream_proxy"]["per_item"] = None
+    # mixed: one bogus non-dict entry + one valid hybrid entry
+    ms_mixed = _model_summary_with_proxy("run-mixed", model="m2")
+    ms_mixed["downstream_proxy"]["per_item"] = [
+        "not-a-dict",
+        {
+            "hit_at_k": {1: True, 10: True},
+            "rank": 1,
+            "mrr": 1.0,
+            "ndcg_at_10": 1.0,
+            "qa_id": "qa-001",
+            "golden_event_id": "claude-7",
+            "mode": "hybrid",
+        },
+    ]
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out_null = ingest_run(
+            _write_jsonl(
+                tmp_path / "null.jsonl", [_manifest("run-null"), ms_null, _run_end("run-null")]
+            ),
+            conn=conn,
+        )
+        assert out_null.inserted
+        assert out_null.retrieval_rows == 0
+
+        out_mixed = ingest_run(
+            _write_jsonl(
+                tmp_path / "mixed.jsonl", [_manifest("run-mixed"), ms_mixed, _run_end("run-mixed")]
+            ),
+            conn=conn,
+        )
+        assert out_mixed.inserted
+        assert out_mixed.retrieval_rows == 1  # only the valid entry
+    finally:
+        conn.close()

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -72,6 +72,79 @@ def _model_summary(run_id="run-1", model="model-a"):
     }
 
 
+def _attempt(
+    run_id="run-1",
+    model="model-a",
+    event_id="claude-7",
+    purpose="main",
+    entity_rates=None,
+    parsed=None,
+):
+    return {
+        "record_type": "attempt",
+        "run_id": run_id,
+        "model": {"id": model},
+        "event": {"event_id": event_id, "source": event_id.split("-")[0], "content_hash": "h"},
+        "attempt_idx": 0,
+        "purpose": purpose,
+        "timestamps": {"total_ms": 150},
+        "raw_output": "{}",
+        "parsed_output": parsed if parsed is not None else {"summary": "s"},
+        "gates": {
+            "schema_valid": True,
+            "refusal_detected": False,
+            "echo_similarity": 0.2,
+            "entity_type_sanity": entity_rates
+            if entity_rates is not None
+            else {"tool": 1.0, "file": 0.5},
+        },
+        "system_snapshot": {},
+        "timeout": False,
+    }
+
+
+def test_ingest_enrichment_main_only(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    records = [
+        _manifest(),
+        _attempt(event_id="claude-7"),
+        _attempt(event_id="shell-9", purpose="self_consistency"),  # excluded
+        _run_end(),
+    ]
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl", records)
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        rows = conn.execute("SELECT * FROM bench_node_enrichment WHERE run_id='run-1'").fetchall()
+        assert len(rows) == 1  # self_consistency attempt excluded
+        row = rows[0]
+        assert row["event_id"] == "claude-7"
+        assert row["source"] == "claude"
+        assert row["schema_valid"] == 1
+        assert abs(row["entity_sanity"] - 0.75) < 1e-9  # mean(1.0, 0.5)
+        assert row["latency_ms"] == 150
+        assert json.loads(row["parsed_output_json"]) == {"summary": "s"}
+    finally:
+        conn.close()
+
+
+def test_ingest_enrichment_empty_entity_rates_is_null(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(
+        tmp_path / "run-1.jsonl",
+        [_manifest(), _attempt(entity_rates={}), _run_end()],
+    )
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        row = conn.execute("SELECT entity_sanity FROM bench_node_enrichment").fetchone()
+        assert row["entity_sanity"] is None
+    finally:
+        conn.close()
+
+
 def test_ingest_models(tmp_path):
     from hippo_brain.bench.results_store import connect, ingest_run
 

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -3,73 +3,13 @@ import json
 from hippo_brain.bench.paths import bench_results_db_path
 from hippo_brain.bench.results_store import SCHEMA_VERSION, connect
 
-
-def _write_jsonl(path, records):
-    with path.open("w", encoding="utf-8") as f:
-        for r in records:
-            f.write(json.dumps(r, sort_keys=True))
-            f.write("\n")
-    return path
-
-
-def _manifest(run_id="run-1"):
-    return {
-        "record_type": "run_manifest",
-        "run_id": run_id,
-        "started_at_iso": "2026-05-31T00:00:00+00:00",
-        "host": {"node": "test-host"},
-        "preflight_checks": [],
-        "candidate_models": ["model-a"],
-        "bench_version": "0.2.0",
-        "corpus_version": "corpus-v2",
-        "corpus_content_hash": "sha256:abc",
-        "corpus_schema_version": 18,
-        "eval_qa_version": "eval-qa-v1",
-        "embedding_model": "embed-x",
-        "inference_backend_version": None,
-        "gate_thresholds": {"schema_validity_min": 0.9},
-        "host_baseline": {},
-        "prod_state_at_start": {},
-        "self_consistency_spec": {},
-        "finished_at_iso": None,
-    }
-
-
-def _run_end(run_id="run-1"):
-    return {
-        "record_type": "run_end",
-        "run_id": run_id,
-        "finished_at_iso": "2026-05-31T01:00:00+00:00",
-        "models_completed": ["model-a"],
-        "models_errored": [],
-        "reason": None,
-    }
-
-
-def _model_summary(run_id="run-1", model="model-a"):
-    return {
-        "record_type": "model_summary",
-        "run_id": run_id,
-        "model": {"id": model},
-        "events_attempted": 2,
-        "attempts_total": 2,
-        "gates": {
-            "schema_validity_rate": 1.0,
-            "refusal_rate": 0.0,
-            "echo_similarity_max": 0.1,
-            "latency_p50_ms": 100,
-            "latency_p95_ms": 200,
-            "latency_p99_ms": 300,
-            "self_consistency_mean": None,
-            "self_consistency_min": None,
-            "entity_sanity_mean": 0.9,
-            "main_attempts_count": 2,
-        },
-        "system_peak": {},
-        "tier0_verdict": {"passed": True, "failed_gates": [], "skipped_gates": [], "notes": []},
-        "downstream_proxy": {},
-        "errors": [],
-    }
+from tests._bench_fixtures import (
+    _manifest,
+    _model_summary,
+    _model_summary_with_proxy,
+    _run_end,
+    _write_jsonl,
+)
 
 
 def _attempt(
@@ -101,36 +41,6 @@ def _attempt(
         "system_snapshot": {},
         "timeout": False,
     }
-
-
-def _model_summary_with_proxy(run_id="run-1", model="model-a"):
-    ms = _model_summary(run_id, model)
-    ms["downstream_proxy"] = {
-        "modes": {"hybrid": {"mrr": 1.0, "hit_at_1": 1.0}},
-        "qa_count": 1,
-        "k": 10,
-        "per_item": [
-            {
-                "hit_at_k": {1: True, 3: True, 5: True, 10: True},
-                "rank": 1,
-                "mrr": 1.0,
-                "ndcg_at_10": 1.0,
-                "qa_id": "qa-001",
-                "golden_event_id": "claude-7",
-                "mode": "hybrid",
-            },
-            {
-                "hit_at_k": {1: False, 3: False, 5: False, 10: False},
-                "rank": None,
-                "mrr": 0.0,
-                "ndcg_at_10": 0.0,
-                "qa_id": "qa-001",
-                "golden_event_id": "claude-7",
-                "mode": "lexical",
-            },
-        ],
-    }
-    return ms
 
 
 def test_ingest_retrieval(tmp_path):

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -321,3 +321,152 @@ def test_aborted_run_not_ingested(tmp_path):
         assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 0
     finally:
         conn.close()
+
+
+def test_ingest_manifest_without_run_id_returns_none_gracefully(tmp_path):
+    """B: a run_manifest lacking run_id must be handled like a missing manifest
+    (no KeyError crash) — the CLI ingest path has no try/except around it."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    m = _manifest()
+    del m["run_id"]
+    jsonl = _write_jsonl(tmp_path / "norunid.jsonl", [m, _run_end()])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        res = ingest_run(jsonl, conn=conn)  # must NOT raise
+        assert res.run_id is None
+        assert res.inserted is False
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_ingest_models_replaces_duplicate_model_id(tmp_path):
+    """F: two model_summary records with the same model_id in one run (e.g.
+    `--models m1,m1`) must not raise IntegrityError on the (run_id, model_id) PK."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    records = [
+        _manifest("run-x"),
+        _model_summary("run-x", "m1"),
+        _model_summary("run-x", "m1"),
+        _run_end("run-x"),
+    ]
+    jsonl = _write_jsonl(tmp_path / "dup.jsonl", records)
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        res = ingest_run(jsonl, conn=conn)  # must NOT raise IntegrityError
+        assert res.inserted
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM bench_models WHERE run_id='run-x' AND model_id='m1'"
+            ).fetchone()[0]
+            == 1
+        )
+    finally:
+        conn.close()
+
+
+def test_incomplete_run_reingested_when_completed(tmp_path):
+    """G: a partial run ingested while in-flight (no run_end) must be re-ingestable
+    once it completes, WITHOUT --force — otherwise its finish + retrieval rows are
+    lost behind the skipped_existing guard."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    partial = [_manifest("run-x")]  # no run_end, no model_summary → incomplete
+    complete = [_manifest("run-x"), _model_summary_with_proxy("run-x"), _run_end("run-x")]
+
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        r1 = ingest_run(_write_jsonl(tmp_path / "p.jsonl", partial), conn=conn)
+        assert r1.inserted
+        assert (
+            conn.execute("SELECT finished_at_iso FROM bench_runs WHERE run_id='run-x'").fetchone()[
+                0
+            ]
+            is None
+        )
+
+        r2 = ingest_run(_write_jsonl(tmp_path / "c.jsonl", complete), conn=conn)  # no force
+        assert r2.inserted, "an incomplete run must re-ingest when it completes, without --force"
+        assert (
+            conn.execute("SELECT finished_at_iso FROM bench_runs WHERE run_id='run-x'").fetchone()[
+                0
+            ]
+            is not None
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM bench_node_retrieval WHERE run_id='run-x'"
+            ).fetchone()[0]
+            == 2
+        )
+    finally:
+        conn.close()
+
+
+def test_enrichment_missing_parsed_output_is_sql_null(tmp_path):
+    """E: an attempt with no parsed_output must store SQL NULL, not the 4-char
+    TEXT string 'null' that json.dumps(None) produces."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    attempt = {
+        "record_type": "attempt",
+        "run_id": "run-x",
+        "model": {"id": "m1"},
+        "event": {"event_id": "claude-7", "source": "claude", "content_hash": "h"},
+        "attempt_idx": 0,
+        "purpose": "main",
+        "timestamps": {"total_ms": 10},
+        "raw_output": "",
+        "parsed_output": None,
+        "gates": {
+            "schema_valid": False,
+            "refusal_detected": False,
+            "echo_similarity": 0.0,
+            "entity_type_sanity": {},
+        },
+        "system_snapshot": {},
+        "timeout": True,
+    }
+    jsonl = _write_jsonl(tmp_path / "np.jsonl", [_manifest("run-x"), attempt, _run_end("run-x")])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        val = conn.execute(
+            "SELECT parsed_output_json FROM bench_node_enrichment WHERE event_id='claude-7'"
+        ).fetchone()[0]
+        assert val is None, "missing parsed_output must store SQL NULL, not the string 'null'"
+    finally:
+        conn.close()
+
+
+def test_all_node_details_groups_by_node(tmp_path):
+    """I: bulk per-node fetch (2 queries total) groups retrieval + enrichment by
+    node, replacing the per-node node_detail N+1 in the dashboard exporter."""
+    from hippo_brain.bench.results_store import all_node_details, connect, ingest_run
+
+    ms = _model_summary_with_proxy("run-1")  # has a hybrid per_item for claude-7
+    ms["downstream_proxy"]["per_item"].append(
+        {
+            "hit_at_k": {1: False, 10: True},
+            "rank": 4,
+            "mrr": 0.25,
+            "ndcg_at_10": 0.5,
+            "qa_id": "qa-002",
+            "golden_event_id": "shell-9",
+            "mode": "hybrid",
+        }
+    )
+    jsonl = _write_jsonl(tmp_path / "r.jsonl", [_manifest("run-1"), ms, _run_end("run-1")])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        nodes = all_node_details(conn, mode="hybrid")
+        assert set(nodes) == {"claude-7", "shell-9"}
+        assert nodes["claude-7"]["retrieval"][0]["model_id"] == "model-a"
+        assert nodes["shell-9"]["retrieval"][0]["mrr"] == 0.25
+        # shape matches node_detail: each node has retrieval + enrichment lists
+        assert nodes["claude-7"]["enrichment"] == []
+    finally:
+        conn.close()

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -103,6 +103,58 @@ def _attempt(
     }
 
 
+def _model_summary_with_proxy(run_id="run-1", model="model-a"):
+    ms = _model_summary(run_id, model)
+    ms["downstream_proxy"] = {
+        "modes": {"hybrid": {"mrr": 1.0, "hit_at_1": 1.0}},
+        "qa_count": 1,
+        "k": 10,
+        "per_item": [
+            {
+                "hit_at_k": {1: True, 3: True, 5: True, 10: True},
+                "rank": 1,
+                "mrr": 1.0,
+                "ndcg_at_10": 1.0,
+                "qa_id": "qa-001",
+                "golden_event_id": "claude-7",
+                "mode": "hybrid",
+            },
+            {
+                "hit_at_k": {1: False, 3: False, 5: False, 10: False},
+                "rank": None,
+                "mrr": 0.0,
+                "ndcg_at_10": 0.0,
+                "qa_id": "qa-001",
+                "golden_event_id": "claude-7",
+                "mode": "lexical",
+            },
+        ],
+    }
+    return ms
+
+
+def test_ingest_retrieval(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(
+        tmp_path / "run-1.jsonl", [_manifest(), _model_summary_with_proxy(), _run_end()]
+    )
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        hybrid = conn.execute("SELECT * FROM bench_node_retrieval WHERE mode='hybrid'").fetchone()
+        assert hybrid["golden_event_id"] == "claude-7"
+        assert hybrid["qa_id"] == "qa-001"
+        assert hybrid["rank"] == 1
+        assert hybrid["hit_at_1"] == 1
+        assert hybrid["hit_at_10"] == 1
+        lexical = conn.execute("SELECT * FROM bench_node_retrieval WHERE mode='lexical'").fetchone()
+        assert lexical["rank"] is None
+        assert lexical["hit_at_1"] == 0
+    finally:
+        conn.close()
+
+
 def test_ingest_enrichment_main_only(tmp_path):
     from hippo_brain.bench.results_store import connect, ingest_run
 

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -167,6 +167,45 @@ def test_connect_creates_schema(tmp_path):
         conn.close()
 
 
+def test_connect_refuses_newer_schema(tmp_path):
+    """connect() must not silently downgrade a DB written by a newer binary:
+    a user_version above SCHEMA_VERSION raises rather than restamping to v1."""
+    import sqlite3
+
+    import pytest
+
+    from hippo_brain.bench.results_store import connect
+
+    db = tmp_path / "bench-results.db"
+    connect(db).close()  # fresh DB at SCHEMA_VERSION
+    # Simulate a future binary bumping the on-disk version.
+    raw = sqlite3.connect(db)
+    raw.execute(f"PRAGMA user_version={SCHEMA_VERSION + 5}")
+    raw.commit()
+    raw.close()
+
+    with pytest.raises(RuntimeError, match="newer than this binary"):
+        connect(db)
+    # The on-disk version must be untouched by the refused open.
+    raw = sqlite3.connect(db)
+    assert raw.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION + 5
+    raw.close()
+
+
+def test_connect_reopen_preserves_version(tmp_path):
+    """Re-opening an existing same-version DB is a no-op on user_version (no
+    spurious rewrite) and stays usable."""
+    from hippo_brain.bench.results_store import connect
+
+    db = tmp_path / "bench-results.db"
+    connect(db).close()
+    conn = connect(db)
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    finally:
+        conn.close()
+
+
 def test_reingest_same_run_is_skipped(tmp_path):
     from hippo_brain.bench.results_store import connect, ingest_run
 

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -275,3 +275,49 @@ def test_malformed_line_tolerated(tmp_path):
         assert out.malformed_lines == 1
     finally:
         conn.close()
+
+
+def test_leaderboard_uses_latest_run_with_retrieval(tmp_path):
+    """I1: when the newest run has no retrieval rows for the mode, the
+    leaderboard falls back to the latest run that DOES — not a blank table."""
+    from hippo_brain.bench.results_store import connect, ingest_run, leaderboard_latest
+
+    older = [_manifest("run-old"), _model_summary_with_proxy("run-old"), _run_end("run-old")]
+    # Newer run: later timestamp, plain model_summary (empty downstream_proxy) →
+    # produces NO retrieval rows for any mode.
+    m_new = _manifest("run-new")
+    m_new["started_at_iso"] = "2026-05-31T09:00:00+00:00"
+    newer = [m_new, _model_summary("run-new"), _run_end("run-new")]
+
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(_write_jsonl(tmp_path / "old.jsonl", older), conn=conn)
+        ingest_run(_write_jsonl(tmp_path / "new.jsonl", newer), conn=conn)
+        lb = leaderboard_latest(conn, mode="hybrid")
+        assert lb, "leaderboard must not blank when an older run has retrieval data"
+        assert lb[0]["run_id"] == "run-old"
+    finally:
+        conn.close()
+
+
+def test_aborted_run_not_ingested(tmp_path):
+    """I2: a preflight-aborted run (run_end carries a reason) writes no rows."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    aborted_end = {
+        "record_type": "run_end",
+        "run_id": "run-abort",
+        "finished_at_iso": "2026-05-31T00:05:00+00:00",
+        "models_completed": [],
+        "models_errored": [],
+        "reason": "preflight_aborted",
+    }
+    jsonl = _write_jsonl(tmp_path / "abort.jsonl", [_manifest("run-abort"), aborted_end])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        res = ingest_run(jsonl, conn=conn)
+        assert res.skipped_aborted is True
+        assert res.inserted is False
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 0
+    finally:
+        conn.close()

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -307,6 +307,49 @@ def test_partial_jsonl_no_run_end(tmp_path):
         conn.close()
 
 
+def test_query_helpers(tmp_path):
+    from hippo_brain.bench.results_store import (
+        connect,
+        ingest_run,
+        leaderboard_latest,
+        node_detail,
+        run_history,
+    )
+
+    # run-1 (older) then run-2 (newer) — leaderboard headline must use run-2.
+    # Each run carries a main attempt on claude-7 so node_detail has enrichment rows.
+    r1 = [
+        _manifest("run-1"),
+        _model_summary_with_proxy("run-1"),
+        _attempt("run-1", event_id="claude-7"),
+        _run_end("run-1"),
+    ]
+    ms2 = _model_summary_with_proxy("run-2")
+    ms2["downstream_proxy"]["per_item"][0]["mrr"] = 0.5  # different score in newer run
+    m2 = _manifest("run-2")
+    m2["started_at_iso"] = "2026-05-31T05:00:00+00:00"
+    r2 = [m2, ms2, _attempt("run-2", event_id="claude-7"), _run_end("run-2")]
+
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(_write_jsonl(tmp_path / "r1.jsonl", r1), conn=conn)
+        ingest_run(_write_jsonl(tmp_path / "r2.jsonl", r2), conn=conn)
+
+        lb = leaderboard_latest(conn, mode="hybrid")
+        # headline = newest run only
+        assert lb[0]["run_id"] == "run-2"
+        assert abs(lb[0]["avg_mrr"] - 0.5) < 1e-9
+
+        detail = node_detail(conn, "claude-7", mode="hybrid")
+        assert {d["run_id"] for d in detail["retrieval"]} == {"run-1", "run-2"}
+        assert detail["enrichment"]  # enrichment rows present
+
+        hist = run_history(conn)
+        assert [h["run_id"] for h in hist] == ["run-2", "run-1"]  # newest first
+    finally:
+        conn.close()
+
+
 def test_malformed_line_tolerated(tmp_path):
     from hippo_brain.bench.results_store import connect, ingest_run
 

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -1,0 +1,7 @@
+from hippo_brain.bench.paths import bench_results_db_path
+
+
+def test_bench_results_db_path_under_xdg(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    p = bench_results_db_path()
+    assert p == tmp_path / "hippo-bench" / "bench-results.db"

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -255,3 +255,70 @@ def test_connect_creates_schema(tmp_path):
         assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
     finally:
         conn.close()
+
+
+def test_reingest_same_run_is_skipped(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(
+        tmp_path / "run-1.jsonl", [_manifest(), _model_summary_with_proxy(), _run_end()]
+    )
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        first = ingest_run(jsonl, conn=conn)
+        assert first.inserted and not first.skipped_existing
+        second = ingest_run(jsonl, conn=conn)
+        assert second.skipped_existing and not second.inserted
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_retrieval").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_force_replaces_run(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(
+        tmp_path / "run-1.jsonl", [_manifest(), _model_summary_with_proxy(), _run_end()]
+    )
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        out = ingest_run(jsonl, conn=conn, force=True)
+        assert out.inserted
+        # cascade delete + reinsert leaves exactly one run, no duplicate child rows
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_retrieval").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_partial_jsonl_no_run_end(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl", [_manifest(), _attempt()])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out = ingest_run(jsonl, conn=conn)
+        assert out.inserted
+        row = conn.execute("SELECT finished_at_iso FROM bench_runs").fetchone()
+        assert row["finished_at_iso"] is None  # incomplete run
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_enrichment").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_malformed_line_tolerated(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    path = tmp_path / "run-1.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_manifest(), sort_keys=True) + "\n")
+        f.write("{not json\n")
+        f.write(json.dumps(_run_end(), sort_keys=True) + "\n")
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out = ingest_run(path, conn=conn)
+        assert out.inserted
+        assert out.malformed_lines == 1
+    finally:
+        conn.close()

--- a/docs/superpowers/plans/2026-05-31-bench-results-datastore.md
+++ b/docs/superpowers/plans/2026-05-31-bench-results-datastore.md
@@ -406,7 +406,7 @@ Expected: FAIL with `ImportError: cannot import name 'ingest_run'`.
 
 - [ ] **Step 3: Implement the parse loop + bench_runs upsert**
 
-Add to `results_store.py` (imports at top: `import json`, `from dataclasses import dataclass`):
+Add to `results_store.py` (imports at top: `import json`, `import time`, `from dataclasses import dataclass`):
 
 ```python
 @dataclass
@@ -443,6 +443,7 @@ def ingest_run(
     now_ms: int = 0,
 ) -> IngestResult:
     """Parse one run's JSONL into the datastore. Idempotent on run_id."""
+    now_ms = now_ms or int(time.time() * 1000)  # populate ingested_at_ms for real ingests
     owns_conn = conn is None
     conn = conn or connect()
     try:

--- a/docs/superpowers/plans/2026-05-31-bench-results-datastore.md
+++ b/docs/superpowers/plans/2026-05-31-bench-results-datastore.md
@@ -1,0 +1,1720 @@
+# Bench Results Datastore + Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Durably accumulate per-run, per-corpus-node bench scoring in a dedicated all-local SQLite datastore, auto-ingested at run-end, and render a self-contained HTML leaderboard/dashboard from it.
+
+**Architecture:** A new `results_store` module owns `~/.local/share/hippo-bench/bench-results.db` (separate from `hippo.db`); it parses a run's JSONL into four tables and exposes query helpers. A new `dashboard_export` module renders those queries into one self-contained HTML file. `orchestrate_run` calls `ingest_run` at run-end (wrapped so it never fails the run); a CLI `ingest`/`export-dashboard` pair handles backfill and rendering. A one-line producer change makes each retrieval `per_item` record carry its `golden_event_id`.
+
+**Tech Stack:** Python 3.14, stdlib `sqlite3`, `argparse` (existing bench CLI), pytest, uv.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md`
+
+**Test command (use throughout):**
+```bash
+uv run --project brain pytest brain/tests/test_bench_results_store.py -v
+```
+Lint/format before each commit:
+```bash
+uv run --project brain ruff check brain/ && uv run --project brain ruff format --check brain/
+```
+
+---
+
+## File Structure
+
+- **Create** `brain/src/hippo_brain/bench/results_store.py` — owns `bench-results.db`: schema, `ingest_run`, query helpers. No HTML.
+- **Create** `brain/src/hippo_brain/bench/dashboard_export.py` — owns HTML rendering from `results_store` queries. No SQLite internals.
+- **Create** `brain/tests/test_bench_results_store.py` — ingest + query tests.
+- **Create** `brain/tests/test_bench_dashboard_export.py` — HTML render tests.
+- **Modify** `brain/src/hippo_brain/bench/paths.py` — add `bench_results_db_path()`.
+- **Modify** `brain/src/hippo_brain/bench/downstream_proxy.py:158` — stamp `golden_event_id` onto each `per_item` score.
+- **Modify** `brain/src/hippo_brain/bench/orchestrate.py` — auto-ingest in the `finally` block after `writer.close()`.
+- **Modify** `brain/src/hippo_brain/bench/cli.py` — add `ingest` and `export-dashboard` subcommands.
+- **Modify** `brain/tests/test_bench_downstream_proxy.py` — assert the new `golden_event_id` field.
+- **Modify** `brain/src/hippo_brain/bench/README.md` and root `CLAUDE.md` — document the datastore + commands.
+
+---
+
+## Task 1: Producer change — `per_item` carries `golden_event_id`
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/downstream_proxy.py:158`
+- Test: `brain/tests/test_bench_downstream_proxy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `brain/tests/test_bench_downstream_proxy.py`:
+
+```python
+def test_per_item_carries_golden_event_id():
+    from hippo_brain.bench.downstream_proxy import run_downstream_proxy_pass
+
+    qa_items = [{"qa_id": "qa-001", "question": "q?", "golden_event_id": "claude-7"}]
+
+    def fake_search(conn, query, vec, *, mode, limit):
+        # Return a single result whose source id matches the golden.
+        return [{"event_id": "claude-7"}]
+
+    out = run_downstream_proxy_pass(
+        conn=None,
+        qa_items=qa_items,
+        embedding_fn=lambda q: [0.0, 1.0],
+        modes=("hybrid",),
+        search_fn=fake_search,
+    )
+    assert out["per_item"][0]["golden_event_id"] == "claude-7"
+    assert out["per_item"][0]["qa_id"] == "qa-001"
+    assert out["per_item"][0]["mode"] == "hybrid"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_downstream_proxy.py::test_per_item_carries_golden_event_id -v`
+Expected: FAIL with `KeyError: 'golden_event_id'`.
+
+- [ ] **Step 3: Add the one-line producer change**
+
+In `run_downstream_proxy_pass`, immediately after the existing `score["qa_id"] = item.get("qa_id")` line (currently `downstream_proxy.py:158`), add:
+
+```python
+            score["golden_event_id"] = item["golden_event_id"]
+```
+
+So the block reads:
+```python
+            score = score_single_retrieval(results, item["golden_event_id"])
+            score["qa_id"] = item.get("qa_id")
+            score["golden_event_id"] = item["golden_event_id"]
+            score["mode"] = mode
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_downstream_proxy.py -v`
+Expected: PASS (all existing tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/downstream_proxy.py brain/tests/test_bench_downstream_proxy.py
+git commit -m "feat(bench): stamp golden_event_id onto downstream_proxy per_item scores"
+```
+
+---
+
+## Task 2: `bench_results_db_path()` in paths.py
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/paths.py`
+- Test: `brain/tests/test_bench_results_store.py` (new file)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `brain/tests/test_bench_results_store.py`:
+
+```python
+import os
+
+from hippo_brain.bench.paths import bench_results_db_path
+
+
+def test_bench_results_db_path_under_xdg(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    p = bench_results_db_path()
+    assert p == tmp_path / "hippo-bench" / "bench-results.db"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py -v`
+Expected: FAIL with `ImportError: cannot import name 'bench_results_db_path'`.
+
+- [ ] **Step 3: Add the path helper**
+
+Append to `brain/src/hippo_brain/bench/paths.py`:
+
+```python
+def bench_results_db_path() -> Path:
+    """Durable, all-local bench results datastore. Separate file from hippo.db."""
+    return hippo_bench_root() / "bench-results.db"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/paths.py brain/tests/test_bench_results_store.py
+git commit -m "feat(bench): add bench_results_db_path()"
+```
+
+---
+
+## Task 3: `results_store.connect()` — schema creation
+
+**Files:**
+- Create: `brain/src/hippo_brain/bench/results_store.py`
+- Test: `brain/tests/test_bench_results_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `brain/tests/test_bench_results_store.py`:
+
+```python
+from hippo_brain.bench.results_store import SCHEMA_VERSION, connect
+
+
+def test_connect_creates_schema(tmp_path):
+    db = tmp_path / "bench-results.db"
+    conn = connect(db)
+    try:
+        names = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert {
+            "bench_runs",
+            "bench_models",
+            "bench_node_enrichment",
+            "bench_node_retrieval",
+        } <= names
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_connect_creates_schema -v`
+Expected: FAIL with `ModuleNotFoundError: ... results_store`.
+
+- [ ] **Step 3: Create the module with schema**
+
+Create `brain/src/hippo_brain/bench/results_store.py`:
+
+```python
+"""Durable, all-local datastore for hippo-bench run results.
+
+Parses a run's append-only JSONL (the disposable working file) into four
+queryable tables keyed on run_id, so historical runs survive JSONL cleanup
+and per-(model, corpus-node) scoring is referenceable across all runs.
+
+Separate SQLite file from the application DB (hippo.db); its own
+PRAGMA user_version. Idempotent on run_id — a run's JSONL is immutable
+after run_end, so re-ingest is a no-op unless force=True.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from hippo_brain.bench.paths import bench_results_db_path
+
+SCHEMA_VERSION = 1
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS bench_runs (
+    run_id                    TEXT PRIMARY KEY,
+    started_at_iso            TEXT,
+    finished_at_iso           TEXT,
+    host_json                 TEXT,
+    bench_version             TEXT,
+    corpus_version            TEXT,
+    corpus_content_hash       TEXT,
+    corpus_schema_version     INTEGER,
+    eval_qa_version           TEXT,
+    embedding_model           TEXT,
+    inference_backend_version TEXT,
+    gate_thresholds_json      TEXT,
+    candidate_models_json     TEXT,
+    models_completed_json     TEXT,
+    models_errored_json       TEXT,
+    reason                    TEXT,
+    ingested_at_ms            INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS bench_models (
+    run_id                TEXT,
+    model_id              TEXT,
+    schema_validity_rate  REAL,
+    refusal_rate          REAL,
+    echo_similarity_max   REAL,
+    latency_p50_ms        INTEGER,
+    latency_p95_ms        INTEGER,
+    latency_p99_ms        INTEGER,
+    self_consistency_mean REAL,
+    self_consistency_min  REAL,
+    entity_sanity_mean    REAL,
+    main_attempts_count   INTEGER,
+    verdict_passed        INTEGER,
+    failed_gates_json     TEXT,
+    errors_json           TEXT,
+    PRIMARY KEY (run_id, model_id),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS bench_node_enrichment (
+    run_id             TEXT,
+    model_id           TEXT,
+    event_id           TEXT,
+    source             TEXT,
+    schema_valid       INTEGER,
+    refusal_detected   INTEGER,
+    echo_similarity    REAL,
+    entity_sanity      REAL,
+    latency_ms         INTEGER,
+    timeout            INTEGER,
+    parsed_output_json TEXT,
+    PRIMARY KEY (run_id, model_id, event_id),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS bench_node_retrieval (
+    run_id          TEXT,
+    model_id        TEXT,
+    qa_id           TEXT,
+    golden_event_id TEXT,
+    mode            TEXT,
+    rank            INTEGER,
+    mrr             REAL,
+    hit_at_1        INTEGER,
+    hit_at_10       INTEGER,
+    ndcg_at_10      REAL,
+    PRIMARY KEY (run_id, model_id, qa_id, mode),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_retrieval_node ON bench_node_retrieval(golden_event_id, mode);
+CREATE INDEX IF NOT EXISTS idx_enrichment_node ON bench_node_enrichment(event_id);
+CREATE INDEX IF NOT EXISTS idx_runs_started ON bench_runs(started_at_iso);
+"""
+
+
+def connect(db_path: Path | None = None) -> sqlite3.Connection:
+    """Open (creating if needed) the bench results DB with schema + pragmas."""
+    path = db_path or bench_results_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.executescript(_SCHEMA)
+    conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+    conn.commit()
+    return conn
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_connect_creates_schema -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/results_store.py brain/tests/test_bench_results_store.py
+git commit -m "feat(bench): results_store schema + connect()"
+```
+
+---
+
+## Task 4: `ingest_run` — `run_manifest` + `run_end` → `bench_runs`
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/results_store.py`
+- Test: `brain/tests/test_bench_results_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a shared JSONL fixture helper and a test:
+
+```python
+import json
+
+
+def _write_jsonl(path, records):
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, sort_keys=True))
+            f.write("\n")
+    return path
+
+
+def _manifest(run_id="run-1"):
+    return {
+        "record_type": "run_manifest",
+        "run_id": run_id,
+        "started_at_iso": "2026-05-31T00:00:00+00:00",
+        "host": {"node": "test-host"},
+        "preflight_checks": [],
+        "candidate_models": ["model-a"],
+        "bench_version": "0.2.0",
+        "corpus_version": "corpus-v2",
+        "corpus_content_hash": "sha256:abc",
+        "corpus_schema_version": 18,
+        "eval_qa_version": "eval-qa-v1",
+        "embedding_model": "embed-x",
+        "inference_backend_version": None,
+        "gate_thresholds": {"schema_validity_min": 0.9},
+        "host_baseline": {},
+        "prod_state_at_start": {},
+        "self_consistency_spec": {},
+        "finished_at_iso": None,
+    }
+
+
+def _run_end(run_id="run-1"):
+    return {
+        "record_type": "run_end",
+        "run_id": run_id,
+        "finished_at_iso": "2026-05-31T01:00:00+00:00",
+        "models_completed": ["model-a"],
+        "models_errored": [],
+        "reason": None,
+    }
+
+
+def test_ingest_run_writes_bench_runs(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl", [_manifest(), _run_end()])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn, now_ms=123)
+        row = conn.execute("SELECT * FROM bench_runs WHERE run_id='run-1'").fetchone()
+        assert row["corpus_content_hash"] == "sha256:abc"
+        assert row["finished_at_iso"] == "2026-05-31T01:00:00+00:00"
+        assert json.loads(row["models_completed_json"]) == ["model-a"]
+        assert row["ingested_at_ms"] == 123
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_ingest_run_writes_bench_runs -v`
+Expected: FAIL with `ImportError: cannot import name 'ingest_run'`.
+
+- [ ] **Step 3: Implement the parse loop + bench_runs upsert**
+
+Add to `results_store.py` (imports at top: `import json`, `from dataclasses import dataclass`):
+
+```python
+@dataclass
+class IngestResult:
+    run_id: str | None
+    inserted: bool
+    skipped_existing: bool
+    models: int = 0
+    enrichment_rows: int = 0
+    retrieval_rows: int = 0
+    malformed_lines: int = 0
+
+
+def _parse_records(jsonl_path: Path) -> tuple[list[dict], int]:
+    records: list[dict] = []
+    malformed = 0
+    with jsonl_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                malformed += 1
+    return records, malformed
+
+
+def ingest_run(
+    jsonl_path: Path,
+    conn: sqlite3.Connection | None = None,
+    *,
+    force: bool = False,
+    now_ms: int = 0,
+) -> IngestResult:
+    """Parse one run's JSONL into the datastore. Idempotent on run_id."""
+    owns_conn = conn is None
+    conn = conn or connect()
+    try:
+        records, malformed = _parse_records(jsonl_path)
+        manifest = next((r for r in records if r.get("record_type") == "run_manifest"), None)
+        if manifest is None:
+            return IngestResult(run_id=None, inserted=False, skipped_existing=False,
+                                malformed_lines=malformed)
+        run_id = manifest["run_id"]
+
+        existing = conn.execute(
+            "SELECT 1 FROM bench_runs WHERE run_id=?", (run_id,)
+        ).fetchone()
+        if existing and not force:
+            return IngestResult(run_id=run_id, inserted=False, skipped_existing=True,
+                                malformed_lines=malformed)
+
+        end = next((r for r in records if r.get("record_type") == "run_end"), None)
+
+        with conn:  # one transaction; FK cascade clears child rows on replace
+            conn.execute("DELETE FROM bench_runs WHERE run_id=?", (run_id,))
+            conn.execute(
+                """INSERT INTO bench_runs (
+                    run_id, started_at_iso, finished_at_iso, host_json, bench_version,
+                    corpus_version, corpus_content_hash, corpus_schema_version,
+                    eval_qa_version, embedding_model, inference_backend_version,
+                    gate_thresholds_json, candidate_models_json, models_completed_json,
+                    models_errored_json, reason, ingested_at_ms
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    run_id,
+                    manifest.get("started_at_iso"),
+                    (end or {}).get("finished_at_iso") or manifest.get("finished_at_iso"),
+                    json.dumps(manifest.get("host", {}), sort_keys=True),
+                    manifest.get("bench_version"),
+                    manifest.get("corpus_version"),
+                    manifest.get("corpus_content_hash"),
+                    manifest.get("corpus_schema_version"),
+                    manifest.get("eval_qa_version"),
+                    manifest.get("embedding_model"),
+                    manifest.get("inference_backend_version"),
+                    json.dumps(manifest.get("gate_thresholds", {}), sort_keys=True),
+                    json.dumps(manifest.get("candidate_models", []), sort_keys=True),
+                    json.dumps((end or {}).get("models_completed", []), sort_keys=True),
+                    json.dumps((end or {}).get("models_errored", []), sort_keys=True),
+                    (end or {}).get("reason"),
+                    now_ms,
+                ),
+            )
+            _ingest_models(conn, run_id, records)
+            _ingest_enrichment(conn, run_id, records)
+            _ingest_retrieval(conn, run_id, records)
+
+        return IngestResult(
+            run_id=run_id, inserted=True, skipped_existing=False, malformed_lines=malformed
+        )
+    finally:
+        if owns_conn:
+            conn.close()
+```
+
+Add temporary no-op helpers so the module imports (real bodies come in Tasks 5–7):
+
+```python
+def _ingest_models(conn, run_id, records):  # noqa: ANN001
+    pass
+
+
+def _ingest_enrichment(conn, run_id, records):  # noqa: ANN001
+    pass
+
+
+def _ingest_retrieval(conn, run_id, records):  # noqa: ANN001
+    pass
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_ingest_run_writes_bench_runs -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/results_store.py brain/tests/test_bench_results_store.py
+git commit -m "feat(bench): ingest run_manifest/run_end into bench_runs"
+```
+
+---
+
+## Task 5: `_ingest_models` — `model_summary` → `bench_models`
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/results_store.py`
+- Test: `brain/tests/test_bench_results_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def _model_summary(run_id="run-1", model="model-a"):
+    return {
+        "record_type": "model_summary",
+        "run_id": run_id,
+        "model": {"id": model},
+        "events_attempted": 2,
+        "attempts_total": 2,
+        "gates": {
+            "schema_validity_rate": 1.0,
+            "refusal_rate": 0.0,
+            "echo_similarity_max": 0.1,
+            "latency_p50_ms": 100,
+            "latency_p95_ms": 200,
+            "latency_p99_ms": 300,
+            "self_consistency_mean": None,
+            "self_consistency_min": None,
+            "entity_sanity_mean": 0.9,
+            "main_attempts_count": 2,
+        },
+        "system_peak": {},
+        "tier0_verdict": {"passed": True, "failed_gates": [], "skipped_gates": [], "notes": []},
+        "downstream_proxy": {},
+        "errors": [],
+    }
+
+
+def test_ingest_models(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(
+        tmp_path / "run-1.jsonl", [_manifest(), _model_summary(), _run_end()]
+    )
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        row = conn.execute(
+            "SELECT * FROM bench_models WHERE run_id='run-1' AND model_id='model-a'"
+        ).fetchone()
+        assert row["schema_validity_rate"] == 1.0
+        assert row["latency_p95_ms"] == 200
+        assert row["verdict_passed"] == 1
+        assert row["self_consistency_mean"] is None
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_ingest_models -v`
+Expected: FAIL (no `bench_models` row; assertion error on `NoneType` subscript).
+
+- [ ] **Step 3: Implement `_ingest_models`**
+
+Replace the `_ingest_models` stub:
+
+```python
+def _ingest_models(conn: sqlite3.Connection, run_id: str, records: list[dict]) -> int:
+    n = 0
+    for r in records:
+        if r.get("record_type") != "model_summary":
+            continue
+        g = r.get("gates", {})
+        verdict = r.get("tier0_verdict", {})
+        conn.execute(
+            """INSERT INTO bench_models (
+                run_id, model_id, schema_validity_rate, refusal_rate, echo_similarity_max,
+                latency_p50_ms, latency_p95_ms, latency_p99_ms, self_consistency_mean,
+                self_consistency_min, entity_sanity_mean, main_attempts_count,
+                verdict_passed, failed_gates_json, errors_json
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                run_id,
+                r.get("model", {}).get("id"),
+                g.get("schema_validity_rate"),
+                g.get("refusal_rate"),
+                g.get("echo_similarity_max"),
+                g.get("latency_p50_ms"),
+                g.get("latency_p95_ms"),
+                g.get("latency_p99_ms"),
+                g.get("self_consistency_mean"),
+                g.get("self_consistency_min"),
+                g.get("entity_sanity_mean"),
+                g.get("main_attempts_count"),
+                1 if verdict.get("passed") else 0,
+                json.dumps(verdict.get("failed_gates", []), sort_keys=True),
+                json.dumps(r.get("errors", []), sort_keys=True),
+            ),
+        )
+        n += 1
+    return n
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_ingest_models -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/results_store.py brain/tests/test_bench_results_store.py
+git commit -m "feat(bench): ingest model_summary into bench_models"
+```
+
+---
+
+## Task 6: `_ingest_enrichment` — `attempt` (main) → `bench_node_enrichment`
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/results_store.py`
+- Test: `brain/tests/test_bench_results_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def _attempt(run_id="run-1", model="model-a", event_id="claude-7", purpose="main",
+             entity_rates=None, parsed=None):
+    return {
+        "record_type": "attempt",
+        "run_id": run_id,
+        "model": {"id": model},
+        "event": {"event_id": event_id, "source": event_id.split("-")[0], "content_hash": "h"},
+        "attempt_idx": 0,
+        "purpose": purpose,
+        "timestamps": {"total_ms": 150},
+        "raw_output": "{}",
+        "parsed_output": parsed if parsed is not None else {"summary": "s"},
+        "gates": {
+            "schema_valid": True,
+            "refusal_detected": False,
+            "echo_similarity": 0.2,
+            "entity_type_sanity": entity_rates if entity_rates is not None else {"tool": 1.0, "file": 0.5},
+        },
+        "system_snapshot": {},
+        "timeout": False,
+    }
+
+
+def test_ingest_enrichment_main_only(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    records = [
+        _manifest(),
+        _attempt(event_id="claude-7"),
+        _attempt(event_id="shell-9", purpose="self_consistency"),  # excluded
+        _run_end(),
+    ]
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl", records)
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        rows = conn.execute(
+            "SELECT * FROM bench_node_enrichment WHERE run_id='run-1'"
+        ).fetchall()
+        assert len(rows) == 1  # self_consistency attempt excluded
+        row = rows[0]
+        assert row["event_id"] == "claude-7"
+        assert row["source"] == "claude"
+        assert row["schema_valid"] == 1
+        assert abs(row["entity_sanity"] - 0.75) < 1e-9  # mean(1.0, 0.5)
+        assert row["latency_ms"] == 150
+        assert json.loads(row["parsed_output_json"]) == {"summary": "s"}
+    finally:
+        conn.close()
+
+
+def test_ingest_enrichment_empty_entity_rates_is_null(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(
+        tmp_path / "run-1.jsonl",
+        [_manifest(), _attempt(entity_rates={}), _run_end()],
+    )
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        row = conn.execute("SELECT entity_sanity FROM bench_node_enrichment").fetchone()
+        assert row["entity_sanity"] is None
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py -k ingest_enrichment -v`
+Expected: FAIL (no enrichment rows).
+
+- [ ] **Step 3: Implement `_ingest_enrichment`**
+
+Replace the `_ingest_enrichment` stub. The `entity_sanity` mean mirrors
+`summary._entity_sanity_attempt_mean` (mean of per-category rates, or None if empty):
+
+```python
+def _entity_sanity_mean(per_cat: dict | None) -> float | None:
+    if not isinstance(per_cat, dict) or not per_cat:
+        return None
+    return sum(per_cat.values()) / len(per_cat)
+
+
+def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict]) -> int:
+    n = 0
+    for r in records:
+        if r.get("record_type") != "attempt" or r.get("purpose") != "main":
+            continue
+        ev = r.get("event", {})
+        g = r.get("gates", {})
+        conn.execute(
+            """INSERT OR REPLACE INTO bench_node_enrichment (
+                run_id, model_id, event_id, source, schema_valid, refusal_detected,
+                echo_similarity, entity_sanity, latency_ms, timeout, parsed_output_json
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                run_id,
+                r.get("model", {}).get("id"),
+                ev.get("event_id"),
+                ev.get("source"),
+                1 if g.get("schema_valid") else 0,
+                1 if g.get("refusal_detected") else 0,
+                g.get("echo_similarity"),
+                _entity_sanity_mean(g.get("entity_type_sanity")),
+                r.get("timestamps", {}).get("total_ms"),
+                1 if r.get("timeout") else 0,
+                json.dumps(r.get("parsed_output"), sort_keys=True),
+            ),
+        )
+        n += 1
+    return n
+```
+
+> Note: `INSERT OR REPLACE` tolerates the rare case of multiple main attempts
+> for the same event (last one wins) without violating the PK.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py -k ingest_enrichment -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/results_store.py brain/tests/test_bench_results_store.py
+git commit -m "feat(bench): ingest main attempts into bench_node_enrichment"
+```
+
+---
+
+## Task 7: `_ingest_retrieval` — `downstream_proxy.per_item` → `bench_node_retrieval`
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/results_store.py`
+- Test: `brain/tests/test_bench_results_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def _model_summary_with_proxy(run_id="run-1", model="model-a"):
+    ms = _model_summary(run_id, model)
+    ms["downstream_proxy"] = {
+        "modes": {"hybrid": {"mrr": 1.0, "hit_at_1": 1.0}},
+        "qa_count": 1,
+        "k": 10,
+        "per_item": [
+            {
+                "hit_at_k": {1: True, 3: True, 5: True, 10: True},
+                "rank": 1,
+                "mrr": 1.0,
+                "ndcg_at_10": 1.0,
+                "qa_id": "qa-001",
+                "golden_event_id": "claude-7",
+                "mode": "hybrid",
+            },
+            {
+                "hit_at_k": {1: False, 3: False, 5: False, 10: False},
+                "rank": None,
+                "mrr": 0.0,
+                "ndcg_at_10": 0.0,
+                "qa_id": "qa-001",
+                "golden_event_id": "claude-7",
+                "mode": "lexical",
+            },
+        ],
+    }
+    return ms
+
+
+def test_ingest_retrieval(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(
+        tmp_path / "run-1.jsonl", [_manifest(), _model_summary_with_proxy(), _run_end()]
+    )
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        hybrid = conn.execute(
+            "SELECT * FROM bench_node_retrieval WHERE mode='hybrid'"
+        ).fetchone()
+        assert hybrid["golden_event_id"] == "claude-7"
+        assert hybrid["qa_id"] == "qa-001"
+        assert hybrid["rank"] == 1
+        assert hybrid["hit_at_1"] == 1
+        assert hybrid["hit_at_10"] == 1
+        lexical = conn.execute(
+            "SELECT * FROM bench_node_retrieval WHERE mode='lexical'"
+        ).fetchone()
+        assert lexical["rank"] is None
+        assert lexical["hit_at_1"] == 0
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_ingest_retrieval -v`
+Expected: FAIL (no retrieval rows).
+
+- [ ] **Step 3: Implement `_ingest_retrieval`**
+
+`per_item.hit_at_k` keys may be ints (in-process) or strings (after a JSON
+round-trip). Look up both:
+
+```python
+def _hit(hit_at_k: dict, k: int) -> int:
+    v = hit_at_k.get(k, hit_at_k.get(str(k), False))
+    return 1 if v else 0
+
+
+def _ingest_retrieval(conn: sqlite3.Connection, run_id: str, records: list[dict]) -> int:
+    n = 0
+    for r in records:
+        if r.get("record_type") != "model_summary":
+            continue
+        model_id = r.get("model", {}).get("id")
+        per_item = r.get("downstream_proxy", {}).get("per_item", [])
+        for item in per_item:
+            hk = item.get("hit_at_k", {})
+            conn.execute(
+                """INSERT OR REPLACE INTO bench_node_retrieval (
+                    run_id, model_id, qa_id, golden_event_id, mode, rank, mrr,
+                    hit_at_1, hit_at_10, ndcg_at_10
+                ) VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    run_id,
+                    model_id,
+                    item.get("qa_id"),
+                    item.get("golden_event_id"),
+                    item.get("mode"),
+                    item.get("rank"),
+                    item.get("mrr"),
+                    _hit(hk, 1),
+                    _hit(hk, 10),
+                    item.get("ndcg_at_10"),
+                ),
+            )
+            n += 1
+    return n
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_ingest_retrieval -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the real return counts**
+
+In `ingest_run`, replace the three bare helper calls with count capture and
+return them:
+
+```python
+            n_models = _ingest_models(conn, run_id, records)
+            n_enrich = _ingest_enrichment(conn, run_id, records)
+            n_retr = _ingest_retrieval(conn, run_id, records)
+
+        return IngestResult(
+            run_id=run_id, inserted=True, skipped_existing=False,
+            models=n_models, enrichment_rows=n_enrich, retrieval_rows=n_retr,
+            malformed_lines=malformed,
+        )
+```
+
+- [ ] **Step 6: Run full file to verify nothing regressed**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/results_store.py brain/tests/test_bench_results_store.py
+git commit -m "feat(bench): ingest downstream_proxy per_item into bench_node_retrieval"
+```
+
+---
+
+## Task 8: Idempotency, `--force`, partial + malformed JSONL
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/results_store.py` (already supports these — tests lock behavior)
+- Test: `brain/tests/test_bench_results_store.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_reingest_same_run_is_skipped(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl",
+                         [_manifest(), _model_summary_with_proxy(), _run_end()])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        first = ingest_run(jsonl, conn=conn)
+        assert first.inserted and not first.skipped_existing
+        second = ingest_run(jsonl, conn=conn)
+        assert second.skipped_existing and not second.inserted
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_retrieval").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_force_replaces_run(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl",
+                         [_manifest(), _model_summary_with_proxy(), _run_end()])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        out = ingest_run(jsonl, conn=conn, force=True)
+        assert out.inserted
+        # cascade delete + reinsert leaves exactly one run, no duplicate child rows
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_retrieval").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_partial_jsonl_no_run_end(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    jsonl = _write_jsonl(tmp_path / "run-1.jsonl", [_manifest(), _attempt()])
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out = ingest_run(jsonl, conn=conn)
+        assert out.inserted
+        row = conn.execute("SELECT finished_at_iso FROM bench_runs").fetchone()
+        assert row["finished_at_iso"] is None  # incomplete run
+        assert conn.execute("SELECT COUNT(*) FROM bench_node_enrichment").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_malformed_line_tolerated(tmp_path):
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    path = tmp_path / "run-1.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_manifest(), sort_keys=True) + "\n")
+        f.write("{not json\n")
+        f.write(json.dumps(_run_end(), sort_keys=True) + "\n")
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        out = ingest_run(path, conn=conn)
+        assert out.inserted
+        assert out.malformed_lines == 1
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py -k "reingest or force or partial or malformed" -v`
+Expected: PASS (logic already implemented in Tasks 4–7). If any fail, fix `ingest_run` until green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add brain/tests/test_bench_results_store.py
+git commit -m "test(bench): lock idempotency, force-replace, partial + malformed ingest"
+```
+
+---
+
+## Task 9: Query helpers — leaderboard (latest run), per-node, history
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/results_store.py`
+- Test: `brain/tests/test_bench_results_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_query_helpers(tmp_path):
+    from hippo_brain.bench.results_store import (
+        connect,
+        ingest_run,
+        leaderboard_latest,
+        node_detail,
+        run_history,
+    )
+
+    # run-1 (older) then run-2 (newer) — leaderboard headline must use run-2.
+    r1 = [_manifest("run-1"), _model_summary_with_proxy("run-1"), _run_end("run-1")]
+    ms2 = _model_summary_with_proxy("run-2")
+    ms2["downstream_proxy"]["per_item"][0]["mrr"] = 0.5  # different score in newer run
+    m2 = _manifest("run-2")
+    m2["started_at_iso"] = "2026-05-31T05:00:00+00:00"
+    r2 = [m2, ms2, _run_end("run-2")]
+
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(_write_jsonl(tmp_path / "r1.jsonl", r1), conn=conn)
+        ingest_run(_write_jsonl(tmp_path / "r2.jsonl", r2), conn=conn)
+
+        lb = leaderboard_latest(conn, mode="hybrid")
+        # headline = newest run only
+        assert lb[0]["run_id"] == "run-2"
+        assert abs(lb[0]["avg_mrr"] - 0.5) < 1e-9
+
+        detail = node_detail(conn, "claude-7", mode="hybrid")
+        assert {d["run_id"] for d in detail["retrieval"]} == {"run-1", "run-2"}
+        assert detail["enrichment"]  # enrichment rows present
+
+        hist = run_history(conn)
+        assert [h["run_id"] for h in hist] == ["run-2", "run-1"]  # newest first
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_query_helpers -v`
+Expected: FAIL with `ImportError` on the helper names.
+
+- [ ] **Step 3: Implement the query helpers**
+
+Append to `results_store.py`:
+
+```python
+def leaderboard_latest(conn: sqlite3.Connection, *, mode: str = "hybrid") -> list[dict]:
+    """Per-model aggregate retrieval for the single most-recent run (headline)."""
+    rows = conn.execute(
+        """
+        WITH latest AS (
+            SELECT run_id FROM bench_runs ORDER BY started_at_iso DESC LIMIT 1
+        )
+        SELECT nr.run_id, nr.model_id,
+               AVG(nr.mrr)            AS avg_mrr,
+               AVG(nr.hit_at_1)       AS hit_at_1,
+               COUNT(*)               AS scored_nodes
+        FROM bench_node_retrieval nr
+        JOIN latest ON latest.run_id = nr.run_id
+        WHERE nr.mode = ?
+        GROUP BY nr.run_id, nr.model_id
+        ORDER BY avg_mrr DESC
+        """,
+        (mode,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def node_detail(conn: sqlite3.Connection, event_id: str, *, mode: str = "hybrid") -> dict:
+    """All historical retrieval + enrichment rows for one corpus node."""
+    retrieval = conn.execute(
+        """SELECT nr.run_id, nr.model_id, nr.mrr, nr.rank, nr.hit_at_1, r.started_at_iso
+           FROM bench_node_retrieval nr JOIN bench_runs r USING (run_id)
+           WHERE nr.golden_event_id = ? AND nr.mode = ?
+           ORDER BY r.started_at_iso DESC""",
+        (event_id, mode),
+    ).fetchall()
+    enrichment = conn.execute(
+        """SELECT ne.run_id, ne.model_id, ne.schema_valid, ne.refusal_detected,
+                  ne.echo_similarity, ne.entity_sanity, ne.parsed_output_json,
+                  r.started_at_iso
+           FROM bench_node_enrichment ne JOIN bench_runs r USING (run_id)
+           WHERE ne.event_id = ?
+           ORDER BY r.started_at_iso DESC""",
+        (event_id,),
+    ).fetchall()
+    return {
+        "event_id": event_id,
+        "retrieval": [dict(r) for r in retrieval],
+        "enrichment": [dict(r) for r in enrichment],
+    }
+
+
+def run_history(conn: sqlite3.Connection) -> list[dict]:
+    """All runs, newest first, for the history/trend view."""
+    rows = conn.execute(
+        """SELECT run_id, started_at_iso, finished_at_iso, corpus_version,
+                  corpus_content_hash, models_completed_json
+           FROM bench_runs ORDER BY started_at_iso DESC"""
+    ).fetchall()
+    return [dict(r) for r in rows]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_results_store.py::test_query_helpers -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/results_store.py brain/tests/test_bench_results_store.py
+git commit -m "feat(bench): leaderboard/node-detail/history query helpers"
+```
+
+---
+
+## Task 10: CLI `ingest` subcommand (+ `--all`, `--force`)
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/cli.py`
+- Test: `brain/tests/test_bench_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `brain/tests/test_bench_cli.py`:
+
+```python
+def test_cli_ingest_single_and_all(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from hippo_brain.bench import cli
+    from hippo_brain.bench.paths import bench_runs_dir
+    from hippo_brain.bench.results_store import connect
+
+    # build a minimal valid run JSONL inside the runs dir
+    runs = bench_runs_dir(create=True)
+    jsonl = runs / "run-x.jsonl"
+    import json
+    with jsonl.open("w") as f:
+        f.write(json.dumps({
+            "record_type": "run_manifest", "run_id": "run-x",
+            "started_at_iso": "2026-05-31T00:00:00+00:00", "host": {},
+            "candidate_models": [], "corpus_content_hash": "h",
+        }, sort_keys=True) + "\n")
+        f.write(json.dumps({
+            "record_type": "run_end", "run_id": "run-x",
+            "finished_at_iso": "2026-05-31T01:00:00+00:00",
+            "models_completed": [], "models_errored": [],
+        }, sort_keys=True) + "\n")
+
+    assert cli.main(["ingest", str(jsonl)]) == 0
+    # --all is idempotent: run-x already present → skipped, still exit 0
+    assert cli.main(["ingest", "--all"]) == 0
+
+    conn = connect()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM bench_runs").fetchone()[0] == 1
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_cli.py::test_cli_ingest_single_and_all -v`
+Expected: FAIL (argparse: invalid choice `ingest`).
+
+- [ ] **Step 3: Implement `_cmd_ingest` and register the subparser**
+
+Add the command handler (near the other `_cmd_*` functions in `cli.py`):
+
+```python
+def _cmd_ingest(args: argparse.Namespace) -> int:
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    if args.all:
+        targets = sorted(bench_runs_dir().glob("*.jsonl"))
+    else:
+        targets = [Path(args.run_file)]
+
+    conn = connect()
+    try:
+        total_new = 0
+        for t in targets:
+            res = ingest_run(t, conn=conn, force=args.force)
+            status = (
+                "skipped (already ingested)" if res.skipped_existing
+                else f"ingested run_id={res.run_id} "
+                     f"(models={res.models}, enrichment={res.enrichment_rows}, "
+                     f"retrieval={res.retrieval_rows}, malformed={res.malformed_lines})"
+            )
+            print(f"{t.name}: {status}")
+            total_new += 1 if res.inserted else 0
+        print(f"done: {total_new} run(s) ingested, {len(targets)} file(s) seen")
+        return 0
+    finally:
+        conn.close()
+```
+
+Register it inside `_build_parser` (after the `summary` subparser):
+
+```python
+    ingest = sub.add_parser("ingest", help="Ingest run JSONL into the bench results datastore")
+    ingest.add_argument("run_file", nargs="?", help="Path to a run JSONL (omit with --all)")
+    ingest.add_argument("--all", action="store_true", help="Ingest every *.jsonl under the runs dir")
+    ingest.add_argument("--force", action="store_true", help="Re-ingest runs already present")
+    ingest.set_defaults(func=_cmd_ingest)
+```
+
+The `bench_runs_dir` import already exists in `cli.py` (it is used by `_cmd_run`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_cli.py::test_cli_ingest_single_and_all -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/cli.py brain/tests/test_bench_cli.py
+git commit -m "feat(bench): hippo-bench ingest CLI (single + --all + --force)"
+```
+
+---
+
+## Task 11: Auto-ingest at run-end in `orchestrate_run`
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/orchestrate.py`
+- Test: `brain/tests/test_bench_orchestrate.py`
+
+The hook is a tiny `_safe_ingest(out_path, dry_run)` wrapper in `orchestrate.py`
+so the "never fail the run" guarantee is unit-testable without running the full
+non-dry orchestration (which needs model-server + prod-pause infra).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `brain/tests/test_bench_orchestrate.py`:
+
+```python
+def test_safe_ingest_skips_dry_run(tmp_path, monkeypatch):
+    import hippo_brain.bench.orchestrate as orch
+
+    called = []
+    monkeypatch.setattr(orch, "ingest_run", lambda p: called.append(p), raising=False)
+    orch._safe_ingest(tmp_path / "run.jsonl", dry_run=True)
+    assert called == []  # dry runs are not ingested
+
+
+def test_safe_ingest_calls_ingest_for_real_run(tmp_path, monkeypatch):
+    import hippo_brain.bench.orchestrate as orch
+
+    called = []
+    monkeypatch.setattr(orch, "ingest_run", lambda p: called.append(p), raising=False)
+    out = tmp_path / "run.jsonl"
+    orch._safe_ingest(out, dry_run=False)
+    assert called == [out]
+
+
+def test_safe_ingest_swallows_errors(tmp_path, monkeypatch):
+    import hippo_brain.bench.orchestrate as orch
+
+    def boom(_p):
+        raise RuntimeError("datastore exploded")
+
+    monkeypatch.setattr(orch, "ingest_run", boom, raising=False)
+    # Must not raise even though ingest blows up — a reporting concern never
+    # fails the run (AP-1).
+    orch._safe_ingest(tmp_path / "run.jsonl", dry_run=False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_orchestrate.py -k safe_ingest -v`
+Expected: FAIL with `AttributeError: module ... has no attribute '_safe_ingest'`.
+
+- [ ] **Step 3: Implement the wrapper + wire it into the finally block**
+
+Add the import near the other bench imports in `orchestrate.py`:
+
+```python
+from hippo_brain.bench.results_store import ingest_run
+```
+
+Add a module-level logger near the top if not present:
+
+```python
+import logging
+
+_log = logging.getLogger(__name__)
+```
+
+Add the wrapper at module scope (above `orchestrate_run`):
+
+```python
+def _safe_ingest(out_path: Path, *, dry_run: bool) -> None:
+    """Ingest the just-written JSONL into the results datastore.
+
+    A reporting concern must never fail the run (AP-1): the JSONL remains the
+    fallback if this raises. Dry runs are not ingested.
+    """
+    if dry_run:
+        return
+    try:
+        ingest_run(out_path)
+    except Exception:  # noqa: BLE001 — never fail the run over reporting
+        _log.exception("results_store ingest failed for %s", out_path)
+```
+
+In the `finally:` block at the end of `orchestrate_run` (currently
+`orchestrate.py:419-420`), after `writer.close()`, call it:
+
+```python
+    finally:
+        writer.close()
+        _safe_ingest(out_path, dry_run=dry_run)
+```
+
+> `ingest_run` is imported at module top so the monkeypatch tests can replace
+> the `orch.ingest_run` attribute.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_orchestrate.py -k safe_ingest -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full orchestrate suite to verify no regression**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_orchestrate.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/orchestrate.py brain/tests/test_bench_orchestrate.py
+git commit -m "feat(bench): auto-ingest run JSONL into datastore at run-end"
+```
+
+---
+
+## Task 12: `dashboard_export` — self-contained HTML
+
+**Files:**
+- Create: `brain/src/hippo_brain/bench/dashboard_export.py`
+- Test: `brain/tests/test_bench_dashboard_export.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `brain/tests/test_bench_dashboard_export.py`:
+
+```python
+import json
+
+from hippo_brain.bench.dashboard_export import build_dashboard_html, export_dashboard
+from hippo_brain.bench.results_store import connect, ingest_run
+
+# reuse the JSONL builders from the results-store test module
+from test_bench_results_store import (  # type: ignore
+    _manifest,
+    _model_summary_with_proxy,
+    _run_end,
+    _write_jsonl,
+)
+
+
+def _seed(tmp_path):
+    conn = connect(tmp_path / "bench-results.db")
+    ingest_run(
+        _write_jsonl(tmp_path / "r.jsonl",
+                     [_manifest(), _model_summary_with_proxy(), _run_end()]),
+        conn=conn,
+    )
+    return conn
+
+
+def test_build_dashboard_html_embeds_data(tmp_path):
+    conn = _seed(tmp_path)
+    try:
+        html = build_dashboard_html(conn)
+    finally:
+        conn.close()
+    assert "<html" in html.lower()
+    assert 'id="hippo-bench-data"' in html
+    # the embedded JSON blob is parseable and carries the three views
+    blob = html.split('id="hippo-bench-data">', 1)[1].split("</script>", 1)[0]
+    data = json.loads(blob)
+    assert {"leaderboard", "history", "nodes"} <= set(data)
+    assert data["leaderboard"][0]["model_id"] == "model-a"
+    # per-node view carries the scored corpus node with its retrieval rows
+    assert "claude-7" in data["nodes"]
+    assert data["nodes"]["claude-7"]["retrieval"][0]["model_id"] == "model-a"
+
+
+def test_export_dashboard_writes_file(tmp_path):
+    conn = _seed(tmp_path)
+    conn.close()
+    out = tmp_path / "dashboard.html"
+    written = export_dashboard(out, db_path=tmp_path / "bench-results.db")
+    assert written == out
+    assert out.read_text(encoding="utf-8").lower().startswith("<!doctype html")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_dashboard_export.py -v`
+Expected: FAIL (`ModuleNotFoundError: ... dashboard_export`).
+
+- [ ] **Step 3: Implement the exporter**
+
+Create `brain/src/hippo_brain/bench/dashboard_export.py`:
+
+```python
+"""Render the bench results datastore into one self-contained HTML file.
+
+No server, no network: the data is embedded as a JSON blob and a small
+vanilla-JS view renders the leaderboard, per-node lookup, and run history.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from hippo_brain.bench.paths import bench_results_db_path
+from hippo_brain.bench.results_store import (
+    connect,
+    leaderboard_latest,
+    node_detail,
+    run_history,
+)
+
+
+def _gather(conn: sqlite3.Connection) -> dict:
+    # Every node scored by either pipeline, for the per-node ("best model per
+    # corpus member") view. node_detail returns all historical rows per node.
+    node_ids = [
+        r[0]
+        for r in conn.execute(
+            "SELECT event_id FROM bench_node_enrichment "
+            "UNION SELECT golden_event_id FROM bench_node_retrieval "
+            "ORDER BY 1"
+        ).fetchall()
+        if r[0] is not None
+    ]
+    nodes = {eid: node_detail(conn, eid, mode="hybrid") for eid in node_ids}
+    return {
+        "leaderboard": leaderboard_latest(conn, mode="hybrid"),
+        "history": run_history(conn),
+        "nodes": nodes,
+    }
+
+
+_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>hippo-bench dashboard</title>
+<style>
+ body {{ font-family: ui-monospace, monospace; margin: 2rem; background:#0f1115; color:#e6e6e6; }}
+ h1, h2 {{ color:#7aa2ff; }}
+ table {{ border-collapse: collapse; width: 100%; margin-bottom: 2rem; }}
+ th, td {{ border: 1px solid #2a2f3a; padding: 6px 10px; text-align: left; }}
+ th {{ background:#1a1e27; }}
+ tr:nth-child(even) {{ background:#161a22; }}
+</style>
+</head>
+<body>
+<h1>hippo-bench dashboard</h1>
+<h2>Leaderboard — latest run (hybrid retrieval)</h2>
+<div id="leaderboard"></div>
+<h2>Per-node — best model per corpus member</h2>
+<select id="node-select"></select>
+<h3>Retrieval (all runs, hybrid)</h3>
+<div id="node-retrieval"></div>
+<h3>Enrichment (all runs)</h3>
+<div id="node-enrichment"></div>
+<h2>Run history</h2>
+<div id="history"></div>
+<script type="application/json" id="hippo-bench-data">{data_json}</script>
+<script>
+ const data = JSON.parse(document.getElementById("hippo-bench-data").textContent);
+ // Build the DOM with textContent so cell values (incl. LLM-generated
+ // parsed_output) can never inject markup — no innerHTML with data.
+ function renderTable(target, rows, cols) {{
+   const el = document.getElementById(target);
+   if (!rows || !rows.length) {{ el.textContent = "(no data)"; return; }}
+   const tbl = document.createElement("table");
+   const thead = tbl.insertRow();
+   for (const c of cols) {{
+     const th = document.createElement("th");
+     th.textContent = c;
+     thead.appendChild(th);
+   }}
+   for (const r of rows) {{
+     const tr = tbl.insertRow();
+     for (const c of cols) {{
+       const td = tr.insertCell();
+       td.textContent = (r[c] === null || r[c] === undefined) ? "" : String(r[c]);
+     }}
+   }}
+   el.replaceChildren(tbl);
+ }}
+ renderTable("leaderboard", data.leaderboard, ["model_id", "avg_mrr", "hit_at_1", "scored_nodes", "run_id"]);
+ renderTable("history", data.history, ["started_at_iso", "run_id", "corpus_version", "finished_at_iso"]);
+
+ // Per-node view: a <select> of every scored corpus node; on change, render
+ // that node's retrieval ranking and enrichment rows across all runs.
+ const sel = document.getElementById("node-select");
+ const nodeIds = Object.keys(data.nodes).sort();
+ for (const id of nodeIds) {{
+   const opt = document.createElement("option");
+   opt.value = id; opt.textContent = id;
+   sel.appendChild(opt);
+ }}
+ function renderNode(id) {{
+   const detail = data.nodes[id] || {{retrieval: [], enrichment: []}};
+   renderTable("node-retrieval", detail.retrieval,
+     ["model_id", "mrr", "rank", "hit_at_1", "run_id", "started_at_iso"]);
+   renderTable("node-enrichment", detail.enrichment,
+     ["model_id", "schema_valid", "refusal_detected", "echo_similarity",
+      "entity_sanity", "parsed_output_json", "run_id"]);
+ }}
+ sel.addEventListener("change", () => renderNode(sel.value));
+ if (nodeIds.length) renderNode(nodeIds[0]);
+</script>
+</body>
+</html>
+"""
+
+
+def build_dashboard_html(conn: sqlite3.Connection) -> str:
+    payload = _gather(conn)
+    # Escape "</script>" defensively so embedded data can't break out of the tag.
+    blob = json.dumps(payload, sort_keys=True).replace("</", "<\\/")
+    return _TEMPLATE.format(data_json=blob)
+
+
+def export_dashboard(out_path: Path | None = None, *, db_path: Path | None = None) -> Path:
+    out = out_path or (bench_results_db_path().parent / "dashboard.html")
+    conn = connect(db_path)
+    try:
+        html_text = build_dashboard_html(conn)
+    finally:
+        conn.close()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html_text, encoding="utf-8")
+    return out
+```
+
+> Note: the `<style>` block and the JS use doubled braces (`{{ }}`) because the
+> template is rendered with `str.format`; only `{data_json}` is substituted.
+> The table is built with `textContent`/`replaceChildren` (never `innerHTML`
+> with data) so stored LLM output cannot inject markup.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_dashboard_export.py -v`
+Expected: PASS. (If the cross-module import of `test_bench_results_store` fails,
+confirm `brain/tests` has no `__init__.py` and pytest `rootdir` puts `brain/tests`
+on `sys.path`; otherwise move the four JSONL builders into a shared
+`brain/tests/_bench_fixtures.py` and import from there in both test files.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/dashboard_export.py brain/tests/test_bench_dashboard_export.py
+git commit -m "feat(bench): self-contained HTML dashboard export"
+```
+
+---
+
+## Task 13: CLI `export-dashboard` subcommand
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/cli.py`
+- Test: `brain/tests/test_bench_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_cli_export_dashboard(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from hippo_brain.bench import cli
+    from hippo_brain.bench.results_store import connect
+
+    connect().close()  # create an empty datastore
+    out = tmp_path / "dash.html"
+    assert cli.main(["export-dashboard", "--out", str(out)]) == 0
+    assert out.exists()
+    assert "hippo-bench dashboard" in out.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_cli.py::test_cli_export_dashboard -v`
+Expected: FAIL (argparse: invalid choice `export-dashboard`).
+
+- [ ] **Step 3: Implement the handler + subparser**
+
+Add the handler in `cli.py`:
+
+```python
+def _cmd_export_dashboard(args: argparse.Namespace) -> int:
+    from hippo_brain.bench.dashboard_export import export_dashboard
+
+    out = export_dashboard(Path(args.out) if args.out else None)
+    print(f"wrote dashboard: {out}")
+    return 0
+```
+
+Register in `_build_parser` (after the `ingest` subparser):
+
+```python
+    export = sub.add_parser("export-dashboard", help="Render the results datastore to one HTML file")
+    export.add_argument("--out", help="Output HTML path (default: <hippo-bench>/dashboard.html)")
+    export.set_defaults(func=_cmd_export_dashboard)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project brain pytest brain/tests/test_bench_cli.py::test_cli_export_dashboard -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/cli.py brain/tests/test_bench_cli.py
+git commit -m "feat(bench): hippo-bench export-dashboard CLI"
+```
+
+---
+
+## Task 14: Documentation
+
+**Files:**
+- Modify: `brain/src/hippo_brain/bench/README.md`
+- Modify: `CLAUDE.md` (root)
+
+- [ ] **Step 1: Update the bench README**
+
+In `brain/src/hippo_brain/bench/README.md`, add a "Results datastore" section
+documenting: the DB location (`~/.local/share/hippo-bench/bench-results.db`,
+separate from `hippo.db`); the four tables and what each captures; that
+retrieval (MRR/Hit@1) is the headline and enrichment gates are full-coverage;
+auto-ingest at run-end plus `hippo-bench ingest <jsonl> [--all] [--force]` for
+backfill; and `hippo-bench export-dashboard [--out]` → one self-contained HTML
+file with leaderboard + run history. Note the JSONL is now a disposable working
+file and the datastore is the durable keeper.
+
+- [ ] **Step 2: Update root CLAUDE.md**
+
+Under the hippo-bench area of `CLAUDE.md`, add a short subsection:
+"Bench results datastore — `bench-results.db` (separate from `hippo.db`),
+auto-ingested at run-end via `results_store.ingest_run`; per-(model, corpus-node)
+scoring across all runs; `hippo-bench ingest`/`export-dashboard` CLIs; spec at
+`docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md`."
+
+- [ ] **Step 3: Verify the whole bench suite is green + lint clean**
+
+Run:
+```bash
+uv run --project brain pytest brain/tests -k bench -v
+uv run --project brain ruff check brain/ && uv run --project brain ruff format --check brain/
+```
+Expected: all PASS, no lint errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add brain/src/hippo_brain/bench/README.md CLAUDE.md
+git commit -m "docs(bench): document results datastore + dashboard commands"
+```
+
+---
+
+## Final verification
+
+- [ ] Whole-DB rebuild is deterministic: `hippo-bench ingest --all --force` over a
+  folder of run JSONLs reproduces the same row counts. (Covered by Task 8 force
+  test at unit level; spot-check manually if real run JSONLs exist.)
+- [ ] Run the full brain suite once: `uv run --project brain pytest brain/tests -q`.
+- [ ] Confirm `bench-results.db` is **not** committed (it lives under
+  `~/.local/share/hippo-bench/`, outside the repo — no `.gitignore` change needed).

--- a/docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md
+++ b/docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md
@@ -39,7 +39,10 @@ corpus"*, visualized in a separate, all-local dashboard with a leaderboard.
 - **Not** recovering the already-lost historical runs (the leftover scratch dirs
   contain no JSONL — nothing to recover). Existing scratch dirs are left alone.
 - **Not** multi-host / sync. This is a single-host deployment.
-- **Not** changing the JSONL run format or the `summary`/`determinism` consumers.
+- **Not** changing the JSONL run format in a breaking way, nor touching the
+  `summary`/`determinism` consumers. (One *additive*, non-breaking field is added:
+  each `downstream_proxy.per_item` score now also carries its `golden_event_id`,
+  so retrieval rows can be keyed to a corpus node. Existing consumers ignore it.)
 
 ## Key Design Decision: the two per-node signals
 

--- a/docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md
+++ b/docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md
@@ -1,0 +1,289 @@
+# hippo-bench Results Datastore + Dashboard — Design
+
+**Date:** 2026-05-31
+**Status:** Approved (brainstorming), pending implementation plan
+**Author:** Steven Carpenter
+
+## Problem
+
+`hippo-bench run` is the only thing that scores enrichment models against a
+frozen corpus, but its output is not being **kept**. Each run streams a single
+append-only JSONL file to `~/.local/share/hippo-bench/runs/run-{ts}-{host}.jsonl`
+(`cli.py:218`, written by `output.RunWriter`). That file is:
+
+- **gitignored and local-only** (`.gitignore:433`) — never committed, never backed up;
+- **not indexed** — no catalog, no `list`, no cross-run query; consumers
+  (`hippo-bench summary`, `hippo-bench determinism`) take hand-fed file paths;
+- **not actually surviving on disk** — at design time, `runs/` held **zero**
+  `.jsonl` files, only 112 MB of ephemeral per-model shadow-stack scratch dirs
+  (`runs/run-…/{model}/hippo.db`, logs). The durable results were gone; only the
+  disposable scratch remained.
+
+The goal: **all historical runs, referenceable**, with **per-corpus-node**
+scoring so we can answer *"which model performs best on each member of the
+corpus"*, visualized in a separate, all-local dashboard with a leaderboard.
+
+## Goals
+
+- A dedicated, all-local datastore separate from the application DB (`hippo.db`).
+- Per-`(model, corpus-node)` scoring retained across **all** runs.
+- Both scoring signals stored; **retrieval quality is the headline leaderboard
+  signal**, enrichment quality is the full-coverage health layer.
+- Auto-captured at run-end so history accrues without operator action.
+- A separate, self-contained dashboard (no running server) with a leaderboard,
+  per-node view, and run history.
+
+## Non-Goals
+
+- **Not** committing run data to git (explicit user constraint — stays local).
+- **Not** recovering the already-lost historical runs (the leftover scratch dirs
+  contain no JSONL — nothing to recover). Existing scratch dirs are left alone.
+- **Not** multi-host / sync. This is a single-host deployment.
+- **Not** changing the JSONL run format or the `summary`/`determinism` consumers.
+
+## Key Design Decision: the two per-node signals
+
+A bench run already contains two per-node scoring signals in its JSONL, with
+different coverage. The datastore captures **both** because both already exist in
+the file — normalizing them into queryable rows is marginal extra schema, not
+extra pipeline.
+
+| Signal | Source record | Coverage | Role |
+|---|---|---|---|
+| **Enrichment quality** | `attempt` (purpose=`main`) gates: `schema_valid`, `refusal_detected`, `echo_similarity`, `entity_type_sanity`, latency | **Every corpus node** | Full-coverage health layer |
+| **Retrieval quality** | `model_summary.downstream_proxy.per_item`: `rank`, `mrr`, `ndcg_at_10`, `hit_at_k{1,3,5,10}`, `qa_id`, `mode` (one entry per QA item × mode) | **QA-labeled subset only** | **Headline leaderboard** |
+
+Enrichment gates are a *floor* (did the output parse / not refuse / not echo),
+so they rarely discriminate "best". Retrieval (`score_single_retrieval`) measures
+whether a model's enrichment makes a node findable — the outcome hippo exists for
+— so it is the headline. Its coverage grows automatically as more `eval-qa` items
+are labeled; no schema change needed.
+
+## Architecture
+
+```
+orchestrate_run ──(writes JSONL as today)──▶ run-{ts}-{host}.jsonl  (disposable working file)
+       │
+       └─(at run_end, reads it back)──▶ results_store.ingest_run()
+                                              │
+                                              ▼
+                                    bench-results.db   (durable keeper, all-local)
+                                              │
+                          hippo-bench export-dashboard
+                                              ▼
+                                    dashboard.html     (self-contained, no server)
+```
+
+The JSONL stays the crash-safe streaming record during a run; at `run_end` it is
+ingested into the durable datastore. After ingest the JSONL is a disposable
+working file — losing it no longer loses history.
+
+### New units (each one job, well-bounded)
+
+- **`brain/src/hippo_brain/bench/results_store.py`** — owns `bench-results.db`:
+  schema creation/migration (own `PRAGMA user_version`), `ingest_run(jsonl_path,
+  force=False)` (idempotent, keyed on `run_id`), and query helpers used by the
+  exporter. Knows nothing about HTML.
+- **`brain/src/hippo_brain/bench/dashboard_export.py`** — owns the HTML: calls
+  `results_store` query helpers, embeds the result as a JSON blob in a single
+  self-contained template. Knows nothing about SQLite internals.
+- **CLI** (`bench/cli.py`): `hippo-bench ingest <jsonl> [--all] [--force]` and
+  `hippo-bench export-dashboard [--out <path>]`.
+- **Hook** (`bench/orchestrate.py`): one `ingest_run(out_path)` call at the end of
+  `orchestrate_run`, wrapped so an ingest failure **never** fails the run.
+
+## Datastore
+
+Location: `~/.local/share/hippo-bench/bench-results.db` (resolved via
+`paths.hippo_bench_root()`, sibling of `runs/` and `fixtures/`). SQLite, WAL mode,
+`PRAGMA foreign_keys=ON`, `busy_timeout=5000`, independent `PRAGMA user_version`.
+
+### Schema
+
+```sql
+CREATE TABLE bench_runs (
+    run_id                  TEXT PRIMARY KEY,
+    started_at_iso          TEXT,
+    finished_at_iso         TEXT,           -- NULL ⇒ incomplete/crashed run
+    host_json               TEXT,
+    bench_version           TEXT,
+    corpus_version          TEXT,
+    corpus_content_hash     TEXT,
+    corpus_schema_version   INTEGER,
+    eval_qa_version         TEXT,
+    embedding_model         TEXT,
+    inference_backend_version TEXT,
+    gate_thresholds_json    TEXT,
+    candidate_models_json   TEXT,
+    models_completed_json   TEXT,
+    models_errored_json     TEXT,
+    reason                  TEXT,
+    ingested_at_ms          INTEGER
+);
+
+CREATE TABLE bench_models (
+    run_id                TEXT,
+    model_id              TEXT,
+    schema_validity_rate  REAL,
+    refusal_rate          REAL,
+    echo_similarity_max   REAL,
+    latency_p50_ms        INTEGER,
+    latency_p95_ms        INTEGER,
+    latency_p99_ms        INTEGER,
+    self_consistency_mean REAL,    -- nullable: "not tested"
+    self_consistency_min  REAL,    -- nullable
+    entity_sanity_mean    REAL,
+    main_attempts_count   INTEGER,
+    verdict_passed        INTEGER, -- 0/1
+    failed_gates_json     TEXT,
+    errors_json           TEXT,
+    PRIMARY KEY (run_id, model_id),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+
+-- Full-coverage health layer: one row per corpus node per model (main pass).
+CREATE TABLE bench_node_enrichment (
+    run_id             TEXT,
+    model_id           TEXT,
+    event_id           TEXT,   -- source-prefixed corpus node id, e.g. "claude-2853"
+    source             TEXT,   -- shell | claude | browser | workflow
+    schema_valid       INTEGER,
+    refusal_detected   INTEGER,
+    echo_similarity    REAL,
+    entity_sanity      REAL,   -- per-attempt entity-type-sanity mean (nullable)
+    latency_ms         INTEGER,
+    timeout            INTEGER,
+    parsed_output_json TEXT,   -- the model's parsed enrichment output, for eyeballing
+    PRIMARY KEY (run_id, model_id, event_id),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+
+-- Headline leaderboard layer: one row per QA item per model per mode.
+-- Keyed on qa_id (not golden_event_id): two questions can target the same node.
+CREATE TABLE bench_node_retrieval (
+    run_id          TEXT,
+    model_id        TEXT,
+    qa_id           TEXT,
+    golden_event_id TEXT,   -- the corpus node the question targets (see producer change)
+    mode            TEXT,    -- hybrid | semantic | lexical
+    rank            INTEGER, -- NULL ⇒ not retrieved within k
+    mrr             REAL,
+    hit_at_1        INTEGER, -- 0/1, derived from per_item.hit_at_k[1]
+    hit_at_10       INTEGER, -- 0/1, derived from per_item.hit_at_k[10]
+    ndcg_at_10      REAL,
+    PRIMARY KEY (run_id, model_id, qa_id, mode),
+    FOREIGN KEY (run_id) REFERENCES bench_runs(run_id) ON DELETE CASCADE
+);
+```
+
+Indexes: `bench_node_retrieval(golden_event_id, mode)` and
+`bench_node_enrichment(event_id)` for the per-node leaderboard;
+`bench_runs(started_at_iso)` for "latest run" and history ordering.
+
+### Headline leaderboard query (latest run, history retained)
+
+The leaderboard headline uses the **latest run** that scored a given model/node;
+all previous runs stay in the DB for the history/trend view.
+
+```sql
+-- "best model on node X", latest run only
+WITH latest AS (
+  SELECT model_id, golden_event_id, mrr, hit_at_1,
+         ROW_NUMBER() OVER (
+           PARTITION BY model_id, golden_event_id, mode
+           ORDER BY r.started_at_iso DESC
+         ) AS rn
+  FROM bench_node_retrieval nr
+  JOIN bench_runs r USING (run_id)
+  WHERE nr.golden_event_id = ? AND nr.mode = 'hybrid'
+)
+SELECT model_id, mrr, hit_at_1 FROM latest WHERE rn = 1 ORDER BY mrr DESC;
+```
+
+## Ingest
+
+`results_store.ingest_run(jsonl_path, force=False)`:
+
+1. Parse the JSONL stream by `record_type`: `run_manifest` → `bench_runs` row;
+   `model_summary` → `bench_models` rows (+ verdict via `summary.compute_verdict`);
+   `attempt` (purpose=`main`) → `bench_node_enrichment` rows; the
+   `model_summary.downstream_proxy.per_item` flat list →
+   `bench_node_retrieval` rows (`hit_at_1`/`hit_at_10` extracted from each
+   item's `hit_at_k` dict; `golden_event_id` from the producer change below);
+   `run_end` → fill `finished_at_iso`, `models_completed/errored`, `reason`.
+2. **Idempotency**: if `run_id` already present and not `force`, no-op. With
+   `force` (or first ingest), run a single transaction: `DELETE FROM bench_runs
+   WHERE run_id=?` (cascades), then insert all rows. A run's JSONL is immutable
+   after `run_end`, so this is safe and makes whole-DB rebuild deterministic.
+3. **Partial/crashed JSONL** (no `run_end`): ingest what is present;
+   `finished_at_iso` stays NULL and the run is rendered as "incomplete".
+4. **Malformed lines**: skip + count + log a warning; never abort the whole
+   ingest over one bad line.
+
+### Producer change (one line, justified)
+
+`downstream_proxy.run_downstream_proxy_pass` currently stamps each `per_item`
+score with `qa_id` and `mode` but **not** `golden_event_id`. Add
+`score["golden_event_id"] = item["golden_event_id"]` next to the existing
+`score["qa_id"] = ...` (`downstream_proxy.py:158`). This makes each run's JSONL
+self-describing — ingest never has to re-read the `eval-qa` fixture (which can be
+relabeled between runs) to resolve a node id, and historical runs stay correct
+even as labels evolve. Update the downstream_proxy golden/unit tests to expect
+the new field.
+
+Trigger points:
+- **Auto**: end of `orchestrate_run`, after `writer.close()`, wrapped in
+  try/except — a failed ingest logs and leaves the JSONL as fallback but does
+  **not** fail the bench run (AP-1 spirit: a reporting concern must not break the
+  primary path).
+- **Manual**: `hippo-bench ingest <jsonl>` (one file), `--all` (scan `runs/` for
+  `*.jsonl`), `--force` (re-ingest existing `run_id`s).
+
+## Dashboard
+
+`hippo-bench export-dashboard [--out <path>]` (default
+`~/.local/share/hippo-bench/dashboard.html`). Queries `bench-results.db` via
+`results_store` helpers, embeds the data as a `<script type="application/json">`
+blob in a single self-contained HTML file (vanilla JS, no network, no server).
+Regenerate after each run (or wire into the auto-ingest hook later). Three views:
+
+1. **Leaderboard** — models ranked by aggregate retrieval MRR / Hit@1 for the
+   selected run (default: latest). Enrichment gate rates as secondary columns.
+2. **Per-node** — pick a corpus node → each model's retrieval rank/MRR (if
+   QA-labeled) plus enrichment gates and `parsed_output_json` (always). This is
+   the "best model per member of the corpus" view.
+3. **Run history** — every run with `corpus_version`, timestamp, and a trend of
+   headline metrics across runs.
+
+## Testing
+
+pytest, reusing existing JSONL golden fixtures (`test_bench_golden.py` and a
+sample run file):
+
+- ingest idempotency: re-ingest same `run_id` is a no-op; `--force` replaces.
+- both-signal extraction correctness (enrichment rows from `attempt`; retrieval
+  rows from `downstream_proxy.per_item`).
+- partial JSONL (no `run_end`) → run marked incomplete, rows still ingested.
+- malformed-line tolerance → skipped + counted, ingest completes.
+- `export-dashboard` produces a self-contained HTML with the data blob embedded;
+  deterministic output for a fixed DB.
+- whole-DB rebuild from a folder of JSONLs is deterministic (`--all` + `--force`).
+
+## Error Handling Summary
+
+- Run-end auto-ingest wrapped: never fails the bench run; JSONL is the fallback.
+- Nullable signals (`self_consistency_*`, `rank`, `entity_sanity`) stored as NULL,
+  preserving the existing "not tested" semantics (`summary.compute_verdict` skips
+  NULLs rather than failing).
+- Foreign keys with `ON DELETE CASCADE` so `--force` re-ingest cleanly replaces a
+  run's full row set in one transaction.
+
+## Open Questions / Future
+
+- Store **raw** (un-parsed) enrichment output too? Deferred — `parsed_output_json`
+  covers eyeballing; raw is bulky. Revisit if parsed proves insufficient.
+- Auto-run `export-dashboard` inside the run-end hook vs. on demand? Start on
+  demand; promote to auto if it proves useful.
+- Retention/size policy for `bench-results.db`? Not needed initially — distilled
+  per-node rows are small; the heavy scratch dirs in `runs/` are the size concern
+  and are out of scope here.

--- a/docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md
+++ b/docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md
@@ -1,7 +1,7 @@
 # hippo-bench Results Datastore + Dashboard — Design
 
 **Date:** 2026-05-31
-**Status:** Approved (brainstorming), pending implementation plan
+**Status:** Implemented (PR #192); enrichment layer deferred to #191
 **Author:** Steven Carpenter
 
 ## Problem

--- a/docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md
+++ b/docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md
@@ -278,6 +278,23 @@ sample run file):
 - Foreign keys with `ON DELETE CASCADE` so `--force` re-ingest cleanly replaces a
   run's full row set in one transaction.
 
+## Implementation Note: enrichment layer deferred
+
+During implementation, the final review found that the bench pipeline does **not**
+emit `attempt` records with `purpose = 'main'` over the full corpus — every
+attempt is `purpose = 'self_consistency'`, and the self-consistency pass samples
+only a few nodes, while the shadow brain's full-corpus enrichment is discarded
+with the shadow stack. The `bench_node_enrichment` table and its ingest are
+therefore **dormant on real runs** (correct, tested against synthetic `main`
+attempts, but empty on real data). The retrieval layer — the agreed headline — is
+unaffected and ships fully working.
+
+Restoring full-corpus per-node enrichment (and, by the same root cause, the
+currently-vacuous per-model gate scorecard) is tracked in
+[#191](https://github.com/stevencarpenter/hippo/issues/191) and is the immediate
+follow-up. The schema and ingest here are intentionally left in place so that work
+is purely additive (emit the records; the datastore already consumes them).
+
 ## Open Questions / Future
 
 - Store **raw** (un-parsed) enrichment output too? Deferred — `parsed_output_json`


### PR DESCRIPTION
## Summary

Adds a durable, all-local **bench results datastore** so every hippo-bench run is referenceable across history, plus a self-contained HTML dashboard to view it.

- **`bench-results.db`** (separate SQLite, sibling of `runs/`, never `hippo.db`) with four tables: `bench_runs`, `bench_models`, `bench_node_enrichment`, `bench_node_retrieval`.
- **Auto-ingest at run-end** (`orchestrate._safe_ingest` → `results_store.ingest_run`), wrapped so a datastore failure never fails the bench run; the JSONL reverts to a disposable working file. Idempotent on `run_id`.
- **`hippo-bench ingest <jsonl…> | --all [--force]`** for backfill, and **`hippo-bench export-dashboard [--out]`** → one self-contained HTML file (leaderboard + per-node "best model per corpus member" + run history). The dashboard renders all values via `textContent` (no `innerHTML` with data), so stored LLM output cannot inject markup.
- **Retrieval (MRR/Hit@1) is the headline** leaderboard signal; the leaderboard uses the latest run that has retrieval rows, with all prior runs retained for history.
- One-line producer change: each `downstream_proxy.per_item` score now carries its `golden_event_id`, making run JSONLs self-describing.

### Scope note: enrichment layer deferred

`bench_node_enrichment` ships **dormant** — the bench pipeline emits no `purpose='main'` attempts over the full corpus today (the self-consistency pass samples only a few nodes; the shadow brain's full-corpus enrichment is discarded with the shadow stack). The schema + ingest are in place so the follow-up is purely additive. Tracked in #191 (picked up next), which also fixes the same-root vacuous per-model gate scorecard.

## Review

Went through two adversarial review passes. The first (`pr-review-toolkit`) deferred enrichment to #191 and surfaced two query/ingest bugs (fixed). A second xhigh multi-angle pass found and fixed 8 more: CLI ingest per-file error isolation, graceful handling of a manifest missing `run_id`, honest status labels for aborted/no-manifest runs, multi-file glob support, `None`→SQL NULL for `parsed_output_json`, `INSERT OR REPLACE` for duplicate model_ids, re-ingest of completed-after-partial runs, and an N+1 → bulk fetch in the dashboard exporter.

## Test Plan

- [x] `uv run --project brain pytest brain/tests -k bench` — 291 passed
- [x] `ruff check brain/` + `ruff format --check` — clean
- [x] End-to-end smoke: synthetic run → `ingest` → idempotent re-ingest → `export-dashboard` → datastore rows + dashboard HTML verified
- [ ] Reviewer: confirm the enrichment-deferral scope (#191) reads correctly

## Docs

- Design spec: `docs/superpowers/specs/2026-05-31-bench-results-datastore-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-31-bench-results-datastore.md`
- Operator docs: `brain/src/hippo_brain/bench/README.md` (Results datastore section)
