### PR TITLE
Exclude workflow journal files from active-session scan

### DIFF
--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -3084,10 +3084,27 @@ fn collect_active_jsonls(
     }
 }
 
+/// Returns true for Claude workflow orchestration journals, not session files.
+///
+/// These are `journal.jsonl` metadata files under a `subagents/.../workflows`
+/// path, so check 5 excludes them from active-session reconciliation.
 fn is_workflow_journal(path: &std::path::Path) -> bool {
-    path.file_name().and_then(|n| n.to_str()) == Some("journal.jsonl")
-        && path.components().any(|c| c.as_os_str() == "subagents")
-        && path.components().any(|c| c.as_os_str() == "workflows")
+    if path.file_name() != Some(std::ffi::OsStr::new("journal.jsonl")) {
+        return false;
+    }
+
+    let mut saw_subagents = false;
+    for component in path.components() {
+        let name = component.as_os_str();
+        if saw_subagents && name == "workflows" {
+            return true;
+        }
+        if name == "subagents" {
+            saw_subagents = true;
+        }
+    }
+
+    false
 }
 
 /// Check 5: Recursively find active Claude session JSONL files under

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -3074,6 +3074,7 @@ fn collect_active_jsonls(
         if path.is_dir() {
             collect_active_jsonls(&path, cutoff, result);
         } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+            && !is_workflow_journal(&path)
             && let Ok(meta) = std::fs::metadata(&path)
             && let Ok(modified) = meta.modified()
             && modified > cutoff
@@ -3081,6 +3082,12 @@ fn collect_active_jsonls(
             result.push(path);
         }
     }
+}
+
+fn is_workflow_journal(path: &std::path::Path) -> bool {
+    path.file_name().and_then(|n| n.to_str()) == Some("journal.jsonl")
+        && path.components().any(|c| c.as_os_str() == "subagents")
+        && path.components().any(|c| c.as_os_str() == "workflows")
 }
 
 /// Check 5: Recursively find active Claude session JSONL files under

--- a/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
+++ b/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
@@ -291,6 +291,25 @@ mod doctor {
         }
 
         #[test]
+        fn check_5_journal_with_unrelated_workflows_and_subagents_is_active() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let unrelated_dir = tmp
+                .path()
+                .join("projects/encoded-proj/workflows/scratch/subagents/not-a-workflow");
+            fs::create_dir_all(&unrelated_dir).unwrap();
+            fs::write(unrelated_dir.join("journal.jsonl"), "{}\n").unwrap();
+
+            let fail =
+                check_claude_session_db(&tmp.path().join("projects"), tmp.path(), &conn, false);
+            assert_eq!(
+                fail, 1,
+                "journal.jsonl is active unless it is under subagents/.../workflows"
+            );
+        }
+
+        #[test]
         fn check_5_missing_sessions_capped_at_3() {
             let tmp = tempdir().unwrap();
             let conn = open_test_db(tmp.path());

--- a/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
+++ b/crates/hippo-daemon/tests/doctor_checks_2_5_6_9_10.rs
@@ -268,6 +268,29 @@ mod doctor {
         }
 
         #[test]
+        fn check_5_workflow_journal_is_not_an_active_session() {
+            let tmp = tempdir().unwrap();
+            let conn = open_test_db(tmp.path());
+
+            let workflow_dir = tmp
+                .path()
+                .join("projects/encoded-proj/parent-uuid/subagents/workflows/wf_abc");
+            fs::create_dir_all(&workflow_dir).unwrap();
+            fs::write(
+                workflow_dir.join("journal.jsonl"),
+                "{\"type\":\"started\",\"agentId\":\"agent-a123\"}\n",
+            )
+            .unwrap();
+
+            let fail =
+                check_claude_session_db(&tmp.path().join("projects"), tmp.path(), &conn, false);
+            assert_eq!(
+                fail, 0,
+                "workflow journal JSONL files are orchestration metadata, not sessions"
+            );
+        }
+
+        #[test]
         fn check_5_missing_sessions_capped_at_3() {
             let tmp = tempdir().unwrap();
             let conn = open_test_db(tmp.path());


### PR DESCRIPTION
This pull request updates the logic for identifying active session JSONL files to ensure that workflow journal files are not incorrectly treated as active sessions. It introduces a new helper function to detect workflow journal files and adds a test to verify this behavior.

**Improvements to session file detection:**

* Updated `collect_active_jsonls` in `commands.rs` to exclude files named `journal.jsonl` located under both `subagents` and `workflows` directories, preventing them from being considered active session files.
* Added the helper function `is_workflow_journal` to encapsulate the logic for identifying workflow journal files based on their path and filename.

**Testing:**

* Added the test `check_5_workflow_journal_is_not_an_active_session` to ensure that workflow journal JSONL files are not treated as active sessions during session checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect detection of workflow orchestration journal files as active sessions; such journal files are now excluded from session reconciliation.
* **Tests**
  * Added integration tests to verify workflow journal files are excluded when in orchestration paths and still detected in unrelated paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->