### PR TITLE
chore(config): default oMLX inference URL to http://127.0.0.1:42069/v1

### DIFF
--- a/brain/scripts/migrate-vectors.py
+++ b/brain/scripts/migrate-vectors.py
@@ -50,7 +50,7 @@ def _default_config_path() -> Path:
 def _load_models(config_path: Path) -> tuple[str, str, str]:
     """Return (base_url, embed_model, command_model) from config.toml."""
     if not config_path.exists():
-        return ("http://localhost:1234/v1", "", "")
+        return ("http://127.0.0.1:42069/v1", "", "")
     with config_path.open("rb") as f:
         cfg = tomllib.load(f)
     models = cfg.get("models", {})
@@ -59,7 +59,7 @@ def _load_models(config_path: Path) -> tuple[str, str, str]:
         raise RuntimeError(
             "config.toml uses the deprecated [lmstudio] section. Rename it to [inference]."
         )
-    base_url = cfg.get("inference", {}).get("base_url", "http://localhost:1234/v1")
+    base_url = cfg.get("inference", {}).get("base_url", "http://127.0.0.1:42069/v1")
     return (
         base_url,
         models.get("embedding", ""),

--- a/brain/scripts/re-enrich-knowledge-nodes.py
+++ b/brain/scripts/re-enrich-knowledge-nodes.py
@@ -395,7 +395,7 @@ async def main_async(args: argparse.Namespace) -> int:
         )
         return 1
 
-    base_url = settings.get("inference_base_url", "http://localhost:1234/v1")
+    base_url = settings.get("inference_base_url", "http://127.0.0.1:42069/v1")
     timeout = float(settings.get("inference_timeout_secs", 300.0))
 
     # vector_store.open_conn loads the sqlite-vec extension (vec0) and

--- a/brain/src/hippo_brain/__init__.py
+++ b/brain/src/hippo_brain/__init__.py
@@ -14,7 +14,7 @@ def _default_settings() -> dict:
     return {
         "db_path": str(data_dir / "hippo.db"),
         "data_dir": str(data_dir),
-        "inference_base_url": "http://localhost:1234/v1",
+        "inference_base_url": "http://127.0.0.1:42069/v1",
         "inference_timeout_secs": 300.0,
         "enrichment_model": "",
         "embedding_model": "",
@@ -69,7 +69,7 @@ def _load_runtime_settings() -> dict:
     return {
         "db_path": str(data_dir / "hippo.db"),
         "data_dir": str(data_dir),
-        "inference_base_url": inference.get("base_url", "http://localhost:1234/v1"),
+        "inference_base_url": inference.get("base_url", "http://127.0.0.1:42069/v1"),
         "inference_timeout_secs": _coerce_float(inference.get("timeout_secs"), 300.0),
         "enrichment_model": models.get("enrichment", ""),
         "embedding_model": models.get("embedding", ""),

--- a/brain/src/hippo_brain/bench/README.md
+++ b/brain/src/hippo_brain/bench/README.md
@@ -138,7 +138,7 @@ active window and reported as peaks per model.
 ```
 hippo-bench run --models m1,m2,...
                 [--corpus-version corpus-v2]
-                [--base-url http://localhost:1234/v1]
+                [--base-url http://127.0.0.1:42069/v1]
                 [--brain-url http://127.0.0.1:9175]
                 [--embedding-model text-embedding-nomic-embed-text-v2-moe]
                 [--skip-checks] [--dry-run] [--skip-prod-pause]

--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -380,7 +380,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=default_inference_base_url(),
         help="Inference server base URL. Defaults to [inference].base_url from "
         "$XDG_CONFIG_HOME/hippo/config.toml (or $HOME/.config/hippo/config.toml "
-        "if XDG_CONFIG_HOME is unset), falling back to http://localhost:8000/v1.",
+        "if XDG_CONFIG_HOME is unset), falling back to http://127.0.0.1:42069/v1.",
     )
     run.add_argument(
         "--brain-url",

--- a/brain/src/hippo_brain/bench/coordinator.py
+++ b/brain/src/hippo_brain/bench/coordinator.py
@@ -191,7 +191,7 @@ def run_one_model(
     run_id: str,
     corpus_sqlite: Path,
     embedding_fn=None,
-    inference_url: str = "http://localhost:1234/v1",
+    inference_url: str = "http://127.0.0.1:42069/v1",
     embedding_model: str = "",
     drain_timeout_sec: float = 3600.0,
     warmup_calls: int = 3,

--- a/brain/src/hippo_brain/bench/prod_config.py
+++ b/brain/src/hippo_brain/bench/prod_config.py
@@ -20,7 +20,7 @@ import tomllib
 from pathlib import Path
 
 DEFAULT_BRAIN_PORT = 9175
-DEFAULT_INFERENCE_BASE_URL = "http://localhost:8000/v1"
+DEFAULT_INFERENCE_BASE_URL = "http://127.0.0.1:42069/v1"
 DEFAULT_EMBEDDING_MODEL = "nomicai-modernbert-embed-base-8bit"
 
 

--- a/brain/src/hippo_brain/bench/shadow_stack.py
+++ b/brain/src/hippo_brain/bench/shadow_stack.py
@@ -103,8 +103,8 @@ def _write_shadow_config(
 
     The [inference] and [models] sections are REQUIRED: the shadow brain is a
     separate process that reads its inference endpoint from this file. Without
-    them it falls back to the built-in default (`http://localhost:1234/v1`, the
-    old LM Studio port) and every enrichment call fails with "All connection
+    them it falls back to the built-in default (`http://127.0.0.1:42069/v1`, the
+    oMLX local port) and every enrichment call fails with "All connection
     attempts failed" — the bench then no-ops with zero system load instead of
     benchmarking the model. The section MUST be named [inference] (the brain
     hard-fails on a legacy [lmstudio] section)."""

--- a/brain/src/hippo_brain/client.py
+++ b/brain/src/hippo_brain/client.py
@@ -140,7 +140,7 @@ class InferenceClient:
 
     def __init__(
         self,
-        base_url: str = "http://localhost:1234/v1",
+        base_url: str = "http://127.0.0.1:42069/v1",
         timeout: float = 300.0,
         max_retries: int = 3,
         backoff_base: float = 0.5,

--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -76,7 +76,7 @@ def _load_config() -> dict:
     defaults = {
         "db_path": str(Path.home() / ".local" / "share" / "hippo" / "hippo.db"),
         "data_dir": str(Path.home() / ".local" / "share" / "hippo"),
-        "inference_base_url": "http://localhost:1234/v1",
+        "inference_base_url": "http://127.0.0.1:42069/v1",
         "embedding_model": "",
         "query_model": "",
     }
@@ -108,7 +108,7 @@ def _load_config() -> dict:
     return {
         "db_path": str(data_dir / "hippo.db"),
         "data_dir": str(data_dir),
-        "inference_base_url": inference.get("base_url", "http://localhost:1234/v1"),
+        "inference_base_url": inference.get("base_url", "http://127.0.0.1:42069/v1"),
         "embedding_model": models.get("embedding", ""),
         "query_model": models.get("query", "") or models.get("enrichment", ""),
     }

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -211,7 +211,7 @@ class BrainServer:
         self,
         db_path: str = "",
         data_dir: str = "",
-        inference_base_url: str = "http://localhost:1234/v1",
+        inference_base_url: str = "http://127.0.0.1:42069/v1",
         inference_timeout_secs: float = 300.0,
         enrichment_model: str = "",
         embedding_model: str = "",
@@ -1815,7 +1815,7 @@ class BrainServer:
 def create_app(
     db_path: str = "",
     data_dir: str = "",
-    inference_base_url: str = "http://localhost:1234/v1",
+    inference_base_url: str = "http://127.0.0.1:42069/v1",
     inference_timeout_secs: float = 300.0,
     enrichment_model: str = "",
     embedding_model: str = "",

--- a/brain/tests/test_mcp_server.py
+++ b/brain/tests/test_mcp_server.py
@@ -142,7 +142,7 @@ class TestLoadConfig:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
         config = _load_config()
         assert "hippo.db" in config["db_path"]
-        assert config["inference_base_url"] == "http://localhost:1234/v1"
+        assert config["inference_base_url"] == "http://127.0.0.1:42069/v1"
         assert config["embedding_model"] == ""
         # data_dir should derive from home
         assert config["data_dir"] == str(tmp_path / ".local" / "share" / "hippo")

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -1,10 +1,10 @@
 # OpenAI-compatible inference backend. Section was renamed from [lmstudio]
 # to [inference] so the same key works for oMLX (the current default,
-# port 8000), LM Studio (port 1234, the historical default), ollama
+# port 42069), LM Studio (port 1234, the historical default), ollama
 # (port 11434), vLLM, and any other backend that speaks
 # /v1/chat/completions + /v1/embeddings.
 [inference]
-base_url = "http://localhost:8000/v1"
+base_url = "http://127.0.0.1:42069/v1"
 timeout_secs = 300
 
 [models]

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -43,7 +43,7 @@ pub struct InferenceConfig {
 }
 
 fn default_inference_base_url() -> String {
-    "http://localhost:1234/v1".to_string()
+    "http://127.0.0.1:42069/v1".to_string()
 }
 
 impl Default for InferenceConfig {
@@ -885,7 +885,7 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = HippoConfig::default();
-        assert_eq!(config.inference.base_url, "http://localhost:1234/v1");
+        assert_eq!(config.inference.base_url, "http://127.0.0.1:42069/v1");
         assert_eq!(config.daemon.flush_interval_ms, 100);
         assert_eq!(config.daemon.flush_batch_size, 50);
         assert_eq!(config.brain.port, 9175);
@@ -915,7 +915,7 @@ port = 8080
     #[test]
     fn test_missing_config_returns_default() {
         let config = HippoConfig::load(Path::new("/nonexistent/path/config.toml")).unwrap();
-        assert_eq!(config.inference.base_url, "http://localhost:1234/v1");
+        assert_eq!(config.inference.base_url, "http://127.0.0.1:42069/v1");
     }
 
     #[test]


### PR DESCRIPTION
## What

Collapses the oMLX inference-endpoint default divergence into a single value: **`http://127.0.0.1:42069/v1`**.

Before this change the repo carried three different "defaults":
- `config/config.default.toml` (shipped template) → `localhost:8000/v1`
- `config.rs` serde fallback + every Python fallback → `localhost:1234/v1` (historical LM Studio port)
- bench `prod_config.py` → `localhost:8000/v1`

## Changes

- **Config template** `config/config.default.toml` (value + header comment).
- **Rust fallback** `config.rs` `default_inference_base_url()` + the two default-asserting tests.
- **Python fallbacks**: `__init__.py`, `mcp.py`, `server.py`, `client.py` (`InferenceClient`), `bench/prod_config.py`, `bench/coordinator.py`, and the `migrate-vectors.py` / `re-enrich-knowledge-nodes.py` scripts.
- **Test**: `test_mcp_server.py` default-path assertion.
- **Docs/comments**: `bench/shadow_stack.py`, `bench/cli.py`, `bench/README.md` updated so they no longer claim the old port.

Deliberately left as-is: the `[lmstudio]`-rejection fixture in `config.rs` (value is irrelevant to the assertion) and `MockInferenceClient` / mock-dict sentinels (bypass the real default).

## Verification

- `cargo test -p hippo-core` config tests pass (incl. updated default assertions).
- `ruff check` + `ruff format --check` clean.
- 652 brain tests pass (74 targeted + 578 bench/client/server/rag sweep), 1 pre-existing xfail.
- lefthook pre-commit (formatting + clippy) passed on commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default inference server endpoint across the application from localhost-based URLs to `http://127.0.0.1:42069/v1`. This affects the default configuration used when no custom inference server address is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->