### PR TITLE
fix(ci): remove invalid --allow-dirty from clippy pre-commit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,4 +3,4 @@ pre-commit:
     - name: check-formatting
       run: cargo fmt --all -- --check
     - name: check-linting
-      run: cargo clippy --all --allow-dirty -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
## Fix: pre-commit hook blocked all commits

`lefthook.yml`'s `check-linting` job ran `cargo clippy --all --allow-dirty -- -D warnings`. **`--allow-dirty` is not a valid clippy argument** — clippy forwards it to `cargo check`, which rejects it with `unexpected argument '--allow-dirty' found`. The job exited non-zero on every commit, so the pre-commit hook blocked **all** commits.

### Fix
Drop the invalid flag and align the lint target with the canonical CI command:

```diff
-      run: cargo clippy --all --allow-dirty -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
```

`--all-targets` (vs the previous `--all`) matches the command documented in `CLAUDE.md` and run in CI, so the local pre-commit gate now catches the same lints CI does — including warnings in test code — instead of passing locally and failing in CI.

### Validation
This commit was made with the hook **enabled** (no `--no-verify`): `check-formatting` and `check-linting` both passed, which is only possible if the corrected command is valid. Self-validating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development build configuration to enforce stricter code quality checks during the pre-commit process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->