### PR TITLE
feat(bench): emit full-corpus main enrichment pass (closes #191)

### DIFF
--- a/brain/src/hippo_brain/bench/README.md
+++ b/brain/src/hippo_brain/bench/README.md
@@ -386,7 +386,7 @@ Four tables, keyed on `run_id` (children cascade-delete on `--force` re-ingest):
 |---|---|---|
 | `bench_runs` | one per run | manifest + run_end: corpus version/hash, thresholds, models, timestamps |
 | `bench_models` | per (run, model) | aggregate gate rates, latency percentiles, verdict |
-| `bench_node_enrichment` | per (run, model, corpus node) | enrichment gates + `parsed_output_json` — per-node health layer (**dormant**, see below) |
+| `bench_node_enrichment` | per (run, model, corpus node) | enrichment gates + `parsed_output_json` — per-node health layer (full-corpus coverage) |
 | `bench_node_retrieval` | per (run, model, QA item, mode) | rank, MRR, Hit@1/10, NDCG — **the headline**, QA-labeled subset only |
 
 **Two scoring signals, two roles.** Retrieval quality (MRR/Hit@1, from
@@ -394,13 +394,21 @@ Four tables, keyed on `run_id` (children cascade-delete on `--force` re-ingest):
 a model's enrichment makes a node findable, the outcome hippo exists for. Its
 coverage grows automatically as more `eval-qa` items are labeled.
 
-> **`bench_node_enrichment` is dormant on real runs.** The ingest + schema are in
-> place, but the bench pipeline does not yet emit per-node enrichment records over
-> the full corpus (the self-consistency pass samples only a few nodes, and the
-> shadow brain's full-corpus enrichment is discarded with the shadow stack). Until
-> that lands, this table stays empty on real runs and the dashboard's per-node
-> enrichment view shows "(no data)". Tracked in
-> [#191](https://github.com/stevencarpenter/hippo/issues/191) — picked up next.
+Enrichment quality (`bench_node_enrichment`) is the **per-node health layer** —
+one direct enrichment call per corpus event, per model (`purpose = "main"`). It
+captures schema-validity, refusal, echo-similarity, entity-sanity, latency, and
+parsed output for every corpus member, so the dashboard's per-node view shows
+"best model per corpus node" across the full corpus (not just the QA-labeled
+subset). These records also back the per-model gate scorecard: schema-validity
+rate, refusal rate, and latency percentiles are computed exclusively from
+`main`-purpose attempts. Inference cost of the main pass is the measurement itself —
+one call per event is required to know how the model actually handles each input.
+
+> **Inference cost at corpus scale:** the main pass calls the inference server once
+> per corpus event per model. With a 100-event corpus and p95 latency of 15s, a
+> single-model run takes ~25 min of inference time (overlapping with other steps).
+> At 5s p95, it's ~8 min. This is intentional: the cost is the measurement. Use
+> `mise run bench:corpus:init --corpus-buckets 9` to control corpus size.
 
 ```bash
 # Backfill any surviving run JSONLs (one file, or every *.jsonl under runs/)
@@ -439,7 +447,7 @@ blanks). All prior runs stay in the datastore for the per-node and history views
 | [`shadow_stack.py`](shadow_stack.py) | Process-group spawn (daemon + brain), env injection, SIGTERM/SIGKILL teardown |
 | [`downstream_proxy.py`](downstream_proxy.py) | Q/A loading, Hit@K, MRR, NDCG, ask-synthesis sampling |
 | [`coordinator.py`](coordinator.py) | Per-model lifecycle (shadow stack, queue drain, downstream proxy) |
-| [`runner.py`](runner.py) | Self-consistency pass; per-attempt gate composition |
+| [`runner.py`](runner.py) | Main enrichment pass (full corpus, `purpose='main'`); self-consistency pass (sample, N runs); shared per-attempt gate composition |
 | [`output.py`](output.py) | JSONL record dataclasses + append-only writer |
 | [`results_store.py`](results_store.py) | Durable `bench-results.db`: schema, idempotent `ingest_run`, leaderboard/node/history queries |
 | [`dashboard_export.py`](dashboard_export.py) | Renders the datastore to one self-contained HTML file (leaderboard + per-node + history) |
@@ -466,16 +474,16 @@ blanks). All prior runs stay in the datastore for the per-node and history views
   (prod brain,                               ▼
    corpus, lms,                       coordinator.run_one_model
    disk, port)                               │
-                            ┌─────────┬──────┼──────┬─────────────────────┐
-                            ▼         ▼      ▼      ▼                     ▼
-                       lms.unload  metrics  shadow_stack.spawn    runner.run_self_consistency
-                       lms.load    Sampler  → daemon + brain      enrich_call.call_enrichment
-                                            → wait_for_brain_ready enrich_call.call_embedding
+                            ┌─────────┬──────┼──────┬───────────────────────────────────────────┐
+                            ▼         ▼      ▼      ▼                                           ▼
+                       lms.unload  metrics  shadow_stack.spawn    runner.run_main_enrichment_pass (all events, once)
+                       lms.load    Sampler  → daemon + brain      runner.run_self_consistency_pass (sample, N runs)
+                                            → wait_for_brain_ready enrich_call.call_enrichment
                                             → drain queue                  │
                                             → downstream_proxy             ▼
                                               .run_downstream       gates.check_*  → AttemptRecord
-                                              _proxy_pass                   │
-                                            → teardown                      ▼
+                                              _proxy_pass             (purpose='main' or 'self_consistency')
+                                            → teardown                      │
                                                   │              system_snapshot
                                                   ▼                         │
                                           ModelRunResult ◄──────────────────┘

--- a/brain/src/hippo_brain/bench/coordinator.py
+++ b/brain/src/hippo_brain/bench/coordinator.py
@@ -1,6 +1,6 @@
 """Per-model lifecycle:
 unload → load → copy corpus → spawn shadow stack → warmup → timed drain →
-downstream-proxy pass → self-consistency pass → teardown → cooldown.
+downstream-proxy pass → main enrichment pass → self-consistency pass → teardown → cooldown.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ from hippo_brain.bench.paths import bench_qa_path, bench_run_tree
 from hippo_brain.bench.qa import collect_corpus_event_ids
 from hippo_brain.bench.pause_rpc import PauseRpcClient
 from hippo_brain.bench.preflight import check_brain_port_free
-from hippo_brain.bench.runner import run_self_consistency_pass
+from hippo_brain.bench.runner import run_main_enrichment_pass, run_self_consistency_pass
 from hippo_brain.vector_store import open_conn as open_vec_conn
 from hippo_brain.bench.shadow_stack import (
     spawn_shadow_stack,
@@ -337,7 +337,23 @@ def run_one_model(
         except Exception as e:
             _capture("downstream_proxy", e)
 
-        # 10. Self-consistency pass — 5 events × N runs via direct inference-server calls
+        # 10. Main enrichment pass — one call per corpus event, purpose='main'
+        if all_entries:
+            try:
+                main_attempts = run_main_enrichment_pass(
+                    base_url=inference_url,
+                    model=model,
+                    entries=all_entries,
+                    timeout_sec=timeout_sec,
+                    metrics_snapshot=_metrics_snapshot_fn(sampler),
+                    temperature=temperature,
+                    run_id=run_id,
+                )
+                attempts.extend(main_attempts)
+            except Exception as e:
+                _capture("main_enrichment", e)
+
+        # 12. Self-consistency pass — 5 events × N runs via direct inference-server calls
         if all_entries and sc_events > 0 and sc_runs > 0:
             sc_pool = rng.sample(all_entries, min(sc_events, len(all_entries)))
             try:
@@ -358,7 +374,7 @@ def run_one_model(
                 _capture("self_consistency", e)
 
     finally:
-        # 11. Teardown — runs even if any step above raised so we never leak
+        # 13. Teardown — runs even if any step above raised so we never leak
         # shadow processes or leave the metrics sampler running.
         if sampler is not None:
             try:
@@ -373,7 +389,7 @@ def run_one_model(
                     "BT-03: teardown_shadow_stack failed — manual cleanup may be required"
                 )
 
-    # 12. Cooldown
+    # 14. Cooldown
     cooldown_start = time.time()
     cooldown_timeout = False
     while time.time() - cooldown_start < cooldown_max_sec:

--- a/brain/src/hippo_brain/bench/results_store.py
+++ b/brain/src/hippo_brain/bench/results_store.py
@@ -334,13 +334,10 @@ def _entity_sanity_mean(per_cat: dict | None) -> float | None:
 
 
 def _ingest_enrichment(conn: sqlite3.Connection, run_id: str, records: list[dict]) -> int:
-    # DORMANT on real runs: this selects `main`-purpose attempts, but the bench
-    # pipeline does not yet emit any (the self-consistency pass labels its
-    # attempts `self_consistency`, and the shadow brain's full-corpus enrichment
-    # is discarded with the shadow stack). The ingest + schema are ready; the
-    # producer is owed by https://github.com/stevencarpenter/hippo/issues/191.
-    # Until then this is a no-op on real runs (tests exercise it with synthetic
-    # `main` attempts). Keep the `main` filter — it is the correct contract.
+    # Selects `main`-purpose attempts produced by runner.run_main_enrichment_pass —
+    # one call per corpus event, covering the full corpus. The `main` filter is the
+    # correct contract: self-consistency attempts are intentionally excluded so they
+    # don't skew per-event rates.
     n = 0
     for r in records:
         if r.get("record_type") != "attempt" or r.get("purpose") != "main":

--- a/brain/src/hippo_brain/bench/runner.py
+++ b/brain/src/hippo_brain/bench/runner.py
@@ -1,4 +1,4 @@
-"""Per-model self-consistency pass: N attempts per event with embedding."""
+"""Per-model enrichment passes: main (full corpus, once each) and self-consistency (sample, N times)."""
 
 from __future__ import annotations
 
@@ -97,6 +97,57 @@ def _compute_gates(call_result, entry: CorpusEntry) -> tuple[dict, dict | None]:
         },
         schema_result.parsed,
     )
+
+
+def run_main_enrichment_pass(
+    *,
+    base_url: str,
+    model: str,
+    entries: list[CorpusEntry],
+    timeout_sec: int,
+    metrics_snapshot: Callable[[], dict],
+    temperature: float,
+    run_id: str = "run-local",
+) -> list[AttemptRecord]:
+    """One enrichment call per corpus event, labelled purpose='main'.
+
+    Covers the full corpus — no sampling. Results feed:
+    - aggregate_model_summary (schema-validity / refusal / latency / entity-sanity rates)
+    - _ingest_enrichment in results_store (bench_node_enrichment table)
+
+    No embeddings: self-consistency cosines come from the SC pass; the main
+    pass only measures per-event correctness and gate rates.
+    """
+    model_dict = {"id": model}
+    attempts: list[AttemptRecord] = []
+    for entry in entries:
+        start_iso = _dt.datetime.now(tz=_dt.UTC).isoformat()
+        start_monotonic_ns = time.monotonic_ns()
+        cr = call_enrichment(
+            base_url=base_url,
+            model=model,
+            payload=entry.redacted_content,
+            source=entry.source,
+            timeout_sec=timeout_sec,
+            temperature=temperature,
+        )
+        gates, parsed = _compute_gates(cr, entry)
+        attempts.append(
+            _build_attempt(
+                run_id=run_id,
+                model=model_dict,
+                entry=entry,
+                attempt_idx=0,
+                purpose="main",
+                call_result=cr,
+                gates=gates,
+                parsed=parsed,
+                system_snapshot=metrics_snapshot(),
+                start_iso=start_iso,
+                start_monotonic_ns=start_monotonic_ns,
+            )
+        )
+    return attempts
 
 
 def run_self_consistency_pass(

--- a/brain/tests/test_bench_coordinator.py
+++ b/brain/tests/test_bench_coordinator.py
@@ -41,6 +41,7 @@ def _patch_lifecycle(
     drain_raises: BaseException | None = None,
     sc_raises: BaseException | None = None,
     proxy_raises: BaseException | None = None,
+    main_raises: BaseException | None = None,
 ) -> dict[str, MagicMock]:
     """Stub every I/O dependency. Returns a dict of MagicMocks keyed by name
     so the test can assert call counts."""
@@ -87,7 +88,7 @@ def _patch_lifecycle(
     pause_client_mock.probe_health.return_value = {"paused": False}
     monkeypatch.setattr(coordinator, "PauseRpcClient", MagicMock(return_value=pause_client_mock))
 
-    # Patch downstream proxy + SC pass for the optional-error variants.
+    # Patch downstream proxy, SC pass, and main enrichment pass for the optional-error variants.
     if proxy_raises is not None:
         monkeypatch.setattr(
             coordinator,
@@ -100,6 +101,14 @@ def _patch_lifecycle(
             "run_self_consistency_pass",
             MagicMock(side_effect=sc_raises),
         )
+    # Always stub run_main_enrichment_pass — it makes real inference calls when the corpus
+    # is non-empty, and most tests just want isolation. Tests that care about the main
+    # pass explicitly override this with their own mock after calling _patch_lifecycle.
+    main_mock = MagicMock(
+        return_value=[],
+        side_effect=main_raises if main_raises is not None else None,
+    )
+    monkeypatch.setattr(coordinator, "run_main_enrichment_pass", main_mock)
 
     return {
         "spawn": spawn_mock,
@@ -107,6 +116,7 @@ def _patch_lifecycle(
         "teardown": teardown_mock,
         "drain": drain_mock,
         "sampler": sampler_mock,
+        "main": main_mock,
     }
 
 
@@ -218,9 +228,9 @@ def test_smoke_run_one_model_full_lifecycle(
     """BT-12: end-to-end smoke through every step.
 
     Patches every I/O boundary, runs through unload→load→spawn→drain→
-    downstream-proxy→SC→teardown→cooldown, and asserts:
+    downstream-proxy→main-enrichment→SC→teardown→cooldown, and asserts:
     - downstream_proxy is populated (not silently {})
-    - SC attempts list is populated
+    - main-pass and SC attempts are both plumbed into result.attempts
     - errors list is empty (clean path)
     - teardown was called exactly once
     """
@@ -250,12 +260,19 @@ def test_smoke_run_one_model_full_lifecycle(
         "run_downstream_proxy_pass",
         MagicMock(return_value={"hit_at_1": 0.4, "mrr": 0.35, "ndcg_at_10": 0.42}),
     )
-    # Provide a non-empty corpus so SC pass actually runs.
+    # Provide a non-empty corpus so main and SC passes actually run.
     fake_entry = MagicMock(redacted_content="hello", source="shell")
     monkeypatch.setattr(
         coordinator,
         "_load_corpus_entries",
         MagicMock(return_value=[fake_entry, fake_entry, fake_entry]),
+    )
+    main_attempt = MagicMock()
+    main_attempt.purpose = "main"
+    monkeypatch.setattr(
+        coordinator,
+        "run_main_enrichment_pass",
+        MagicMock(return_value=[main_attempt, main_attempt, main_attempt]),
     )
     sc_attempt = MagicMock()
     sc_attempt.to_dict.return_value = {"k": "v"}
@@ -282,7 +299,7 @@ def test_smoke_run_one_model_full_lifecycle(
         "mrr": 0.35,
         "ndcg_at_10": 0.42,
     }, "downstream_proxy must be populated, not silently empty"
-    assert len(result.attempts) == 2, "SC attempts plumbed into result"
+    assert len(result.attempts) == 5, "3 main + 2 SC attempts plumbed into result"
     assert result.errors == [], "no errors on clean path"
 
 
@@ -544,3 +561,82 @@ def test_load_corpus_failure_captured_as_structured_error(
     assert load_error["type"] == "ValueError"
     # Bench continued past the failure — it's a captured-error, not a crash.
     assert result.model == "test-model"
+
+
+def test_main_enrichment_pass_called_with_full_corpus(
+    monkeypatch: pytest.MonkeyPatch, fake_corpus: Path
+) -> None:
+    """Cycle 2 RED: coordinator invokes run_main_enrichment_pass over ALL corpus entries."""
+    from hippo_brain.bench.corpus import CorpusEntry
+    from hippo_brain.bench.output import AttemptRecord
+
+    entries = [
+        CorpusEntry(event_id=f"shell-{i}", source="shell", redacted_content=f"cmd {i}")
+        for i in range(4)
+    ]
+    main_attempts = [
+        AttemptRecord(
+            run_id="test-run",
+            model={"id": "test-model"},
+            event={"event_id": e.event_id, "source": e.source, "content_hash": ""},
+            attempt_idx=0,
+            purpose="main",
+            timestamps={},
+            raw_output="",
+            parsed_output=None,
+            gates={"schema_valid": True},
+            system_snapshot={},
+        )
+        for e in entries
+    ]
+
+    main_pass_mock = MagicMock(return_value=main_attempts)
+    mocks = _patch_lifecycle(monkeypatch)
+    monkeypatch.setattr(coordinator, "_load_corpus_entries", MagicMock(return_value=entries))
+    monkeypatch.setattr(coordinator, "run_main_enrichment_pass", main_pass_mock)
+
+    result = coordinator.run_one_model(
+        model="test-model",
+        run_id="test-run",
+        corpus_sqlite=fake_corpus,
+        warmup_calls=0,
+        sc_events=0,
+        cooldown_max_sec=0,
+    )
+
+    main_pass_mock.assert_called_once()
+    call_kwargs = main_pass_mock.call_args.kwargs
+    assert call_kwargs["entries"] == entries, "main pass must receive the full corpus, not a sample"
+    assert call_kwargs["model"] == "test-model"
+    assert call_kwargs["run_id"] == "test-run"
+    main_in_result = [a for a in result.attempts if a.purpose == "main"]
+    assert len(main_in_result) == len(entries), (
+        "all main-pass attempts must appear in ModelRunResult.attempts"
+    )
+    assert mocks["teardown"].call_count == 1
+
+
+def test_main_enrichment_pass_failure_captured_as_structured_error(
+    monkeypatch: pytest.MonkeyPatch, fake_corpus: Path
+) -> None:
+    """Cycle 2 RED: a crash in run_main_enrichment_pass is captured, not propagated."""
+    from hippo_brain.bench.corpus import CorpusEntry
+
+    entries = [CorpusEntry(event_id="e1", source="shell", redacted_content="ls")]
+    mocks = _patch_lifecycle(monkeypatch, main_raises=RuntimeError("synthetic: main pass boom"))
+    monkeypatch.setattr(coordinator, "_load_corpus_entries", MagicMock(return_value=entries))
+
+    result = coordinator.run_one_model(
+        model="test-model",
+        run_id="test-run",
+        corpus_sqlite=fake_corpus,
+        warmup_calls=0,
+        sc_events=0,
+        cooldown_max_sec=0,
+    )
+
+    assert mocks["teardown"].call_count == 1, "teardown still runs on captured main-pass failure"
+    main_error = next((e for e in result.errors if e["step"] == "main_enrichment"), None)
+    assert main_error is not None, f"expected main_enrichment error, got: {result.errors}"
+    assert "synthetic" in main_error["error"]
+    assert main_error["type"] == "RuntimeError"

--- a/brain/tests/test_bench_results_store.py
+++ b/brain/tests/test_bench_results_store.py
@@ -801,3 +801,92 @@ def test_enrichment_attempt_missing_event_id_is_skipped(tmp_path):
         assert [r["event_id"] for r in rows] == ["shell-9"]  # bad attempt skipped
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4: per-node dashboard view shows enrichment for every corpus node
+# ---------------------------------------------------------------------------
+
+
+def test_all_node_details_shows_enrichment_for_every_corpus_node(tmp_path):
+    """Cycle 4: all_node_details returns enrichment rows for every node that has
+    a main-pass attempt — verifying the dashboard's per-node view is populated."""
+    from hippo_brain.bench.results_store import all_node_details, connect, ingest_run
+
+    # Three corpus nodes — all with main-pass attempts.
+    corpus_event_ids = ["shell-1", "shell-2", "claude-7"]
+    records = [
+        _manifest("run-1"),
+        *[_attempt(event_id=eid) for eid in corpus_event_ids],
+        _model_summary("run-1"),
+        _run_end("run-1"),
+    ]
+    jsonl = _write_jsonl(tmp_path / "r.jsonl", records)
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        result = ingest_run(jsonl, conn=conn)
+        assert result.enrichment_rows == len(corpus_event_ids), (
+            f"expected {len(corpus_event_ids)} enrichment rows, got {result.enrichment_rows}"
+        )
+
+        nodes = all_node_details(conn)
+        for eid in corpus_event_ids:
+            assert eid in nodes, f"corpus node {eid!r} missing from all_node_details"
+            enrich = nodes[eid]["enrichment"]
+            assert len(enrich) == 1, f"expected 1 enrichment row for {eid!r}, got {len(enrich)}"
+            assert enrich[0]["model_id"] == "model-a"
+    finally:
+        conn.close()
+
+
+def test_all_node_details_enrichment_coverage_equals_corpus_size(tmp_path):
+    """Cycle 4: bench_node_enrichment rows == corpus size × models that ran."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    corpus_size = 5
+    corpus_events = [f"shell-{i}" for i in range(corpus_size)]
+    records = [
+        _manifest("run-1"),
+        *[_attempt(event_id=eid) for eid in corpus_events],
+        _model_summary("run-1"),
+        _run_end("run-1"),
+    ]
+    jsonl = _write_jsonl(tmp_path / "r.jsonl", records)
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        result = ingest_run(jsonl, conn=conn)
+        n = conn.execute("SELECT COUNT(*) FROM bench_node_enrichment").fetchone()[0]
+        assert n == corpus_size, (
+            f"bench_node_enrichment must have {corpus_size} rows (one per corpus event), got {n}"
+        )
+        assert result.enrichment_rows == corpus_size
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5: idempotency — re-ingest does not duplicate enrichment rows
+# ---------------------------------------------------------------------------
+
+
+def test_reingest_does_not_duplicate_enrichment_rows(tmp_path):
+    """Cycle 5: re-ingesting the same run JSONL must not produce duplicate rows
+    in bench_node_enrichment — the (run_id, model_id, event_id) PK must hold."""
+    from hippo_brain.bench.results_store import connect, ingest_run
+
+    records = [
+        _manifest("run-1"),
+        _attempt(event_id="shell-1"),
+        _attempt(event_id="shell-2"),
+        _model_summary("run-1"),
+        _run_end("run-1"),
+    ]
+    jsonl = _write_jsonl(tmp_path / "r.jsonl", records)
+    conn = connect(tmp_path / "bench-results.db")
+    try:
+        ingest_run(jsonl, conn=conn)
+        ingest_run(jsonl, conn=conn, force=True)  # explicit force to re-ingest same run_id
+        n = conn.execute("SELECT COUNT(*) FROM bench_node_enrichment").fetchone()[0]
+        assert n == 2, f"re-ingest must not duplicate rows: expected 2 (one per event), got {n}"
+    finally:
+        conn.close()

--- a/brain/tests/test_bench_runner.py
+++ b/brain/tests/test_bench_runner.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from hippo_brain.bench.corpus import CorpusEntry
 from hippo_brain.bench.enrich_call import CallResult
-from hippo_brain.bench.runner import run_self_consistency_pass
+from hippo_brain.bench.runner import run_main_enrichment_pass, run_self_consistency_pass
 
 
 @patch("hippo_brain.bench.runner.call_embedding")
@@ -32,3 +32,81 @@ def test_self_consistency_pass_embeds_each_output(mock_call, mock_embed):
     assert len(attempts) == 2 * 3
     assert len(per_event_vectors) == 2
     assert all(len(v) == 3 for v in per_event_vectors)
+
+
+@patch("hippo_brain.bench.runner.call_enrichment")
+def test_main_enrichment_pass_one_attempt_per_event(mock_call):
+    """Cycle 1 RED: exactly one main-purpose attempt per corpus event."""
+    mock_call.return_value = CallResult(
+        raw_output='{"summary": "ok", "intent": "x", "outcome": "success", "entities": {}}',
+        ttft_ms=None,
+        total_ms=50,
+        timeout=False,
+    )
+    entries = [
+        CorpusEntry(event_id="e1", source="shell", redacted_content="ls"),
+        CorpusEntry(event_id="e2", source="shell", redacted_content="pwd"),
+        CorpusEntry(event_id="e3", source="shell", redacted_content="cargo test"),
+    ]
+    attempts = run_main_enrichment_pass(
+        base_url="http://x",
+        model="m1",
+        entries=entries,
+        timeout_sec=10,
+        metrics_snapshot=lambda: {},
+        temperature=0.0,
+        run_id="run-test",
+    )
+    assert len(attempts) == len(entries), "one attempt per corpus event, no more"
+    assert all(a.purpose == "main" for a in attempts), "every attempt must be purpose='main'"
+    assert [a.event["event_id"] for a in attempts] == ["e1", "e2", "e3"]
+    assert all(a.attempt_idx == 0 for a in attempts)
+    assert mock_call.call_count == len(entries)
+
+
+@patch("hippo_brain.bench.runner.call_enrichment")
+def test_main_enrichment_pass_populates_gates(mock_call):
+    """Cycle 1 RED: gates are computed and stored on each main-pass attempt."""
+    mock_call.return_value = CallResult(
+        raw_output='{"summary": "ok", "intent": "x", "outcome": "success", "entities": {}}',
+        ttft_ms=None,
+        total_ms=80,
+        timeout=False,
+    )
+    entries = [CorpusEntry(event_id="e1", source="shell", redacted_content="echo hi")]
+    attempts = run_main_enrichment_pass(
+        base_url="http://x",
+        model="m1",
+        entries=entries,
+        timeout_sec=10,
+        metrics_snapshot=lambda: {},
+        temperature=0.0,
+    )
+    assert len(attempts) == 1
+    gates = attempts[0].gates
+    assert "schema_valid" in gates
+    assert "refusal_detected" in gates
+    assert "echo_similarity" in gates
+    assert attempts[0].parsed_output is not None
+
+
+@patch("hippo_brain.bench.runner.call_enrichment")
+def test_main_enrichment_pass_does_not_embed(mock_call):
+    """Cycle 1 RED: main pass never calls call_embedding (no SC vectors needed)."""
+    mock_call.return_value = CallResult(
+        raw_output='{"summary": "ok", "intent": "x", "outcome": "success", "entities": {}}',
+        ttft_ms=None,
+        total_ms=50,
+        timeout=False,
+    )
+    entries = [CorpusEntry(event_id="e1", source="shell", redacted_content="ls")]
+    with patch("hippo_brain.bench.runner.call_embedding") as mock_embed:
+        run_main_enrichment_pass(
+            base_url="http://x",
+            model="m1",
+            entries=entries,
+            timeout_sec=10,
+            metrics_snapshot=lambda: {},
+            temperature=0.0,
+        )
+        mock_embed.assert_not_called()

--- a/brain/tests/test_bench_summary.py
+++ b/brain/tests/test_bench_summary.py
@@ -216,3 +216,20 @@ def test_self_consistency_gate_values_return_real_scores():
     )
     assert mean == 0.5
     assert minimum == 0.0
+
+
+def test_gate_scorecard_is_non_vacuous_with_main_pass_attempts():
+    """Cycle 2 (issue #191): gate aggregation returns measured rates (not 0.0 defaults)
+    when fed main-purpose attempts — i.e. the 'no main attempts' vacuous path is gone."""
+    main_attempts = [
+        _attempt(schema_valid=True, purpose="main", event_id=f"e{i}") for i in range(10)
+    ]
+    gates = aggregate_model_summary(
+        attempts=main_attempts,
+        self_consistency_mean=0.85,
+        self_consistency_min=0.80,
+    )
+    assert gates["main_attempts_count"] == 10, "must count all 10 main attempts"
+    assert gates["schema_validity_rate"] == 1.0, "all valid → rate must be 1.0, not vacuous 0.0"
+    assert gates["refusal_rate"] == 0.0
+    assert gates["self_consistency_mean"] == 0.85


### PR DESCRIPTION
## Summary

This PR implements issue #191 — the enrichment half of the bench-results-datastore work. It adds `run_main_enrichment_pass` to fill the gap between the ingest layer (which was pre-written and correct) and the producer (which didn't exist).

**Note:** This PR includes the `bench-results-datastore` work (PR #192) as its base. The single new commit is the `#191` implementation on top.

### What was wrong

Two bench outputs were vacuous on every real run:

- **`bench_node_enrichment`** — 0 rows after every run. The ingest code (`_ingest_enrichment`) correctly selected `purpose='main'` attempts, but no producer ever emitted any.
- **Per-model gate scorecard** — `aggregate_model_summary` returned vacuous `0.0` defaults (schema-validity, refusal, latency) because the `total_main == 0` branch was always taken.

### What changed

- **`runner.py`**: adds `run_main_enrichment_pass` — one enrichment call per corpus event, `purpose='main'`, full corpus coverage (no sampling, no embeddings). Reuses existing `_build_attempt` and `_compute_gates` helpers.
- **`coordinator.py`**: calls `run_main_enrichment_pass` between the downstream-proxy pass and the self-consistency pass; failures captured via `_capture`.
- **`results_store.py`**: removes DORMANT comment (the code was correct all along).
- **`README.md`**: removes "dormant/pending" notes; documents per-event inference cost; updates module map and architecture diagram.

### Design note

The ingest, aggregation, and dashboard query code was pre-written and already correct — it only needed its data source. `_ingest_enrichment` already filtered to `purpose='main'`; `aggregate_model_summary` already computed rates from `main`-purpose attempts only; `all_node_details` already queried `bench_node_enrichment`. The entire fix is: give them data.

Inference cost at corpus scale is intentional and acknowledged in the README.

## Test plan

- 28 new tests (runner, coordinator, summary, results-store)
- Full brain suite: 1038 passed, 0 failures
- `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ingest` CLI command to import benchmark run results into a persistent database
  * Added `export-dashboard` CLI command to generate an interactive HTML dashboard of results
  * Results now automatically persist and can be queried across multiple runs
  * Added main enrichment evaluation pass to benchmark workflow

* **Documentation**
  * Expanded CLI reference with new subcommands and usage examples
  * Added detailed documentation on results storage and database schema
  * Updated architecture diagrams and module maps

* **Tests**
  * Added comprehensive tests for new CLI commands and dashboard features
  * Added ingestion, querying, and export tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->