### PR TITLE
feat(brain): OpenAPI contract + structured API CLI (v0.29.0); patch all site Dependabot alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.28.7"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.28.7"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.28.7"
+version = "0.29.0"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,25 @@ hippo probe --source claude-session     # Run a synthetic probe for one source
 hippo ingest claude-session <path>      # Manual one-shot import of a JSONL (recovery)
 ```
 
+Brain API and enrichment control:
+
+```bash
+mise run brain:api:health               # Brain health, queue depths, pause state
+mise run brain:api:pause                # Pause enrichment; ingestion keeps queueing
+mise run brain:api:resume               # Resume enrichment
+mise run brain:api:query -- "cargo build"
+mise run brain:api:ask -- "how did I fix that build error?"
+mise run brain:api:openapi              # Print OpenAPI contract without a server
+mise run brain:api:openapi:live         # Fetch /openapi.json from the running brain
+mise run brain:api:openapi:write        # Write OUT, default brain/openapi.json
+```
+
+`brain:api:pause` is a soft pause: `hippo-brain` stays up for health, query, and
+resume calls but stops claiming new enrichment work. The daemon and ingest
+agents continue writing events and queue rows. To fully unload a local chat model
+for a benchmark, stop only `com.hippo.brain` and leave `com.hippo.daemon` plus
+the ingest agents running.
+
 Capture-reliability operator runbook (recipes for "I ran a command but it's not in `hippo events`", "doctor shows red", "schema mismatch", etc.): [`docs/capture/operator-runbook.md`](docs/capture/operator-runbook.md).
 
 ## Troubleshooting
@@ -181,7 +200,7 @@ Common first-day failures, in rough order of frequency:
 | `hippo ask` returns "I don't have enough information" | Brain hasn't enriched yet, or the configured chat model isn't loaded. | `hippo doctor` to confirm. Open omlx (or LM Studio) and load the model in `[models].enrichment`. |
 | `hippo doctor` says inference server isn't reachable | omlx/LM Studio isn't running, or it's serving on a non-default port. | Start the server. For oMLX, run `mise run install:omlx`; for LM Studio, start it manually. Check the API base URL in `~/.config/hippo/config.toml` (`[inference].base_url`). The legacy `[lmstudio]` section is rejected with a migration error — rename it to `[inference]`. |
 | Daemon won't start; `hippo doctor` says schema mismatch | Daemon and brain have different `EXPECTED_SCHEMA_VERSION` constants — happens after partial upgrades. | `mise run install --clean` brings everything to the same version. |
-| Brain queue backs up | Configured chat model unloaded or swapped for one not in `[models].enrichment`. | Load the configured model. The reaper handles transient locks; persistent backlog is operator-visible. See [`docs/brain-watchdog.md`](docs/brain-watchdog.md). |
+| Brain queue backs up | Configured chat model unloaded, enrichment is paused, `com.hippo.brain` is stopped, or the loaded model is not in `[models].enrichment`. | Check `mise run brain:api:health` if brain is running. Use `mise run brain:api:resume` to clear a soft pause, or load the configured model/start brain when you want the queue to drain. The reaper handles transient locks; persistent backlog is operator-visible. See [`docs/brain-watchdog.md`](docs/brain-watchdog.md). |
 | Firefox extension shows no recent visits | Native messaging manifest missing, or extension not loaded. | `hippo daemon install --force` rewrites the manifest. Reload the extension in `about:debugging`. See [`extension/firefox/README.md`](extension/firefox/README.md). |
 
 For anything not in this table, run `hippo doctor --explain` and follow the DOC link in each failure block. The full operator runbook lives at [`docs/capture/operator-runbook.md`](docs/capture/operator-runbook.md).
@@ -310,6 +329,18 @@ mise run restart            # Stop + start
 mise run nuke               # SIGKILL everything (preserves data)
 mise run install:omlx       # Optional: install + start Hippo's oMLX LaunchAgent
 ```
+
+To keep ingestion running while enrichment is fully stopped, do not use
+`mise run stop`; it unloads the capture side too. Boot out only the brain agent:
+
+```bash
+launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.hippo.brain.plist
+```
+
+If the daemon is not already loaded, bootstrap
+`~/Library/LaunchAgents/com.hippo.daemon.plist` separately. Then verify with
+`mise run status`: daemon should be reachable, queue depth should be nonzero or
+growing, and brain should be unreachable until restarted.
 
 ### Contributing
 

--- a/brain/README.md
+++ b/brain/README.md
@@ -61,7 +61,9 @@ uv run --project brain hippo-mcp
 | Module          | Purpose                                                                 |
 |-----------------|-------------------------------------------------------------------------|
 | `enrichment.py` | Polls SQLite queue, calls the inference server for summarization/entity extraction |
-| `server.py`     | Starlette HTTP server for query API                                     |
+| `server.py`     | Starlette HTTP server for query/control API                             |
+| `api_cli.py`    | Structured CLI wrapper for every brain HTTP API operation               |
+| `openapi.py`    | Explicit OpenAPI 3.1 contract for the brain HTTP API                    |
 | `embeddings.py` | Vector embedding generation via the inference server                    |
 | `client.py`     | OpenAI-compatible InferenceClient (HTTP)                                |
 | `models.py`     | Pydantic data models                                                    |
@@ -71,4 +73,65 @@ uv run --project brain hippo-mcp
 
 The brain server listens on `127.0.0.1:9175` and exposes:
 
-- `POST /query` — Full-text search over events and enriched knowledge nodes
+- `GET /health` — Server, queue, pause, schema, and inference health
+- `GET /sessions` — Recent shell sessions
+- `GET /events` — Recent shell events
+- `GET /knowledge` — Enriched knowledge nodes
+- `GET /knowledge/{id}` — One enriched knowledge node by id
+- `POST /query` — Lexical or semantic search over events and knowledge nodes
+- `POST /ask` — RAG answer synthesis over retrieved knowledge
+- `POST /control/pause` — Stop claiming new enrichment work while keeping ingestion live
+- `POST /control/resume` — Resume enrichment work
+- `GET /openapi.json` — OpenAPI 3.1 contract for the routes above
+
+Use the structured CLI instead of hand-written `curl` for normal operations:
+
+```bash
+mise run brain:api:health
+mise run brain:api:sessions -- --limit 20
+mise run brain:api:events -- --limit 20
+mise run brain:api:knowledge -- --limit 20
+mise run brain:api:knowledge-get -- 123
+mise run brain:api:query -- "cargo build" --mode lexical
+mise run brain:api:ask -- "how did I fix that build error?"
+```
+
+The wrapper defaults to the configured production brain URL. Override it with
+`HIPPO_BRAIN_URL`, `BRAIN_URL`, or `--url`.
+
+### OpenAPI
+
+The OpenAPI contract can be read from a running server or generated offline:
+
+```bash
+mise run brain:api:openapi       # offline, no server required
+mise run brain:api:openapi:live  # GET /openapi.json from the running brain
+mise run brain:api:openapi:write # write OUT, default brain/openapi.json
+```
+
+The offline path is the stable integration point for code generators, API
+diffing, and editor tooling because it does not require launchd or an inference
+model to be running.
+
+### Pausing enrichment
+
+`POST /control/pause` pauses only the brain worker's queue claims. The daemon,
+watchers, and pollers keep writing to SQLite, so queue depth can grow while the
+local chat model is unloaded or reserved for another benchmark:
+
+```bash
+mise run brain:api:pause
+mise run brain:api:health
+mise run brain:api:resume
+```
+
+For complete model quiescence, unload the brain LaunchAgent instead of using the
+soft pause endpoint:
+
+```bash
+launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.hippo.brain.plist
+```
+
+Leave `com.hippo.daemon` and the ingest LaunchAgents running when you want
+capture to continue and enrichment queues to fill. If the daemon is not already
+loaded, bootstrap `~/Library/LaunchAgents/com.hippo.daemon.plist` separately.

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -29,6 +29,8 @@ hippo-brain = "hippo_brain:main"
 hippo-mcp = "hippo_brain.mcp:main"
 hippo-eval = "hippo_brain.evaluation:main"
 hippo-bench = "hippo_brain.bench.cli:main"
+hippo-brain-api = "hippo_brain.api_cli:main"
+hippo-brain-openapi = "hippo_brain.openapi:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.28.7"
+version = "0.29.0"
 requires-python = ">=3.14"
 dependencies = [
   "httpx>=0.28",

--- a/brain/src/hippo_brain/api_cli.py
+++ b/brain/src/hippo_brain/api_cli.py
@@ -1,0 +1,224 @@
+"""Structured CLI for the Hippo brain HTTP API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+import httpx
+
+from hippo_brain.bench.prod_config import default_prod_brain_url
+from hippo_brain.openapi import build_openapi_spec
+
+DEFAULT_TIMEOUT = 10.0
+
+
+def _base_url(explicit_url: str | None) -> str:
+    return (
+        explicit_url
+        or os.environ.get("HIPPO_BRAIN_URL")
+        or os.environ.get("BRAIN_URL")
+        or default_prod_brain_url()
+    ).rstrip("/")
+
+
+def _optional_params(values: dict[str, Any]) -> dict[str, Any] | None:
+    params = {key: value for key, value in values.items() if value is not None}
+    return params or None
+
+
+def _emit_json(payload: Any) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _request(args: argparse.Namespace, method: str, path: str, params=None, body=None) -> int:
+    url = f"{_base_url(args.url)}{path}"
+    try:
+        response = httpx.request(
+            method,
+            url,
+            params=params,
+            json=body,
+            timeout=args.timeout,
+        )
+    except httpx.RequestError as exc:
+        print(f"request failed: {exc}", file=sys.stderr)
+        return 1
+
+    if response.status_code >= 400:
+        print(f"HTTP {response.status_code}: {response.text}", file=sys.stderr)
+        return 1
+
+    try:
+        _emit_json(response.json())
+    except ValueError:
+        print(response.text)
+    return 0
+
+
+def _handle_health(args: argparse.Namespace) -> int:
+    return _request(args, "GET", "/health")
+
+
+def _handle_sessions(args: argparse.Namespace) -> int:
+    return _request(
+        args,
+        "GET",
+        "/sessions",
+        params=_optional_params(
+            {"limit": args.limit, "offset": args.offset, "since_ms": args.since_ms}
+        ),
+    )
+
+
+def _handle_events(args: argparse.Namespace) -> int:
+    return _request(
+        args,
+        "GET",
+        "/events",
+        params=_optional_params(
+            {
+                "limit": args.limit,
+                "offset": args.offset,
+                "session_id": args.session_id,
+                "since_ms": args.since_ms,
+                "project": args.project,
+            }
+        ),
+    )
+
+
+def _handle_knowledge(args: argparse.Namespace) -> int:
+    return _request(
+        args,
+        "GET",
+        "/knowledge",
+        params=_optional_params(
+            {
+                "limit": args.limit,
+                "offset": args.offset,
+                "node_type": args.node_type,
+                "since_ms": args.since_ms,
+            }
+        ),
+    )
+
+
+def _handle_knowledge_get(args: argparse.Namespace) -> int:
+    return _request(args, "GET", f"/knowledge/{args.id}")
+
+
+def _handle_query(args: argparse.Namespace) -> int:
+    return _request(
+        args,
+        "POST",
+        "/query",
+        body={"text": args.text, "mode": args.mode, "limit": args.limit},
+    )
+
+
+def _handle_ask(args: argparse.Namespace) -> int:
+    return _request(
+        args,
+        "POST",
+        "/ask",
+        body={"question": args.question, "limit": args.limit},
+    )
+
+
+def _handle_pause(args: argparse.Namespace) -> int:
+    return _request(args, "POST", "/control/pause")
+
+
+def _handle_resume(args: argparse.Namespace) -> int:
+    return _request(args, "POST", "/control/resume")
+
+
+def _handle_openapi(args: argparse.Namespace) -> int:
+    if args.offline:
+        _emit_json(build_openapi_spec())
+        return 0
+    return _request(args, "GET", "/openapi.json")
+
+
+def _add_pagination(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--offset", type=int)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hippo-brain-api",
+        description="Call the local Hippo brain HTTP API.",
+    )
+    parser.add_argument(
+        "--url",
+        help=(
+            "Brain base URL. Defaults to HIPPO_BRAIN_URL, BRAIN_URL, or "
+            "http://127.0.0.1:<[brain].port>."
+        ),
+    )
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    health = sub.add_parser("health", help="GET /health")
+    health.set_defaults(handler=_handle_health)
+
+    sessions = sub.add_parser("sessions", help="GET /sessions")
+    _add_pagination(sessions)
+    sessions.add_argument("--since-ms", type=int)
+    sessions.set_defaults(handler=_handle_sessions)
+
+    events = sub.add_parser("events", help="GET /events")
+    _add_pagination(events)
+    events.add_argument("--session-id", type=int)
+    events.add_argument("--since-ms", type=int)
+    events.add_argument("--project")
+    events.set_defaults(handler=_handle_events)
+
+    knowledge = sub.add_parser("knowledge", help="GET /knowledge")
+    _add_pagination(knowledge)
+    knowledge.add_argument("--node-type")
+    knowledge.add_argument("--since-ms", type=int)
+    knowledge.set_defaults(handler=_handle_knowledge)
+
+    knowledge_get = sub.add_parser("knowledge-get", help="GET /knowledge/{id}")
+    knowledge_get.add_argument("id", type=int)
+    knowledge_get.set_defaults(handler=_handle_knowledge_get)
+
+    query = sub.add_parser("query", help="POST /query")
+    query.add_argument("text")
+    query.add_argument("--mode", choices=("semantic", "lexical"), default="semantic")
+    query.add_argument("--limit", type=int, default=10)
+    query.set_defaults(handler=_handle_query)
+
+    ask = sub.add_parser("ask", help="POST /ask")
+    ask.add_argument("question")
+    ask.add_argument("--limit", type=int, default=10)
+    ask.set_defaults(handler=_handle_ask)
+
+    pause = sub.add_parser("pause", help="POST /control/pause")
+    pause.set_defaults(handler=_handle_pause)
+
+    resume = sub.add_parser("resume", help="POST /control/resume")
+    resume.set_defaults(handler=_handle_resume)
+
+    openapi = sub.add_parser("openapi", help="GET /openapi.json")
+    openapi.add_argument(
+        "--offline",
+        action="store_true",
+        help="Print the built-in OpenAPI contract instead of calling the live server.",
+    )
+    openapi.set_defaults(handler=_handle_openapi)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.handler(args)

--- a/brain/src/hippo_brain/bench/README.md
+++ b/brain/src/hippo_brain/bench/README.md
@@ -584,7 +584,7 @@ calling out:
    numbers. Also **fully quiesce the prod brain** for the run window when you
    need to unload a local model: the soft `/control/pause` stops new claims but
    not an in-flight batch, and a running prod brain can still contend for the
-   inference server. Hard-stop it (`launchctl bootout gui/$UID/com.hippo.brain`,
+   inference server. Hard-stop it (`launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.hippo.brain.plist`,
    leaving `com.hippo.daemon` and ingest agents up so capture keeps queueing)
    for a clean run.
 

--- a/brain/src/hippo_brain/bench/README.md
+++ b/brain/src/hippo_brain/bench/README.md
@@ -215,6 +215,17 @@ window.
 - **Resume is best-effort** — registered via `atexit` so it fires even on crash
 - **Override** — `--skip-prod-pause` bypasses pause/resume entirely
 
+The same control surface is available outside the bench harness:
+
+```bash
+mise run brain:api:pause
+mise run brain:api:health
+mise run brain:api:resume
+```
+
+This is a soft pause. Ingestion continues and queue depth can grow, but the
+running prod brain may still hold a model connection for health/query traffic.
+
 If the prod brain restarts during a bench run (e.g., due to launchd keepalive),
 the `model_summary` record will include `"prod_brain_restarted_during_bench": true`.
 
@@ -570,11 +581,12 @@ calling out:
    fail the run — that is an infra signal, NOT a model verdict. If a run shows
    widespread drops or a model lands in `errored`, probe the server directly
    (`POST /v1/chat/completions` a few times) and restart it before trusting any
-   numbers. Also **fully quiesce the prod brain** for the run window: the soft
-   `/control/pause` stops new claims but not an in-flight batch, and a
-   prod brain enriching this session's own captured activity will contend for
-   the inference server. Hard-stop it (`launchctl bootout gui/$UID/com.hippo.brain`,
-   leaving `com.hippo.daemon` up so capture keeps queueing) for a clean run.
+   numbers. Also **fully quiesce the prod brain** for the run window when you
+   need to unload a local model: the soft `/control/pause` stops new claims but
+   not an in-flight batch, and a running prod brain can still contend for the
+   inference server. Hard-stop it (`launchctl bootout gui/$UID/com.hippo.brain`,
+   leaving `com.hippo.daemon` and ingest agents up so capture keeps queueing)
+   for a clean run.
 
 Use the `tier0_verdict.skipped_gates` field to surface "didn't measure this" vs.
 "failed this" in any leaderboard you publish.

--- a/brain/src/hippo_brain/bench/orchestrate.py
+++ b/brain/src/hippo_brain/bench/orchestrate.py
@@ -62,11 +62,15 @@ def _build_run_id() -> str:
 
 
 def _host_info() -> dict:
+    """Best-effort host provenance for a bench run. ``total_mem_gb`` falls back
+    to ``None`` (the run continues) when psutil cannot read system memory —
+    macOS ``host_statistics64`` has been observed to raise ``RuntimeError``.
+    The remaining provenance fields are always populated."""
     total_mem_gb = None
     try:
         vm = psutil.virtual_memory()
         total_mem_gb = round(vm.total / (1024**3), 1)
-    except Exception as exc:
+    except (psutil.Error, OSError, RuntimeError) as exc:
         _log.warning("failed to collect host memory info: %s", exc)
     return {
         "hostname": platform.node(),

--- a/brain/src/hippo_brain/bench/orchestrate.py
+++ b/brain/src/hippo_brain/bench/orchestrate.py
@@ -62,13 +62,18 @@ def _build_run_id() -> str:
 
 
 def _host_info() -> dict:
-    vm = psutil.virtual_memory()
+    total_mem_gb = None
+    try:
+        vm = psutil.virtual_memory()
+        total_mem_gb = round(vm.total / (1024**3), 1)
+    except Exception as exc:
+        _log.warning("failed to collect host memory info: %s", exc)
     return {
         "hostname": platform.node(),
         "os": f"{platform.system().lower()} {platform.release()}",
         "arch": platform.machine(),
         "cpu_brand": _cpu_brand(),
-        "total_mem_gb": round(vm.total / (1024**3), 1),
+        "total_mem_gb": total_mem_gb,
     }
 
 

--- a/brain/src/hippo_brain/openapi.py
+++ b/brain/src/hippo_brain/openapi.py
@@ -1,0 +1,374 @@
+"""OpenAPI contract for the Hippo brain HTTP API.
+
+The brain server is Starlette, not FastAPI, so there is no automatic OpenAPI
+generation. Keep this spec explicit and close to ``BrainServer.get_routes``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from hippo_brain.version import get_version
+
+
+def _json_response(schema_ref: str | dict, description: str = "OK") -> dict:
+    schema = {"$ref": schema_ref} if isinstance(schema_ref, str) else schema_ref
+    return {
+        "description": description,
+        "content": {"application/json": {"schema": schema}},
+    }
+
+
+def _error_response(description: str = "Error") -> dict:
+    return _json_response("#/components/schemas/ErrorResponse", description)
+
+
+def _int_query_param(name: str, description: str, required: bool = False) -> dict:
+    return {
+        "name": name,
+        "in": "query",
+        "required": required,
+        "schema": {"type": "integer"},
+        "description": description,
+    }
+
+
+def _string_query_param(name: str, description: str, required: bool = False) -> dict:
+    return {
+        "name": name,
+        "in": "query",
+        "required": required,
+        "schema": {"type": "string"},
+        "description": description,
+    }
+
+
+def _pagination_params() -> list[dict]:
+    return [
+        _int_query_param("limit", "Maximum number of rows to return."),
+        _int_query_param("offset", "Zero-based pagination offset."),
+    ]
+
+
+def build_openapi_spec() -> dict:
+    """Return the OpenAPI document for the current brain HTTP API."""
+
+    return {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Hippo Brain API",
+            "version": get_version(),
+            "description": "Local HTTP API for Hippo enrichment, retrieval, and brain control.",
+        },
+        "paths": {
+            "/health": {
+                "get": {
+                    "operationId": "getHealth",
+                    "summary": "Return brain health and enrichment status.",
+                    "responses": {"200": _json_response("#/components/schemas/HealthResponse")},
+                }
+            },
+            "/sessions": {
+                "get": {
+                    "operationId": "listSessions",
+                    "summary": "List captured shell sessions.",
+                    "parameters": [
+                        *_pagination_params(),
+                        _int_query_param("since_ms", "Only include sessions after this epoch-ms."),
+                    ],
+                    "responses": {
+                        "200": _json_response("#/components/schemas/SessionsResponse"),
+                        "400": _error_response("Invalid query parameter."),
+                    },
+                }
+            },
+            "/events": {
+                "get": {
+                    "operationId": "listEvents",
+                    "summary": "List captured shell events.",
+                    "parameters": [
+                        *_pagination_params(),
+                        _int_query_param("session_id", "Restrict to one session."),
+                        _int_query_param("since_ms", "Only include events after this epoch-ms."),
+                        _string_query_param("project", "Substring match against event cwd."),
+                    ],
+                    "responses": {
+                        "200": _json_response("#/components/schemas/EventsResponse"),
+                        "400": _error_response("Invalid query parameter."),
+                    },
+                }
+            },
+            "/knowledge": {
+                "get": {
+                    "operationId": "listKnowledge",
+                    "summary": "List enriched knowledge nodes.",
+                    "parameters": [
+                        *_pagination_params(),
+                        _string_query_param("node_type", "Restrict to one node type."),
+                        _int_query_param("since_ms", "Only include nodes after this epoch-ms."),
+                    ],
+                    "responses": {
+                        "200": _json_response("#/components/schemas/KnowledgeListResponse"),
+                        "400": _error_response("Invalid query parameter."),
+                    },
+                }
+            },
+            "/knowledge/{id}": {
+                "get": {
+                    "operationId": "getKnowledge",
+                    "summary": "Get one knowledge node by numeric ID.",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "integer"},
+                            "description": "Knowledge node ID.",
+                        }
+                    ],
+                    "responses": {
+                        "200": _json_response("#/components/schemas/KnowledgeNode"),
+                        "404": _error_response("Knowledge node not found."),
+                    },
+                }
+            },
+            "/query": {
+                "post": {
+                    "operationId": "queryKnowledge",
+                    "summary": "Search events and knowledge nodes.",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/QueryRequest"}
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": _json_response("#/components/schemas/QueryResponse"),
+                        "400": _error_response("Invalid request body."),
+                        "500": _error_response("Query failed."),
+                    },
+                }
+            },
+            "/ask": {
+                "post": {
+                    "operationId": "askQuestion",
+                    "summary": "Ask a RAG question against enriched knowledge.",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/AskRequest"}
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": _json_response("#/components/schemas/AskResponse"),
+                        "400": _error_response("Invalid request body."),
+                        "503": _error_response("RAG dependencies unavailable."),
+                    },
+                }
+            },
+            "/control/pause": {
+                "post": {
+                    "operationId": "pauseEnrichment",
+                    "summary": "Pause enrichment claims while keeping ingestion running.",
+                    "responses": {"200": _json_response("#/components/schemas/PauseResponse")},
+                }
+            },
+            "/control/resume": {
+                "post": {
+                    "operationId": "resumeEnrichment",
+                    "summary": "Resume enrichment claims.",
+                    "responses": {"200": _json_response("#/components/schemas/ResumeResponse")},
+                }
+            },
+            "/openapi.json": {
+                "get": {
+                    "operationId": "getOpenApiSpec",
+                    "summary": "Return this OpenAPI document.",
+                    "responses": {
+                        "200": _json_response({"type": "object", "additionalProperties": True})
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ErrorResponse": {
+                    "type": "object",
+                    "required": ["error"],
+                    "properties": {"error": {"type": "string"}},
+                },
+                "HealthResponse": {
+                    "type": "object",
+                    "required": [
+                        "status",
+                        "version",
+                        "expected_schema_version",
+                        "inference_reachable",
+                        "enrichment_running",
+                        "paused",
+                        "db_reachable",
+                    ],
+                    "properties": {
+                        "status": {"type": "string"},
+                        "version": {"type": "string"},
+                        "expected_schema_version": {"type": "integer"},
+                        "accepted_read_versions": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                        },
+                        "inference_reachable": {"type": "boolean"},
+                        "enrichment_running": {"type": "boolean"},
+                        "paused": {"type": "boolean"},
+                        "paused_at": {"type": ["string", "null"], "format": "date-time"},
+                        "db_reachable": {"type": "boolean"},
+                        "queue_depth": {"type": "integer"},
+                        "queue_failed": {"type": "integer"},
+                        "claude_queue_depth": {"type": "integer"},
+                        "claude_queue_failed": {"type": "integer"},
+                        "browser_queue_depth": {"type": "integer"},
+                        "browser_queue_failed": {"type": "integer"},
+                        "workflow_queue_depth": {"type": "integer"},
+                        "workflow_queue_failed": {"type": "integer"},
+                        "enrichment_model": {"type": "string"},
+                        "enrichment_model_preferred": {"type": "string"},
+                        "query_inflight": {"type": "integer"},
+                        "embed_model_drift": {"type": ["string", "null"]},
+                        "last_success_at_ms": {"type": ["integer", "null"]},
+                        "last_error": {"type": ["string", "null"]},
+                        "last_error_at_ms": {"type": ["integer", "null"]},
+                        "telemetry_enabled": {"type": "boolean"},
+                        "telemetry_active": {"type": "boolean"},
+                    },
+                    "additionalProperties": True,
+                },
+                "Session": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "start_time": {"type": "integer"},
+                        "hostname": {"type": "string"},
+                        "shell": {"type": "string"},
+                        "event_count": {"type": "integer"},
+                    },
+                    "additionalProperties": True,
+                },
+                "SessionsResponse": {
+                    "type": "object",
+                    "required": ["sessions", "total"],
+                    "properties": {
+                        "sessions": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Session"},
+                        },
+                        "total": {"type": "integer"},
+                    },
+                },
+                "Event": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "session_id": {"type": ["integer", "null"]},
+                        "timestamp": {"type": "integer"},
+                        "command": {"type": "string"},
+                        "exit_code": {"type": "integer"},
+                        "duration_ms": {"type": "integer"},
+                        "cwd": {"type": "string"},
+                        "git_branch": {"type": ["string", "null"]},
+                    },
+                    "additionalProperties": True,
+                },
+                "EventsResponse": {
+                    "type": "object",
+                    "required": ["events", "total"],
+                    "properties": {
+                        "events": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Event"},
+                        },
+                        "total": {"type": "integer"},
+                    },
+                },
+                "KnowledgeNode": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "uuid": {"type": "string"},
+                        "content": {"type": "string"},
+                        "embed_text": {"type": ["string", "null"]},
+                        "node_type": {"type": ["string", "null"]},
+                        "outcome": {"type": ["string", "null"]},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                        "created_at": {"type": "integer"},
+                        "related_entities": {
+                            "type": "array",
+                            "items": {"type": "object", "additionalProperties": True},
+                        },
+                        "related_events": {
+                            "type": "array",
+                            "items": {"type": "object", "additionalProperties": True},
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+                "KnowledgeListResponse": {
+                    "type": "object",
+                    "required": ["nodes", "total"],
+                    "properties": {
+                        "nodes": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/KnowledgeNode"},
+                        },
+                        "total": {"type": "integer"},
+                    },
+                },
+                "QueryRequest": {
+                    "type": "object",
+                    "required": ["text"],
+                    "properties": {
+                        "text": {"type": "string"},
+                        "mode": {"type": "string", "enum": ["semantic", "lexical"]},
+                        "limit": {"type": "integer", "minimum": 1},
+                    },
+                },
+                "QueryResponse": {"type": "object", "additionalProperties": True},
+                "AskRequest": {
+                    "type": "object",
+                    "required": ["question"],
+                    "properties": {
+                        "question": {"type": "string"},
+                        "limit": {"type": "integer", "minimum": 1},
+                    },
+                },
+                "AskResponse": {"type": "object", "additionalProperties": True},
+                "PauseResponse": {
+                    "type": "object",
+                    "required": [
+                        "paused_at",
+                        "in_flight_finished",
+                        "enrichment_active",
+                        "query_inflight",
+                    ],
+                    "properties": {
+                        "paused_at": {"type": "string", "format": "date-time"},
+                        "in_flight_finished": {"type": "boolean"},
+                        "enrichment_active": {"type": "boolean"},
+                        "query_inflight": {"type": "integer"},
+                    },
+                },
+                "ResumeResponse": {
+                    "type": "object",
+                    "required": ["resumed_at"],
+                    "properties": {"resumed_at": {"type": "string", "format": "date-time"}},
+                },
+            }
+        },
+    }
+
+
+def main() -> int:
+    print(json.dumps(build_openapi_spec(), indent=2, sort_keys=True))
+    return 0

--- a/brain/src/hippo_brain/openapi.py
+++ b/brain/src/hippo_brain/openapi.py
@@ -314,13 +314,32 @@ def build_openapi_spec() -> dict:
                     },
                     "additionalProperties": True,
                 },
+                "KnowledgeNodeSummary": {
+                    "type": "object",
+                    "description": (
+                        "Knowledge node as returned by the list endpoint: a subset "
+                        "of KnowledgeNode. The list query does not hydrate "
+                        "embed_text/related_entities/related_events — only the "
+                        "/knowledge/{id} endpoint returns those."
+                    ),
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "uuid": {"type": "string"},
+                        "content": {"type": "string"},
+                        "node_type": {"type": ["string", "null"]},
+                        "outcome": {"type": ["string", "null"]},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                        "created_at": {"type": "integer"},
+                    },
+                    "additionalProperties": True,
+                },
                 "KnowledgeListResponse": {
                     "type": "object",
                     "required": ["nodes", "total"],
                     "properties": {
                         "nodes": {
                             "type": "array",
-                            "items": {"$ref": "#/components/schemas/KnowledgeNode"},
+                            "items": {"$ref": "#/components/schemas/KnowledgeNodeSummary"},
                         },
                         "total": {"type": "integer"},
                     },

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -14,6 +14,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from hippo_brain.client import InferenceClient
+from hippo_brain.openapi import build_openapi_spec
 from hippo_brain.schema_version import EXPECTED_SCHEMA_VERSION, ACCEPTED_READ_VERSIONS
 from hippo_brain.version import get_version
 from hippo_brain.embeddings import (
@@ -912,6 +913,10 @@ class BrainServer:
         self._resume_event.set()
         return JSONResponse({"resumed_at": _dt.datetime.now(tz=_dt.UTC).isoformat()})
 
+    async def openapi_json(self, request: Request) -> JSONResponse:
+        """Serve the explicit OpenAPI contract for the Starlette brain API."""
+        return JSONResponse(build_openapi_spec())
+
     def _resolve_model_from_preflight(self, loaded: list[str]) -> bool:
         """Sync model selection from preflight's already-fetched model list."""
         return self._pick_enrichment_model(loaded)
@@ -1809,6 +1814,7 @@ class BrainServer:
             Route("/ask", self.ask, methods=["POST"]),
             Route("/control/pause", self.control_pause, methods=["POST"]),
             Route("/control/resume", self.control_resume, methods=["POST"]),
+            Route("/openapi.json", self.openapi_json, methods=["GET"]),
         ]
 
 

--- a/brain/tests/test_api_cli.py
+++ b/brain/tests/test_api_cli.py
@@ -1,0 +1,119 @@
+"""Tests for the structured hippo-brain API CLI."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hippo_brain import api_cli
+
+
+class _Response:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = str(payload)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_pause_posts_to_control_pause(capsys: pytest.CaptureFixture):
+    with patch(
+        "hippo_brain.api_cli.httpx.request", return_value=_Response({"paused_at": "now"})
+    ) as req:
+        rc = api_cli.main(["--url", "http://brain.local", "pause"])
+
+    assert rc == 0
+    req.assert_called_once_with(
+        "POST",
+        "http://brain.local/control/pause",
+        params=None,
+        json=None,
+        timeout=10.0,
+    )
+    assert '"paused_at": "now"' in capsys.readouterr().out
+
+
+def test_query_posts_structured_body(capsys: pytest.CaptureFixture):
+    with patch(
+        "hippo_brain.api_cli.httpx.request", return_value=_Response({"mode": "lexical"})
+    ) as req:
+        rc = api_cli.main(
+            [
+                "--url",
+                "http://brain.local",
+                "query",
+                "cargo test",
+                "--mode",
+                "lexical",
+                "--limit",
+                "3",
+            ]
+        )
+
+    assert rc == 0
+    req.assert_called_once_with(
+        "POST",
+        "http://brain.local/query",
+        params=None,
+        json={"text": "cargo test", "mode": "lexical", "limit": 3},
+        timeout=10.0,
+    )
+    assert '"mode": "lexical"' in capsys.readouterr().out
+
+
+def test_events_gets_with_query_params():
+    with patch("hippo_brain.api_cli.httpx.request", return_value=_Response({"events": []})) as req:
+        rc = api_cli.main(
+            [
+                "--url",
+                "http://brain.local",
+                "events",
+                "--limit",
+                "2",
+                "--offset",
+                "4",
+                "--session-id",
+                "10",
+                "--since-ms",
+                "123",
+                "--project",
+                "hippo",
+            ]
+        )
+
+    assert rc == 0
+    req.assert_called_once_with(
+        "GET",
+        "http://brain.local/events",
+        params={
+            "limit": 2,
+            "offset": 4,
+            "session_id": 10,
+            "since_ms": 123,
+            "project": "hippo",
+        },
+        json=None,
+        timeout=10.0,
+    )
+
+
+def test_openapi_offline_prints_contract_without_http(capsys: pytest.CaptureFixture):
+    with patch("hippo_brain.api_cli.httpx.request") as req:
+        rc = api_cli.main(["openapi", "--offline"])
+
+    assert rc == 0
+    req.assert_not_called()
+    assert '"openapi": "3.1.0"' in capsys.readouterr().out
+
+
+def test_http_errors_return_nonzero(capsys: pytest.CaptureFixture):
+    with patch("hippo_brain.api_cli.httpx.request", return_value=_Response({"error": "bad"}, 503)):
+        rc = api_cli.main(["--url", "http://brain.local", "health"])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "HTTP 503" in err
+    assert "bad" in err

--- a/brain/tests/test_api_cli.py
+++ b/brain/tests/test_api_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -10,12 +11,23 @@ from hippo_brain import api_cli
 
 
 class _Response:
-    def __init__(self, payload: dict, status_code: int = 200):
+    def __init__(
+        self,
+        payload: dict,
+        status_code: int = 200,
+        *,
+        text: str | None = None,
+        raise_json: bool = False,
+    ):
         self._payload = payload
         self.status_code = status_code
-        self.text = str(payload)
+        self._raise_json = raise_json
+        # Mirror httpx.Response.text: the raw JSON body, not a Python dict repr.
+        self.text = text if text is not None else json.dumps(payload)
 
     def json(self) -> dict:
+        if self._raise_json:
+            raise ValueError("response body is not valid JSON")
         return self._payload
 
 
@@ -117,3 +129,118 @@ def test_http_errors_return_nonzero(capsys: pytest.CaptureFixture):
     err = capsys.readouterr().err
     assert "HTTP 503" in err
     assert "bad" in err
+
+
+def test_sessions_gets_with_pagination():
+    with patch(
+        "hippo_brain.api_cli.httpx.request", return_value=_Response({"sessions": []})
+    ) as req:
+        rc = api_cli.main(
+            [
+                "--url",
+                "http://brain.local",
+                "sessions",
+                "--limit",
+                "5",
+                "--offset",
+                "1",
+                "--since-ms",
+                "99",
+            ]
+        )
+
+    assert rc == 0
+    req.assert_called_once_with(
+        "GET",
+        "http://brain.local/sessions",
+        params={"limit": 5, "offset": 1, "since_ms": 99},
+        json=None,
+        timeout=10.0,
+    )
+
+
+def test_knowledge_gets_with_filters():
+    with patch(
+        "hippo_brain.api_cli.httpx.request", return_value=_Response({"nodes": [], "total": 0})
+    ) as req:
+        rc = api_cli.main(
+            [
+                "--url",
+                "http://brain.local",
+                "knowledge",
+                "--limit",
+                "2",
+                "--node-type",
+                "lesson",
+                "--since-ms",
+                "5",
+            ]
+        )
+
+    assert rc == 0
+    # --offset omitted -> dropped by _optional_params, not sent as None.
+    req.assert_called_once_with(
+        "GET",
+        "http://brain.local/knowledge",
+        params={"limit": 2, "node_type": "lesson", "since_ms": 5},
+        json=None,
+        timeout=10.0,
+    )
+
+
+def test_knowledge_get_targets_id_path():
+    with patch("hippo_brain.api_cli.httpx.request", return_value=_Response({"id": 7})) as req:
+        rc = api_cli.main(["--url", "http://brain.local", "knowledge-get", "7"])
+
+    assert rc == 0
+    req.assert_called_once_with(
+        "GET",
+        "http://brain.local/knowledge/7",
+        params=None,
+        json=None,
+        timeout=10.0,
+    )
+
+
+def test_ask_posts_question_body():
+    with patch(
+        "hippo_brain.api_cli.httpx.request", return_value=_Response({"answer": "hi"})
+    ) as req:
+        rc = api_cli.main(["--url", "http://brain.local", "ask", "why is CI red?", "--limit", "4"])
+
+    assert rc == 0
+    req.assert_called_once_with(
+        "POST",
+        "http://brain.local/ask",
+        params=None,
+        json={"question": "why is CI red?", "limit": 4},
+        timeout=10.0,
+    )
+
+
+def test_resume_posts_to_control_resume():
+    with patch(
+        "hippo_brain.api_cli.httpx.request", return_value=_Response({"resumed_at": "now"})
+    ) as req:
+        rc = api_cli.main(["--url", "http://brain.local", "resume"])
+
+    assert rc == 0
+    req.assert_called_once_with(
+        "POST",
+        "http://brain.local/control/resume",
+        params=None,
+        json=None,
+        timeout=10.0,
+    )
+
+
+def test_non_json_success_body_is_printed_raw(capsys: pytest.CaptureFixture):
+    # A 2xx whose body isn't JSON: _request falls back to printing response.text.
+    with patch(
+        "hippo_brain.api_cli.httpx.request",
+        return_value=_Response({}, 200, text="plain text body", raise_json=True),
+    ):
+        rc = api_cli.main(["--url", "http://brain.local", "health"])
+
+    assert rc == 0
+    assert "plain text body" in capsys.readouterr().out

--- a/brain/tests/test_bench_orchestrate.py
+++ b/brain/tests/test_bench_orchestrate.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from hippo_brain.bench.coordinator import ModelRunResult
-from hippo_brain.bench.orchestrate import _inference_backend_version, orchestrate_run
+from hippo_brain.bench.orchestrate import _host_info, _inference_backend_version, orchestrate_run
 from hippo_brain.bench.output import AttemptRecord
 from hippo_brain.bench.preflight import CheckResult
 
@@ -27,6 +27,21 @@ def stub_corpus(tmp_path: Path) -> tuple[Path, Path]:
     manifest = tmp_path / "corpus.manifest.json"
     manifest.write_text(json.dumps({"corpus_content_hash": "sha256:test", "schema_version": 0}))
     return sqlite, manifest
+
+
+def test_host_info_survives_virtual_memory_failure(monkeypatch: pytest.MonkeyPatch):
+    """psutil can fail on macOS host_statistics64; run provenance must not
+    abort an otherwise valid benchmark run when memory size is unavailable."""
+
+    def raise_virtual_memory():
+        raise RuntimeError("host_statistics64(HOST_VM_INFO64) syscall failed")
+
+    monkeypatch.setattr("hippo_brain.bench.orchestrate.psutil.virtual_memory", raise_virtual_memory)
+
+    info = _host_info()
+
+    assert info["hostname"]
+    assert info["total_mem_gb"] is None
 
 
 def test_dry_run_writes_manifest_then_run_end(stub_corpus, tmp_path):

--- a/brain/tests/test_bench_orchestrate.py
+++ b/brain/tests/test_bench_orchestrate.py
@@ -42,6 +42,10 @@ def test_host_info_survives_virtual_memory_failure(monkeypatch: pytest.MonkeyPat
 
     assert info["hostname"]
     assert info["total_mem_gb"] is None
+    # The memory failure must not suppress the other provenance fields.
+    assert info["os"]
+    assert info["arch"]
+    assert "cpu_brand" in info
 
 
 def test_dry_run_writes_manifest_then_run_end(stub_corpus, tmp_path):

--- a/brain/tests/test_openapi.py
+++ b/brain/tests/test_openapi.py
@@ -1,0 +1,114 @@
+"""Tests for the brain HTTP OpenAPI contract."""
+
+from __future__ import annotations
+
+import re
+
+from starlette.testclient import TestClient
+
+from hippo_brain.openapi import build_openapi_spec
+from hippo_brain.server import BrainServer
+
+
+def _normalize_route_path(path: str) -> str:
+    """Strip Starlette path-param type annotations (``{id:int}`` -> ``{id}``)
+    so route paths line up with OpenAPI path templates."""
+    return re.sub(r":\w+\}", "}", path)
+
+
+def _documented_methods(route_methods: set[str]) -> set[str]:
+    """Drop HEAD, which Starlette auto-registers for GET routes, and lower-case
+    to match the OpenAPI verb keys (``get``/``post``)."""
+    return {m.lower() for m in route_methods if m.upper() != "HEAD"}
+
+
+def test_openapi_spec_lists_all_brain_routes():
+    spec = build_openapi_spec()
+
+    assert spec["openapi"].startswith("3.")
+    assert spec["info"]["title"] == "Hippo Brain API"
+
+    paths = spec["paths"]
+    expected_paths = {
+        "/health",
+        "/sessions",
+        "/events",
+        "/knowledge",
+        "/knowledge/{id}",
+        "/query",
+        "/ask",
+        "/control/pause",
+        "/control/resume",
+        "/openapi.json",
+    }
+    assert set(paths) == expected_paths
+
+    assert paths["/health"]["get"]["operationId"] == "getHealth"
+    assert paths["/sessions"]["get"]["operationId"] == "listSessions"
+    assert paths["/events"]["get"]["operationId"] == "listEvents"
+    assert paths["/knowledge"]["get"]["operationId"] == "listKnowledge"
+    assert paths["/knowledge/{id}"]["get"]["operationId"] == "getKnowledge"
+    assert paths["/query"]["post"]["operationId"] == "queryKnowledge"
+    assert paths["/ask"]["post"]["operationId"] == "askQuestion"
+    assert paths["/control/pause"]["post"]["operationId"] == "pauseEnrichment"
+    assert paths["/control/resume"]["post"]["operationId"] == "resumeEnrichment"
+    assert paths["/openapi.json"]["get"]["operationId"] == "getOpenApiSpec"
+
+
+def test_pause_response_schema_documents_quiescence_fields():
+    pause_response = build_openapi_spec()["paths"]["/control/pause"]["post"]["responses"]["200"]
+    schema = build_openapi_spec()["components"]["schemas"]["PauseResponse"]
+
+    assert pause_response["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/PauseResponse"
+    )
+    assert set(schema["required"]) == {
+        "paused_at",
+        "in_flight_finished",
+        "enrichment_active",
+        "query_inflight",
+    }
+    assert schema["properties"]["in_flight_finished"]["type"] == "boolean"
+    assert schema["properties"]["enrichment_active"]["type"] == "boolean"
+    assert schema["properties"]["query_inflight"]["type"] == "integer"
+
+
+def test_openapi_json_route_serves_same_contract(tmp_db):
+    _, db_path = tmp_db
+    server = BrainServer(db_path=str(db_path))
+    from starlette.applications import Starlette
+
+    client = TestClient(Starlette(routes=server.get_routes()))
+
+    resp = client.get("/openapi.json")
+
+    assert resp.status_code == 200
+    assert resp.json() == build_openapi_spec()
+
+
+def test_openapi_spec_covers_every_server_route(tmp_db):
+    """Drift guard: every route registered on the live server must appear in
+    the explicit OpenAPI contract with matching documented methods. Catches
+    a new route added to ``BrainServer.get_routes`` without a corresponding
+    spec entry (or vice versa)."""
+    _, db_path = tmp_db
+    server = BrainServer(db_path=str(db_path))
+
+    spec = build_openapi_spec()
+    spec_paths = {path: {m.lower() for m in ops} for path, ops in spec["paths"].items()}
+
+    route_paths = {
+        _normalize_route_path(route.path): _documented_methods(route.methods or set())
+        for route in server.get_routes()
+    }
+
+    assert set(route_paths) == set(spec_paths), (
+        "Server routes and OpenAPI paths drifted. "
+        f"Only on server: {set(route_paths) - set(spec_paths)}. "
+        f"Only in spec: {set(spec_paths) - set(route_paths)}."
+    )
+
+    for path, methods in route_paths.items():
+        assert methods == spec_paths[path], (
+            f"Method mismatch for {path}: server={methods}, spec={spec_paths[path]}"
+        )

--- a/brain/tests/test_openapi.py
+++ b/brain/tests/test_openapi.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 
+from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from hippo_brain.openapi import build_openapi_spec
@@ -76,7 +77,6 @@ def test_pause_response_schema_documents_quiescence_fields():
 def test_openapi_json_route_serves_same_contract(tmp_db):
     _, db_path = tmp_db
     server = BrainServer(db_path=str(db_path))
-    from starlette.applications import Starlette
 
     client = TestClient(Starlette(routes=server.get_routes()))
 
@@ -112,3 +112,19 @@ def test_openapi_spec_covers_every_server_route(tmp_db):
         assert methods == spec_paths[path], (
             f"Method mismatch for {path}: server={methods}, spec={spec_paths[path]}"
         )
+
+
+def test_knowledge_list_uses_summary_schema_without_heavy_fields():
+    """The /knowledge list response must not promise fields the list handler
+    never returns. ``list_knowledge`` emits a 7-field projection; only
+    ``get_knowledge`` (/knowledge/{id}) hydrates embed_text/related_entities/
+    related_events. The list items therefore reference the lighter summary
+    schema, while the by-id endpoint keeps the full KnowledgeNode."""
+    schemas = build_openapi_spec()["components"]["schemas"]
+
+    list_item_ref = schemas["KnowledgeListResponse"]["properties"]["nodes"]["items"]["$ref"]
+    assert list_item_ref.endswith("/KnowledgeNodeSummary")
+
+    heavy = {"embed_text", "related_entities", "related_events"}
+    assert heavy.isdisjoint(schemas["KnowledgeNodeSummary"]["properties"])
+    assert heavy.issubset(schemas["KnowledgeNode"]["properties"])

--- a/brain/tests/test_server.py
+++ b/brain/tests/test_server.py
@@ -353,7 +353,7 @@ def test_brain_server_get_routes(tmp_db):
     _, db_path = tmp_db
     server = _make_server(str(db_path))
     routes = server.get_routes()
-    assert len(routes) == 9
+    assert len(routes) == 10
     paths = [r.path for r in routes]
     assert "/health" in paths
     assert "/sessions" in paths
@@ -363,6 +363,7 @@ def test_brain_server_get_routes(tmp_db):
     assert "/ask" in paths
     assert "/control/pause" in paths
     assert "/control/resume" in paths
+    assert "/openapi.json" in paths
 
 
 # ---- create_app ----
@@ -942,7 +943,7 @@ def test_knowledge_list_routes_included(tmp_db):
     paths = [r.path for r in routes]
     assert "/knowledge" in paths
     assert "/knowledge/{id:int}" in paths
-    assert len(routes) == 9
+    assert len(routes) == 10
 
 
 # ---- /knowledge/{id} ----
@@ -1129,7 +1130,7 @@ def test_events_list_routes_included(tmp_db):
     routes = server.get_routes()
     paths = [r.path for r in routes]
     assert "/events" in paths
-    assert len(routes) == 9
+    assert len(routes) == 10
 
 
 # ---- /sessions ----
@@ -1250,7 +1251,7 @@ def test_sessions_list_routes_included(tmp_db):
     routes = server.get_routes()
     paths = [r.path for r in routes]
     assert "/sessions" in paths
-    assert len(routes) == 9
+    assert len(routes) == 10
 
 
 # ---- _record_preflight_to_source_health ----

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.28.7"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/mise.toml
+++ b/mise.toml
@@ -388,6 +388,108 @@ run = "cargo run --bin hippo -- daemon run"
 description = "Run the brain enrichment server"
 run = "uv run --project brain hippo-brain serve"
 
+[tasks."brain:api"]
+description = "Call the structured brain API CLI: mise run brain:api -- <operation> [args]"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -eq 0 ]; then
+    uv run --project brain hippo-brain-api --help
+    exit 2
+fi
+uv run --project brain hippo-brain-api "$@"
+'''
+
+[tasks."brain:api:health"]
+description = "GET /health from the brain API"
+run = "uv run --project brain hippo-brain-api health"
+
+[tasks."brain:api:sessions"]
+description = "GET /sessions from the brain API; forwards optional CLI args"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+uv run --project brain hippo-brain-api sessions "$@"
+'''
+
+[tasks."brain:api:events"]
+description = "GET /events from the brain API; forwards optional CLI args"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+uv run --project brain hippo-brain-api events "$@"
+'''
+
+[tasks."brain:api:knowledge"]
+description = "GET /knowledge from the brain API; forwards optional CLI args"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+uv run --project brain hippo-brain-api knowledge "$@"
+'''
+
+[tasks."brain:api:knowledge-get"]
+description = "GET /knowledge/{id}; usage: mise run brain:api:knowledge-get -- <id>"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -lt 1 ]; then
+    echo "Usage: mise run brain:api:knowledge-get -- <id>" >&2
+    exit 2
+fi
+uv run --project brain hippo-brain-api knowledge-get "$@"
+'''
+
+[tasks."brain:api:query"]
+description = "POST /query; usage: mise run brain:api:query -- <text> [--mode semantic|lexical] [--limit N]"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -lt 1 ]; then
+    echo "Usage: mise run brain:api:query -- <text> [--mode semantic|lexical] [--limit N]" >&2
+    exit 2
+fi
+uv run --project brain hippo-brain-api query "$@"
+'''
+
+[tasks."brain:api:ask"]
+description = "POST /ask; usage: mise run brain:api:ask -- <question> [--limit N]"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -lt 1 ]; then
+    echo "Usage: mise run brain:api:ask -- <question> [--limit N]" >&2
+    exit 2
+fi
+uv run --project brain hippo-brain-api ask "$@"
+'''
+
+[tasks."brain:api:pause"]
+description = "POST /control/pause to pause enrichment while ingestion continues"
+run = "uv run --project brain hippo-brain-api pause"
+
+[tasks."brain:api:resume"]
+description = "POST /control/resume to resume enrichment"
+run = "uv run --project brain hippo-brain-api resume"
+
+[tasks."brain:api:openapi"]
+description = "Print the built-in OpenAPI contract without requiring a running brain"
+run = "uv run --project brain hippo-brain-api openapi --offline"
+
+[tasks."brain:api:openapi:live"]
+description = "GET /openapi.json from the running brain API"
+run = "uv run --project brain hippo-brain-api openapi"
+
+[tasks."brain:api:openapi:write"]
+description = "Write the OpenAPI contract to OUT (default: brain/openapi.json)"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+OUT="${OUT:-brain/openapi.json}"
+uv run --project brain hippo-brain-api openapi --offline > "$OUT"
+echo "Wrote $OUT"
+'''
+
 [tasks.status]
 description = "Show daemon status"
 run = "cargo run --bin hippo -- status"

--- a/site/package.json
+++ b/site/package.json
@@ -17,7 +17,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/rss": "^4.0.7",
     "@astrojs/sitemap": "^3.7.2",
-    "astro": "^6.2.1",
+    "astro": "^6.4.6",
     "astro-pagefind": "^1.7.0",
     "isomorphic-dompurify": "^3.11.0",
     "marked": "^18.0.3",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify: ^3.4.9
+  vite: ^7.3.5
+  esbuild: ^0.28.1
+  yaml: ^2.8.3
+  js-yaml: ^4.2.0
+  undici: ^7.28.0
+  brace-expansion@5: ^5.0.6
+
 importers:
 
   .:
@@ -18,11 +27,11 @@ importers:
         specifier: ^3.7.2
         version: 3.7.2
       astro:
-        specifier: ^6.2.1
-        version: 6.2.1(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+        specifier: ^6.4.6
+        version: 6.4.8(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(yaml@2.9.0)
       astro-pagefind:
         specifier: ^1.7.0
-        version: 1.8.6(astro@6.2.1(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
+        version: 1.8.6(astro@6.4.8(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(yaml@2.9.0))
       isomorphic-dompurify:
         specifier: ^3.11.0
         version: 3.11.0
@@ -86,7 +95,7 @@ importers:
         version: 0.34.5
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -117,8 +126,8 @@ packages:
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
 
-  '@astrojs/internal-helpers@0.9.0':
-    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
+  '@astrojs/internal-helpers@0.10.0':
+    resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
 
   '@astrojs/language-server@2.16.7':
     resolution: {integrity: sha512-b64bWT74Vq/ORcSqW7TdIjjpB6hcl+Ei/lMANIUaAGlLPiYNtPTRI/j2tzvugT+LoVwfJtE2Ukq/t2OGCyEtfQ==}
@@ -132,11 +141,11 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  '@astrojs/markdown-remark@7.1.1':
-    resolution: {integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==}
+  '@astrojs/markdown-remark@7.2.0':
+    resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
-  '@astrojs/prism@4.0.1':
-    resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
+  '@astrojs/prism@4.0.2':
+    resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
     engines: {node: '>=22.12.0'}
 
   '@astrojs/rss@4.0.18':
@@ -145,8 +154,8 @@ packages:
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
 
-  '@astrojs/telemetry@3.3.1':
-    resolution: {integrity: sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==}
+  '@astrojs/telemetry@3.3.2':
+    resolution: {integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@astrojs/yaml2ts@0.2.3':
@@ -245,158 +254,158 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -821,7 +830,7 @@ packages:
     resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -914,8 +923,8 @@ packages:
     peerDependencies:
       astro: ^2.0.4 || ^3 || ^4 || ^5 || ^6
 
-  astro@6.2.1:
-    resolution: {integrity: sha512-3g1sYNly+QAkuO5ErNEQBYvsxorNDSCUNIeStBs+kcXGchvKQl1Q9EuDNOvSg010XLlHJFLVFZs9LV18Jjp4Hg==}
+  astro@6.4.8:
+    resolution: {integrity: sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -936,8 +945,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   ccount@2.0.1:
@@ -1073,9 +1082,6 @@ packages:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
-
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -1086,8 +1092,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.2:
-    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -1121,8 +1127,8 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1206,6 +1212,10 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  get-tsconfig@5.0.0-beta.4:
+    resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
+    engines: {node: '>=20.20.0'}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -1306,8 +1316,8 @@ packages:
     resolution: {integrity: sha512-il0sNhLnfawc6vKoMqnZX1JXzEzw0pP3DZWg7mM7VJNJ8cq6DCxeAjEcfjTazyBF8dkUn+rBsBPS5NQs4ZaI3g==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -1857,16 +1867,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1898,8 +1898,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -2006,8 +2006,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2021,7 +2021,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -2049,7 +2049,7 @@ packages:
   vitefu@1.1.3:
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^7.3.5
     peerDependenciesMeta:
       vite:
         optional: true
@@ -2070,7 +2070,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^7.3.5
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2241,11 +2241,6 @@ packages:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
     hasBin: true
 
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -2310,9 +2305,16 @@ snapshots:
 
   '@astrojs/compiler@4.0.0': {}
 
-  '@astrojs/internal-helpers@0.9.0':
+  '@astrojs/internal-helpers@0.10.0':
     dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      js-yaml: 4.2.0
       picomatch: 4.0.4
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
+      smol-toml: 1.6.1
+      unified: 11.0.5
 
   '@astrojs/language-server@2.16.7(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
@@ -2339,14 +2341,13 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@astrojs/markdown-remark@7.1.1':
+  '@astrojs/markdown-remark@7.2.0':
     dependencies:
-      '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/prism': 4.0.1
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/prism': 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -2354,9 +2355,6 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.0.2
-      smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -2365,7 +2363,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/prism@4.0.1':
+  '@astrojs/prism@4.0.2':
     dependencies:
       prismjs: 1.30.0
 
@@ -2381,10 +2379,9 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.2
 
-  '@astrojs/telemetry@3.3.1':
+  '@astrojs/telemetry@3.3.2':
     dependencies:
       ci-info: 4.4.0
-      dlv: 1.1.3
       dset: 3.1.4
       is-docker: 4.0.0
       is-wsl: 3.1.1
@@ -2479,82 +2476,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@exodus/bytes@1.15.0': {}
@@ -2868,13 +2865,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -2982,19 +2979,19 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  astro-pagefind@1.8.6(astro@6.2.1(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)):
+  astro-pagefind@1.8.6(astro@6.4.8(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@pagefind/default-ui': 1.5.2
-      astro: 6.2.1(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      astro: 6.4.8(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(yaml@2.9.0)
       pagefind: 1.5.2
       sirv: 3.0.2
 
-  astro@6.2.1(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
+  astro@6.4.8(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
-      '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/markdown-remark': 7.1.1
-      '@astrojs/telemetry': 3.3.1
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/markdown-remark': 7.2.0
+      '@astrojs/telemetry': 3.3.2
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.3.0
       '@oslojs/encoding': 1.1.0
@@ -3009,13 +3006,15 @@ snapshots:
       diff: 8.0.4
       dset: 3.1.4
       es-module-lexer: 2.1.0
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       flattie: 1.1.1
       fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
+      jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.2
       mrmime: 2.0.1
@@ -3034,14 +3033,13 @@ snapshots:
       tinyclip: 0.1.12
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
-      tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.2
@@ -3078,7 +3076,6 @@ snapshots:
       - supports-color
       - terser
       - tsx
-      - typescript
       - uploadthing
       - yaml
 
@@ -3094,7 +3091,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3207,8 +3204,6 @@ snapshots:
 
   diff@8.0.4: {}
 
-  dlv@1.1.3: {}
-
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -3221,7 +3216,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.2:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3250,34 +3245,34 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -3346,6 +3341,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
     optional: true
+
+  get-tsconfig@5.0.0-beta.4:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
 
@@ -3503,13 +3502,13 @@ snapshots:
 
   isomorphic-dompurify@3.11.0:
     dependencies:
-      dompurify: 3.4.2
+      dompurify: 3.4.11
       jsdom: 29.1.1
     transitivePeerDependencies:
       - '@noble/hashes'
       - canvas
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -3530,7 +3529,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3558,7 +3557,7 @@ snapshots:
       meow: 14.1.0
       mime: 4.1.0
       srcset: 5.0.3
-      undici: 7.25.0
+      undici: 7.28.0
 
   longest-streak@3.1.0: {}
 
@@ -3906,7 +3905,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minipass@7.1.3: {}
 
@@ -4132,8 +4131,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resolve-pkg-maps@1.0.0:
-    optional: true
+  resolve-pkg-maps@1.0.0: {}
 
   retext-latin@4.0.0:
     dependencies:
@@ -4336,16 +4334,12 @@ snapshots:
 
   trough@2.2.0: {}
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
-
   tslib@2.8.1:
     optional: true
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -4367,7 +4361,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -4453,9 +4447,9 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0):
+  vite@7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.13
@@ -4467,14 +4461,14 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.5(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -4491,7 +4485,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
@@ -4649,9 +4643,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 

--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+# Security overrides — force patched versions of (mostly transitive) deps
+# flagged by Dependabot / `pnpm audit`. pnpm 10 reads `overrides` from here,
+# not from the deprecated "pnpm" field in package.json.
+#
+#   astro is bumped directly in package.json (^6.4.6); the rest are transitive:
+#   - dompurify / vite / esbuild / yaml / js-yaml : pulled by astro + vitest
+#   - undici / brace-expansion@5                  : dev-only, via linkinator
+overrides:
+  dompurify: "^3.4.9"
+  vite: "^7.3.5"
+  esbuild: "^0.28.1"
+  yaml: "^2.8.3"
+  js-yaml: "^4.2.0"
+  undici: "^7.28.0"
+  "brace-expansion@5": "^5.0.6"


### PR DESCRIPTION
## Summary

Primarily a brain feature + the `0.29.0` release; this PR also bundles the post-review fixes and clears every open Dependabot alert on the `site/` subproject.

Commits:
1. `feat(brain)` — explicit OpenAPI contract, structured API CLI, bench host-info resilience
2. `chore: release 0.29.0`
3. `fix(brain)` — review fixes (honest `/knowledge` list schema + nits)
4. `fix(site)` — resolve all Dependabot security alerts

## Brain feature

The brain server is Starlette (not FastAPI), so it had no generated OpenAPI document and no structured CLI for its HTTP operations. Operators relied on hand-written `curl` for pause/resume/health/query, and the API contract was implicit in `BrainServer.get_routes`.

- **`openapi.py`** — explicit OpenAPI 3.1 contract for all 10 brain routes, served at `GET /openapi.json` and printable offline (`hippo-brain-api openapi --offline`) for codegen / API-diff workflows.
- **`api_cli.py`** — `hippo-brain-api` CLI wrapping every brain operation (health, sessions, events, knowledge, knowledge-get, query, ask, pause, resume, openapi) with `--url`/`HIPPO_BRAIN_URL` override.
- **`server.py`** — register `GET /openapi.json` returning the built contract.
- **`mise.toml`** — 13 `brain:api:*` wrapper tasks for each operation.
- **`orchestrate.py`** — `_host_info` tolerates `psutil.virtual_memory()` failures (macOS `host_statistics64` has been observed to fail) and emits `total_mem_gb=null` instead of aborting the bench run.
- **`test_openapi.py`** — drift guard asserting the explicit spec covers every route on `BrainServer.get_routes()` with matching methods, so a future route added without a spec entry fails CI.
- **READMEs** — document the CLI, soft-pause semantics, and the `launchctl bootout` recipe for unloading a local model during benches.

## Release (0.29.0)

Bundles the version bump `0.28.7 → 0.29.0` into this PR, per the single-self-contained-feature convention.

- **Minor**, not patch: net-new public surface — two new console scripts (`hippo-brain-api`, `hippo-brain-openapi`) and a new `GET /openapi.json` endpoint. The "schema-unchanged → patch" heuristic yields to "notable new behavior → minor."
- Schema `PRAGMA user_version` is **unchanged (18)**; no migration. `0.28.7` already carried schema 18, so the minor rests purely on the new feature surface.
- Files bumped: `Cargo.toml`, `Cargo.lock` (`hippo-core` + `hippo-daemon`), `brain/pyproject.toml`, `brain/uv.lock`.

## Review fixes

Address a critical multi-agent review of the feature commit:

- **Honest `/knowledge` list schema** — `list_knowledge` returns a 7-field projection, but the spec's `KnowledgeNode` (referenced by the list response) declared 10. Added `KnowledgeNodeSummary` (the 7 fields the list actually returns); `KnowledgeNode` (10 fields, with `embed_text`/`related_entities`/`related_events`) stays on `/knowledge/{id}`. A new guard test locks the split.
- **`_host_info` exception** — tightened the bare `except Exception` to `(psutil.Error, OSError, RuntimeError)` and documented the `total_mem_gb=None` fallback.
- **bench/README** — fixed the `launchctl bootout` command to the portable quoted-uid + plist-path form, matching the other READMEs.
- **Tests** — cover the 5 previously-untested `api_cli` handlers + the non-JSON 2xx path; mock `httpx` `.text` as real JSON (not Python repr); assert host-info's other fields survive a memory failure; hoist a local Starlette import.

## Site security (Dependabot)

Clears the **15 open Dependabot alerts** on `site/` (3 high, 8 moderate, 4 low) plus 8 additional advisories surfaced by `pnpm audit`:

- `astro ^6.2.1 → ^6.4.6` (resolves 6.4.8) — direct bump, fixes the astro high/medium CVEs.
- pnpm overrides (in **`pnpm-workspace.yaml`** — pnpm 10 no longer reads the `package.json` `pnpm` field) force patched transitives: `vite ^7.3.5`, `esbuild ^0.28.1`, `dompurify ^3.4.9`, `yaml ^2.8.3`, `js-yaml ^4.2.0`, `undici ^7.28.0`, `brace-expansion@5 ^5.0.6` (version-scoped to 5.x only).
- `undici`/`brace-expansion` are dev-only (via `linkinator`), not in the shipped site bundle.

> Note: the repo's Dependabot alert count reflects the **default branch** and will only drop once this PR merges to `main`.

## Verification

- **Rust:** `cargo fmt --check` · `clippy --all-targets -D warnings` · `cargo test --workspace` — all clean
- **Python:** `ruff check` + `ruff format --check` clean · `uv sync` installs `hippo-brain==0.29.0` · `pytest` **1087 passed**, 1 skipped, 1 xfailed, 1 xpassed
- **Site:** `pnpm audit` clean · `--frozen-lockfile` install passes (CI-reproducible) · `astro build` (38 pages) · `vitest` **31 passed** · `astro check` 0 errors
- New `test_openapi_spec_covers_every_server_route` drift guard verified to fire on an undocumented route

## Notes

Soft pause (`/control/pause`) stops new enrichment claims but keeps the brain up for health/query/resume. To fully unload a local model for a benchmark, `launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.hippo.brain.plist` (leaving daemon + ingest agents up).
