### PR TITLE
feat(training): multi-source export with full enrichment JSON for fine-tuning

### DIFF
--- a/brain/src/hippo_brain/__init__.py
+++ b/brain/src/hippo_brain/__init__.py
@@ -91,6 +91,85 @@ def _load_runtime_settings() -> dict:
     }
 
 
+def _cmd_serve(args: object) -> None:
+    import uvicorn
+
+    from hippo_brain.server import create_app
+    from hippo_brain.telemetry import init_telemetry
+
+    settings = _load_runtime_settings()
+
+    # Brain uses HTTP OTLP (port 4318); config.toml stores the daemon's gRPC
+    # endpoint (4317) as the single [telemetry] endpoint key. This replace
+    # is a local-stack convenience — if you run a remote collector with a
+    # non-standard port, set OTEL_EXPORTER_OTLP_ENDPOINT=http://host:PORT
+    # in the brain LaunchAgent env to bypass this substitution.
+    otel_endpoint = settings.get("telemetry_endpoint", "").replace(":4317", ":4318")
+    _otel_shutdown = init_telemetry("hippo-brain", endpoint=otel_endpoint)
+
+    app = create_app(
+        db_path=settings["db_path"],
+        data_dir=settings["data_dir"],
+        inference_base_url=settings["inference_base_url"],
+        inference_timeout_secs=settings["inference_timeout_secs"],
+        enrichment_model=settings["enrichment_model"],
+        embedding_model=settings["embedding_model"],
+        query_model=settings["query_model"],
+        poll_interval_secs=settings["poll_interval_secs"],
+        enrichment_batch_size=settings["max_events_per_chunk"],
+        session_stale_secs=settings["session_stale_secs"],
+        max_claim_batch=settings["max_claim_batch"],
+        lock_timeout_ms=int(settings["lock_timeout_secs"]) * 1000,
+        long_dwell_bypass_ms=settings["long_dwell_bypass_ms"],
+        embed_reaper_interval_secs=settings["embed_reaper_interval_secs"],
+        embed_reaper_batch_size=settings["embed_reaper_batch_size"],
+        embed_orphan_stale_secs=settings["embed_orphan_stale_secs"],
+    )
+    try:
+        uvicorn.run(app, host="127.0.0.1", port=settings["port"])
+    finally:
+        if _otel_shutdown:
+            _otel_shutdown()
+
+
+def _cmd_enrich(args: object) -> None:
+    print("Enrichment worker not yet implemented as standalone command.")
+
+
+def _cmd_export(args: object) -> None:
+    import sqlite3
+
+    from hippo_brain.mcp_queries import parse_since
+    from hippo_brain.training import export_training_data
+
+    settings = _load_runtime_settings()
+    db_path = settings["db_path"]
+
+    since_ms = None
+    if getattr(args, "since", None):
+        since_ms = parse_since(args.since)
+        if since_ms == 0:
+            print(f"Invalid --since value: {args.since!r} (expected e.g. 30d, 7d, 24h)")
+            return
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    try:
+        stats = export_training_data(conn, args.out, since_ms=since_ms)
+    finally:
+        conn.close()
+
+    print(f"Exported {stats['total']} examples to {args.out}/")
+    print(f"  train: {stats['train']}")
+    print(f"  valid: {stats['valid']}")
+    print(f"  test:  {stats['test']}")
+    if stats.get("sources"):
+        print("  sources:")
+        for src, count in sorted(stats["sources"].items()):
+            print(f"    {src}: {count}")
+
+
 def main() -> None:
     import argparse
 
@@ -101,56 +180,25 @@ def main() -> None:
             "~/.config/hippo/config.toml and serves an HTTP API on 127.0.0.1."
         ),
     )
-    parser.add_argument(
-        "command",
-        choices=("serve", "enrich"),
-        help=(
-            "serve: run the HTTP enrichment+query server (default under the "
-            "LaunchAgent). enrich: run a one-shot enrichment pass "
-            "(not yet implemented as a standalone command)."
-        ),
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    serve_p = sub.add_parser("serve", help="run the HTTP enrichment+query server")
+    serve_p.set_defaults(func=_cmd_serve)
+
+    enrich_p = sub.add_parser("enrich", help="run a one-shot enrichment pass")
+    enrich_p.set_defaults(func=_cmd_enrich)
+
+    export_p = sub.add_parser("export", help="export training data as JSONL for fine-tuning")
+    export_p.add_argument(
+        "--out",
+        default=".",
+        help="output directory (default: current directory)",
     )
+    export_p.add_argument(
+        "--since",
+        help="export nodes created since duration (e.g. 30d, 7d, 24h)",
+    )
+    export_p.set_defaults(func=_cmd_export)
+
     args = parser.parse_args()
-    command = args.command
-
-    if command == "serve":
-        import uvicorn
-
-        from hippo_brain.server import create_app
-        from hippo_brain.telemetry import init_telemetry
-
-        settings = _load_runtime_settings()
-
-        # Brain uses HTTP OTLP (port 4318); config.toml stores the daemon's gRPC
-        # endpoint (4317) as the single [telemetry] endpoint key. This replace
-        # is a local-stack convenience — if you run a remote collector with a
-        # non-standard port, set OTEL_EXPORTER_OTLP_ENDPOINT=http://host:PORT
-        # in the brain LaunchAgent env to bypass this substitution.
-        otel_endpoint = settings.get("telemetry_endpoint", "").replace(":4317", ":4318")
-        _otel_shutdown = init_telemetry("hippo-brain", endpoint=otel_endpoint)
-
-        app = create_app(
-            db_path=settings["db_path"],
-            data_dir=settings["data_dir"],
-            inference_base_url=settings["inference_base_url"],
-            inference_timeout_secs=settings["inference_timeout_secs"],
-            enrichment_model=settings["enrichment_model"],
-            embedding_model=settings["embedding_model"],
-            query_model=settings["query_model"],
-            poll_interval_secs=settings["poll_interval_secs"],
-            enrichment_batch_size=settings["max_events_per_chunk"],
-            session_stale_secs=settings["session_stale_secs"],
-            max_claim_batch=settings["max_claim_batch"],
-            lock_timeout_ms=int(settings["lock_timeout_secs"]) * 1000,
-            long_dwell_bypass_ms=settings["long_dwell_bypass_ms"],
-            embed_reaper_interval_secs=settings["embed_reaper_interval_secs"],
-            embed_reaper_batch_size=settings["embed_reaper_batch_size"],
-            embed_orphan_stale_secs=settings["embed_orphan_stale_secs"],
-        )
-        try:
-            uvicorn.run(app, host="127.0.0.1", port=settings["port"])
-        finally:
-            if _otel_shutdown:
-                _otel_shutdown()
-    elif command == "enrich":
-        print("Enrichment worker not yet implemented as standalone command.")
+    args.func(args)

--- a/brain/src/hippo_brain/__init__.py
+++ b/brain/src/hippo_brain/__init__.py
@@ -138,6 +138,7 @@ def _cmd_enrich(args: object) -> None:
 
 def _cmd_export(args: object) -> None:
     import sqlite3
+    import sys
 
     from hippo_brain.mcp_queries import parse_since
     from hippo_brain.training import export_training_data
@@ -150,15 +151,21 @@ def _cmd_export(args: object) -> None:
         since_ms = parse_since(args.since)
         if since_ms == 0:
             print(f"Invalid --since value: {args.since!r} (expected e.g. 30d, 7d, 24h)")
-            return
+            sys.exit(1)
 
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA busy_timeout=5000")
+    # sqlite errors (missing/locked/corrupt DB) get a clean message; anything
+    # else is a bug and should keep its full traceback rather than be masked.
     try:
-        stats = export_training_data(conn, args.out, since_ms=since_ms)
-    finally:
-        conn.close()
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        try:
+            stats = export_training_data(conn, args.out, since_ms=since_ms)
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        print(f"Export failed reading {db_path}: {exc}")
+        sys.exit(1)
 
     print(f"Exported {stats['total']} examples to {args.out}/")
     print(f"  train: {stats['train']}")

--- a/brain/src/hippo_brain/__init__.py
+++ b/brain/src/hippo_brain/__init__.py
@@ -150,21 +150,26 @@ def _cmd_export(args: object) -> None:
     if getattr(args, "since", None):
         since_ms = parse_since(args.since)
         if since_ms == 0:
-            print(f"Invalid --since value: {args.since!r} (expected e.g. 30d, 7d, 24h)")
+            print(
+                f"Invalid --since value: {args.since!r} (expected e.g. 30d, 7d, 24h)",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
-    # sqlite errors (missing/locked/corrupt DB) get a clean message; anything
-    # else is a bug and should keep its full traceback rather than be masked.
+    # Read-only URI: a plain connect() would silently create an empty DB (and
+    # WAL sidecars) on a missing/typo'd path, then fail with a misleading
+    # "no such table" error. mode=ro turns that into "unable to open database
+    # file" caught below. sqlite errors (missing/locked/corrupt DB) get a
+    # clean message; anything else is a bug and keeps its full traceback.
     try:
-        conn = sqlite3.connect(db_path)
-        conn.execute("PRAGMA journal_mode=WAL")
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
         conn.execute("PRAGMA busy_timeout=5000")
         try:
             stats = export_training_data(conn, args.out, since_ms=since_ms)
         finally:
             conn.close()
     except sqlite3.Error as exc:
-        print(f"Export failed reading {db_path}: {exc}")
+        print(f"Export failed reading {db_path}: {exc}", file=sys.stderr)
         sys.exit(1)
 
     print(f"Exported {stats['total']} examples to {args.out}/")

--- a/brain/src/hippo_brain/auto_memory.py
+++ b/brain/src/hippo_brain/auto_memory.py
@@ -415,14 +415,32 @@ def claim_pending_memories(
     return claims
 
 
+def render_memory_enrichment_input(
+    repository: str, logical_path: str, content_hash: str, chunk_texts: list[str]
+) -> str:
+    """Render the enrichment user message for a memory revision.
+
+    Single source of truth for the input format: the live enrichment loop
+    (via build_memory_enrichment_prompt) and the training exporter
+    (training.py) both go through here so exported examples match what the
+    model saw at enrichment time.
+    """
+    header = (
+        f"Claude Code auto-memory\nRepository: {repository}\n"
+        f"Path: {logical_path}\nContent hash: {content_hash}"
+    )
+    body = "\n\n---\n\n".join(chunk_texts)
+    return f"{header}\n\n{body}"
+
+
 def build_memory_enrichment_prompt(claim: MemoryClaim) -> str:
     """Render one claimed, already-redacted memory revision for enrichment."""
-    header = (
-        f"Claude Code auto-memory\nRepository: {claim.repository}\n"
-        f"Path: {claim.logical_path}\nContent hash: {claim.content_hash}"
+    return render_memory_enrichment_input(
+        claim.repository,
+        claim.logical_path,
+        claim.content_hash,
+        [chunk["content"] for chunk in claim.chunks],
     )
-    body = "\n\n---\n\n".join(chunk["content"] for chunk in claim.chunks)
-    return f"{header}\n\n{body}"
 
 
 def write_memory_knowledge_node(

--- a/brain/src/hippo_brain/training.py
+++ b/brain/src/hippo_brain/training.py
@@ -23,7 +23,8 @@ from hippo_brain.claude_sessions import CLAUDE_SYSTEM_PROMPT
 from hippo_brain.browser_enrichment import BROWSER_SYSTEM_PROMPT
 from hippo_brain.workflow_enrichment import WORKFLOW_SYSTEM_PROMPT
 from hippo_brain.auto_memory import (
-    MEMORY_ENRICHMENT_SYSTEM_PROMPT,
+    MEMORY_ENRICHMENT_SYSTEM_PROMPT as MEMORY_SYSTEM_PROMPT,
+    render_memory_enrichment_input,
 )
 
 
@@ -162,6 +163,11 @@ def export_training_data(
 
     Returns stats dict with total, train, valid, test counts and per-source
     breakdown.
+
+    ``min_events`` applies to the multi-event sources (shell, agentic,
+    browser).  Workflow and auto-memory nodes are single-input by
+    construction (one run / one revision per node), so they are exported
+    regardless of ``min_events`` rather than vanishing when it is > 1.
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -301,6 +307,11 @@ def export_training_data(
         source_counts["browser"] = source_counts.get("browser", 0) + 1
 
     # ── 4. Workflow (CI) enrichment nodes ──────────────────────────────
+    # No outcome filter here, deliberately: for workflow nodes the outcome
+    # column holds the raw GitHub conclusion (success/failure/cancelled/…),
+    # not the LLM's success/partial vocab (see workflow_enrichment.py), and
+    # enriched *failed* runs — root cause + fix summaries — are exactly the
+    # training signal we want to keep.
     workflow_sql = """
         SELECT kn.id, kn.content
         FROM knowledge_nodes kn
@@ -356,25 +367,27 @@ def export_training_data(
         mem_params.append(since_ms)
 
     for node_id, content in conn.execute(memory_sql, mem_params).fetchall():
-        rev_row = conn.execute(
-            """SELECT mr.redacted_content
-               FROM memory_revisions mr
-               JOIN memory_chunks mc ON mc.revision_id = mr.id
+        chunk_rows = conn.execute(
+            """SELECT d.repository, d.logical_path, mr.content_hash, mc.content
+               FROM memory_chunks mc
+               JOIN memory_revisions mr ON mr.id = mc.revision_id
+               JOIN memory_documents d ON d.id = mr.document_id
                JOIN knowledge_node_memory_chunks knmc ON knmc.memory_chunk_id = mc.id
                WHERE knmc.knowledge_node_id = ?
-               LIMIT 1""",
+               ORDER BY mc.ordinal ASC""",
             (node_id,),
-        ).fetchone()
-        if rev_row is None:
-            continue
-        revision_text = rev_row[0] or ""
-        if not revision_text.strip():
+        ).fetchall()
+        chunk_texts = [row[3] for row in chunk_rows if (row[3] or "").strip()]
+        if not chunk_texts:
             continue
         try:
             parsed = json.loads(content)
         except json.JSONDecodeError, TypeError:
             continue
-        user_msg = revision_text
+        repository, logical_path, content_hash = chunk_rows[0][:3]
+        user_msg = render_memory_enrichment_input(
+            repository, logical_path, content_hash, chunk_texts
+        )
         assistant_msg = json.dumps(parsed, ensure_ascii=False)
         examples.append(
             {
@@ -411,6 +424,3 @@ def export_training_data(
         "test": len(test),
         "sources": source_counts,
     }
-
-
-MEMORY_SYSTEM_PROMPT = MEMORY_ENRICHMENT_SYSTEM_PROMPT

--- a/brain/src/hippo_brain/training.py
+++ b/brain/src/hippo_brain/training.py
@@ -1,12 +1,29 @@
+"""Training data export for fine-tuning enrichment models.
+
+Exports knowledge nodes from all enrichment sources (shell, Claude, OpenCode,
+browser, workflow, auto-memory) as JSONL chat-format pairs suitable for LoRA
+fine-tuning with mlx-lm.
+
+Each example contains:
+  - system: source-specific enrichment prompt (matches what the brain sends)
+  - user: reconstructed enrichment input (events, session data, URLs, CI runs)
+  - assistant: full validated JSON output the enrichment model produced
+"""
+
 import json
 import random
 from pathlib import Path
 
-SYSTEM_PROMPT = (
-    "You are a personal developer assistant with deep knowledge of the user's projects, "
-    "tools, and workflows. You have observed their shell activity and can provide contextual "
-    "help, recall past commands and their outcomes, suggest solutions based on prior experience, "
-    "and help with debugging, deployment, and development tasks."
+# Source-specific system prompts — imported from the enrichment modules so
+# they stay in sync with the live pipeline.  The auto-memory prompt is
+# truncated to its system-role text only (the enrichment loop appends
+# document chunks as the user message).
+from hippo_brain.enrichment import SYSTEM_PROMPT as SHELL_SYSTEM_PROMPT
+from hippo_brain.claude_sessions import CLAUDE_SYSTEM_PROMPT
+from hippo_brain.browser_enrichment import BROWSER_SYSTEM_PROMPT
+from hippo_brain.workflow_enrichment import WORKFLOW_SYSTEM_PROMPT
+from hippo_brain.auto_memory import (
+    MEMORY_ENRICHMENT_SYSTEM_PROMPT,
 )
 
 
@@ -14,6 +31,119 @@ def _write_jsonl(path: Path, examples: list[dict]) -> None:
     with open(path, "w") as f:
         for ex in examples:
             f.write(json.dumps(ex) + "\n")
+
+
+def _build_shell_user_message(events: list[tuple]) -> str:
+    """Reconstruct the user prompt the brain sends for shell enrichment."""
+    parts = []
+    for i, (cmd, exit_code, duration_ms, cwd, git_branch, shell) in enumerate(events, 1):
+        actor = (
+            "Claude Code (AI agent)" if shell in ("claude-code", "claude") else "developer (human)"
+        )
+        lines = [f"Event {i} (executed by {actor}):"]
+        lines.append(f"  command: {cmd}")
+        lines.append(f"  exit_code: {exit_code}")
+        lines.append(f"  duration_ms: {duration_ms}")
+        lines.append(f"  cwd: {cwd or ''}")
+        if git_branch:
+            lines.append(f"  git_branch: {git_branch}")
+        parts.append("\n".join(lines))
+    return "\n\n".join(parts)
+
+
+def _build_agentic_user_message(sessions: list[tuple]) -> str:
+    """Reconstruct the user prompt for Claude/OpenCode session enrichment."""
+    parts = []
+    for i, (
+        summary_text,
+        tool_calls_json,
+        user_prompts_json,
+        cwd,
+        git_branch,
+        model,
+        agent,
+        start_time,
+        end_time,
+        message_count,
+    ) in enumerate(sessions, 1):
+        lines = [f"Segment {i}:"]
+        lines.append(f"  summary: {summary_text}")
+        if user_prompts_json:
+            try:
+                prompts = json.loads(user_prompts_json)
+                if prompts:
+                    lines.append(f"  user_prompts: {json.dumps(prompts[:3])}")
+            except json.JSONDecodeError, TypeError:
+                pass
+        if tool_calls_json:
+            try:
+                calls = json.loads(tool_calls_json)
+                if calls:
+                    lines.append(f"  tool_calls ({len(calls)}): {json.dumps(calls[:5])}")
+            except json.JSONDecodeError, TypeError:
+                pass
+        if cwd:
+            lines.append(f"  cwd: {cwd}")
+        if git_branch:
+            lines.append(f"  git_branch: {git_branch}")
+        if model:
+            lines.append(f"  model: {model}")
+        if agent:
+            lines.append(f"  agent: {agent}")
+        if message_count:
+            lines.append(f"  message_count: {message_count}")
+        parts.append("\n".join(lines))
+    return "\n\n".join(parts)
+
+
+def _build_browser_user_message(events: list[tuple]) -> str:
+    """Reconstruct the user prompt for browser history enrichment."""
+    parts = []
+    for i, (url, title, domain, dwell_ms, scroll_depth, search_query) in enumerate(events, 1):
+        lines = [f"Page {i}:"]
+        lines.append(f"  url: {url}")
+        if title:
+            lines.append(f"  title: {title}")
+        lines.append(f"  domain: {domain}")
+        dwell_s = (dwell_ms or 0) / 1000.0
+        time_line = f"  time spent: {dwell_s:.1f}s"
+        if scroll_depth is not None:
+            time_line += f", scrolled: {int(scroll_depth * 100)}%"
+        lines.append(time_line)
+        if search_query:
+            lines.append(f"  search query: {search_query}")
+        parts.append("\n".join(lines))
+    return "\n\n".join(parts)
+
+
+def _build_workflow_user_message(run: tuple) -> str:
+    """Reconstruct the user prompt for CI workflow enrichment."""
+    (
+        repo,
+        head_sha,
+        head_branch,
+        event,
+        status,
+        conclusion,
+        started_at,
+        completed_at,
+        html_url,
+        actor,
+    ) = run
+    lines = ["Workflow run:"]
+    lines.append(f"  repo: {repo}")
+    lines.append(f"  sha: {head_sha}")
+    if head_branch:
+        lines.append(f"  branch: {head_branch}")
+    lines.append(f"  event: {event}")
+    lines.append(f"  status: {status}")
+    if conclusion:
+        lines.append(f"  conclusion: {conclusion}")
+    if html_url:
+        lines.append(f"  url: {html_url}")
+    if actor:
+        lines.append(f"  actor: {actor}")
+    return "\n".join(lines)
 
 
 def export_training_data(
@@ -24,83 +154,243 @@ def export_training_data(
 ) -> dict:
     """Export knowledge nodes as JSONL conversation pairs for fine-tuning.
 
-    Returns stats dict with total, train, valid, test counts.
+    Exports nodes from all enrichment sources (shell, Claude/OpenCode agentic
+    sessions, browser history, CI workflow runs, auto-memory).  Each example
+    includes the source-appropriate system prompt, a reconstructed user prompt
+    matching the live enrichment input format, and the full validated JSON
+    output the enrichment model produced.
+
+    Returns stats dict with total, train, valid, test counts and per-source
+    breakdown.
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Query knowledge nodes with success/partial outcome
-    sql = """
-          SELECT kn.id, kn.content, kn.embed_text, kn.outcome, kn.tags
-          FROM knowledge_nodes kn
-          WHERE kn.outcome IN ('success', 'partial')
-          """
-    params = []
+    examples: list[dict] = []
+    source_counts: dict[str, int] = {}
+
+    # ── 1. Shell enrichment nodes ──────────────────────────────────────
+    shell_sql = """
+        SELECT kn.id, kn.content
+        FROM knowledge_nodes kn
+        WHERE kn.outcome IN ('success', 'partial')
+          AND kn.node_type = 'observation'
+          AND kn.id IN (SELECT DISTINCT knowledge_node_id FROM knowledge_node_events)
+          AND kn.id NOT IN (SELECT DISTINCT knowledge_node_id FROM knowledge_node_agentic_sessions)
+          AND kn.id NOT IN (SELECT DISTINCT knowledge_node_id FROM knowledge_node_browser_events)
+          AND kn.id NOT IN (SELECT DISTINCT knowledge_node_id FROM knowledge_node_workflow_runs)
+    """
+    shell_params: list = []
     if since_ms is not None:
-        sql += " AND kn.created_at >= ?"
-        params.append(since_ms)
+        shell_sql += " AND kn.created_at >= ?"
+        shell_params.append(since_ms)
 
-    cursor = conn.execute(sql, params)
-    nodes = cursor.fetchall()
-
-    examples = []
-    for node_id, content, embed_text, outcome, tags in nodes:
-        # Get linked events
-        # nosemgrep: unfiltered-event-table-select -- linked via knowledge_node_events;
-        # knowledge nodes are only written from non-probe events (probes skip the
-        # enrichment queue) so probe rows cannot appear here via this JOIN path.
-        event_cursor = conn.execute(  # nosemgrep: unfiltered-event-table-select
-            """
-            SELECT e.command, e.exit_code, e.duration_ms, e.cwd, e.git_branch
-            FROM events e
-                     JOIN knowledge_node_events kne ON kne.event_id = e.id
-            WHERE kne.knowledge_node_id = ?
-            """,
+    for node_id, content in conn.execute(shell_sql, shell_params).fetchall():
+        events = conn.execute(
+            """SELECT e.command, e.exit_code, e.duration_ms, e.cwd, e.git_branch, e.shell
+               FROM events e
+               JOIN knowledge_node_events kne ON kne.event_id = e.id
+               WHERE kne.knowledge_node_id = ?
+                 AND e.probe_tag IS NULL
+               ORDER BY e.timestamp ASC""",
             (node_id,),
-        )
-        events = event_cursor.fetchall()
-
+        ).fetchall()
         if len(events) < min_events:
             continue
-
-        # Build user message from events
-        user_parts = []
-        for cmd, exit_code, duration_ms, cwd, git_branch in events:
-            parts = [f"$ {cmd}"]
-            if exit_code is not None:
-                parts.append(f"  exit: {exit_code}")
-            if duration_ms:
-                parts.append(f"  duration: {duration_ms}ms")
-            if cwd:
-                parts.append(f"  cwd: {cwd}")
-            if git_branch:
-                parts.append(f"  branch: {git_branch}")
-            user_parts.append("\n".join(parts))
-
-        user_message = "What was I doing here?\n\n" + "\n\n".join(user_parts)
-
-        # Build assistant message from knowledge node
         try:
-            content_data = json.loads(content)
-            summary = content_data.get("summary", embed_text)
+            parsed = json.loads(content)
         except json.JSONDecodeError, TypeError:
-            summary = embed_text
+            continue
+        user_msg = _build_shell_user_message(events)
+        assistant_msg = json.dumps(parsed, ensure_ascii=False)
+        examples.append(
+            {
+                "messages": [
+                    {"role": "system", "content": SHELL_SYSTEM_PROMPT},
+                    {"role": "user", "content": user_msg},
+                    {"role": "assistant", "content": assistant_msg},
+                ]
+            }
+        )
+        source_counts["shell"] = source_counts.get("shell", 0) + 1
 
-        assistant_message = summary
+    # ── 2. Agentic session enrichment nodes (Claude + OpenCode) ────────
+    agentic_sql = """
+        SELECT kn.id, kn.content
+        FROM knowledge_nodes kn
+        WHERE kn.outcome IN ('success', 'partial')
+          AND kn.node_type = 'observation'
+          AND kn.id IN (SELECT DISTINCT knowledge_node_id FROM knowledge_node_agentic_sessions)
+    """
+    agentic_params: list = []
+    if since_ms is not None:
+        agentic_sql += " AND kn.created_at >= ?"
+        agentic_params.append(since_ms)
 
-        example = {
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": user_message},
-                {"role": "assistant", "content": assistant_message},
-            ]
-        }
-        examples.append(example)
+    for node_id, content in conn.execute(agentic_sql, agentic_params).fetchall():
+        sessions = conn.execute(
+            """SELECT as_.summary_text, as_.tool_calls_json, as_.user_prompts_json,
+                      as_.cwd, as_.git_branch, as_.model, as_.agent,
+                      as_.start_time, as_.end_time, as_.message_count
+               FROM agentic_sessions as_
+               JOIN knowledge_node_agentic_sessions knas ON knas.agentic_session_id = as_.id
+               WHERE knas.knowledge_node_id = ?
+                 AND as_.probe_tag IS NULL
+               ORDER BY as_.start_time ASC""",
+            (node_id,),
+        ).fetchall()
+        if len(sessions) < min_events:
+            continue
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError, TypeError:
+            continue
+        user_msg = _build_agentic_user_message(sessions)
+        assistant_msg = json.dumps(parsed, ensure_ascii=False)
+        examples.append(
+            {
+                "messages": [
+                    {"role": "system", "content": CLAUDE_SYSTEM_PROMPT},
+                    {"role": "user", "content": user_msg},
+                    {"role": "assistant", "content": assistant_msg},
+                ]
+            }
+        )
+        source_counts["agentic"] = source_counts.get("agentic", 0) + 1
 
+    # ── 3. Browser enrichment nodes ────────────────────────────────────
+    browser_sql = """
+        SELECT kn.id, kn.content
+        FROM knowledge_nodes kn
+        WHERE kn.outcome IN ('success', 'partial')
+          AND kn.node_type = 'observation'
+          AND kn.id IN (SELECT DISTINCT knowledge_node_id FROM knowledge_node_browser_events)
+    """
+    browser_params: list = []
+    if since_ms is not None:
+        browser_sql += " AND kn.created_at >= ?"
+        browser_params.append(since_ms)
+
+    for node_id, content in conn.execute(browser_sql, browser_params).fetchall():
+        events = conn.execute(
+            """SELECT be.url, be.title, be.domain, be.dwell_ms, be.scroll_depth, be.search_query
+               FROM browser_events be
+               JOIN knowledge_node_browser_events knbe ON knbe.browser_event_id = be.id
+               WHERE knbe.knowledge_node_id = ?
+                 AND be.probe_tag IS NULL
+               ORDER BY be.timestamp ASC""",
+            (node_id,),
+        ).fetchall()
+        if len(events) < min_events:
+            continue
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError, TypeError:
+            continue
+        user_msg = _build_browser_user_message(events)
+        assistant_msg = json.dumps(parsed, ensure_ascii=False)
+        examples.append(
+            {
+                "messages": [
+                    {"role": "system", "content": BROWSER_SYSTEM_PROMPT},
+                    {"role": "user", "content": user_msg},
+                    {"role": "assistant", "content": assistant_msg},
+                ]
+            }
+        )
+        source_counts["browser"] = source_counts.get("browser", 0) + 1
+
+    # ── 4. Workflow (CI) enrichment nodes ──────────────────────────────
+    workflow_sql = """
+        SELECT kn.id, kn.content
+        FROM knowledge_nodes kn
+        WHERE kn.node_type = 'change_outcome'
+          AND kn.id IN (SELECT DISTINCT knowledge_node_id FROM knowledge_node_workflow_runs)
+    """
+    wf_params: list = []
+    if since_ms is not None:
+        workflow_sql += " AND kn.created_at >= ?"
+        wf_params.append(since_ms)
+
+    for node_id, content in conn.execute(workflow_sql, wf_params).fetchall():
+        run_row = conn.execute(
+            """SELECT wr.repo, wr.head_sha, wr.head_branch, wr.event, wr.status,
+                      wr.conclusion, wr.started_at, wr.completed_at, wr.html_url, wr.actor
+               FROM workflow_runs wr
+               JOIN knowledge_node_workflow_runs knwr ON knwr.run_id = wr.id
+               WHERE knwr.knowledge_node_id = ?
+               LIMIT 1""",
+            (node_id,),
+        ).fetchone()
+        if run_row is None:
+            continue
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError, TypeError:
+            continue
+        user_msg = _build_workflow_user_message(run_row)
+        assistant_msg = json.dumps(parsed, ensure_ascii=False)
+        examples.append(
+            {
+                "messages": [
+                    {"role": "system", "content": WORKFLOW_SYSTEM_PROMPT},
+                    {"role": "user", "content": user_msg},
+                    {"role": "assistant", "content": assistant_msg},
+                ]
+            }
+        )
+        source_counts["workflow"] = source_counts.get("workflow", 0) + 1
+
+    # ── 5. Auto-memory enrichment nodes ────────────────────────────────
+    memory_sql = """
+        SELECT DISTINCT kn.id, kn.content
+        FROM knowledge_nodes kn
+        JOIN knowledge_node_memory_chunks knmc ON knmc.knowledge_node_id = kn.id
+        JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id
+        WHERE kn.outcome IN ('success', 'partial')
+          AND kn.node_type = 'observation'
+    """
+    mem_params: list = []
+    if since_ms is not None:
+        memory_sql += " AND kn.created_at >= ?"
+        mem_params.append(since_ms)
+
+    for node_id, content in conn.execute(memory_sql, mem_params).fetchall():
+        rev_row = conn.execute(
+            """SELECT mr.redacted_content
+               FROM memory_revisions mr
+               JOIN memory_chunks mc ON mc.revision_id = mr.id
+               JOIN knowledge_node_memory_chunks knmc ON knmc.memory_chunk_id = mc.id
+               WHERE knmc.knowledge_node_id = ?
+               LIMIT 1""",
+            (node_id,),
+        ).fetchone()
+        if rev_row is None:
+            continue
+        revision_text = rev_row[0] or ""
+        if not revision_text.strip():
+            continue
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError, TypeError:
+            continue
+        user_msg = revision_text
+        assistant_msg = json.dumps(parsed, ensure_ascii=False)
+        examples.append(
+            {
+                "messages": [
+                    {"role": "system", "content": MEMORY_SYSTEM_PROMPT},
+                    {"role": "user", "content": user_msg},
+                    {"role": "assistant", "content": assistant_msg},
+                ]
+            }
+        )
+        source_counts["auto-memory"] = source_counts.get("auto-memory", 0) + 1
+
+    # ── Split & write ──────────────────────────────────────────────────
     if not examples:
-        return {"total": 0, "train": 0, "valid": 0, "test": 0}
+        return {"total": 0, "train": 0, "valid": 0, "test": 0, "sources": {}}
 
-    # Shuffle and split 80/10/10
     random.shuffle(examples)
     n = len(examples)
     train_end = max(1, int(n * 0.8))
@@ -119,4 +409,13 @@ def export_training_data(
         "train": len(train),
         "valid": len(valid),
         "test": len(test),
+        "sources": source_counts,
     }
+
+
+# Truncate the auto-memory system prompt to the system-role instruction
+# only (the enrichment loop appends document chunks as the user message).
+_MEM_LINES = MEMORY_ENRICHMENT_SYSTEM_PROMPT.strip().split("\n")
+# The auto-memory system prompt ends with the output schema description;
+# we use the full prompt since the enrichment pipeline sends it as-is.
+MEMORY_SYSTEM_PROMPT = MEMORY_ENRICHMENT_SYSTEM_PROMPT

--- a/brain/src/hippo_brain/training.py
+++ b/brain/src/hippo_brain/training.py
@@ -374,7 +374,7 @@ def export_training_data(
                JOIN memory_documents d ON d.id = mr.document_id
                JOIN knowledge_node_memory_chunks knmc ON knmc.memory_chunk_id = mc.id
                WHERE knmc.knowledge_node_id = ?
-               ORDER BY mc.ordinal ASC""",
+               ORDER BY mc.revision_id ASC, mc.ordinal ASC""",
             (node_id,),
         ).fetchall()
         chunk_texts = [row[3] for row in chunk_rows if (row[3] or "").strip()]

--- a/brain/src/hippo_brain/training.py
+++ b/brain/src/hippo_brain/training.py
@@ -413,9 +413,4 @@ def export_training_data(
     }
 
 
-# Truncate the auto-memory system prompt to the system-role instruction
-# only (the enrichment loop appends document chunks as the user message).
-_MEM_LINES = MEMORY_ENRICHMENT_SYSTEM_PROMPT.strip().split("\n")
-# The auto-memory system prompt ends with the output schema description;
-# we use the full prompt since the enrichment pipeline sends it as-is.
 MEMORY_SYSTEM_PROMPT = MEMORY_ENRICHMENT_SYSTEM_PROMPT

--- a/brain/tests/test_training.py
+++ b/brain/tests/test_training.py
@@ -3,10 +3,13 @@ import tempfile
 import time
 from pathlib import Path
 
+from hippo_brain.auto_memory import render_memory_enrichment_input
 from hippo_brain.training import (
     BROWSER_SYSTEM_PROMPT,
     CLAUDE_SYSTEM_PROMPT,
+    MEMORY_SYSTEM_PROMPT,
     SHELL_SYSTEM_PROMPT,
+    WORKFLOW_SYSTEM_PROMPT,
     export_training_data,
 )
 
@@ -218,3 +221,127 @@ def test_export_browser_node(tmp_db):
         assert "docs.rs" in messages[1]["content"]
         assistant = json.loads(messages[2]["content"])
         assert "Tokio" in assistant["summary"]
+
+
+def test_export_workflow_node(tmp_db):
+    """Workflow (CI) nodes export with the live prompt — including failed runs."""
+    conn, _ = tmp_db
+    now_ms = int(time.time() * 1000)
+
+    conn.execute(
+        """INSERT INTO workflow_runs (id, repo, head_sha, head_branch, event, status,
+             conclusion, started_at, completed_at, html_url, actor, raw_json,
+             first_seen_at, last_seen_at, enriched)
+           VALUES (1, 'owner/repo', 'abc123', 'main', 'push', 'completed', 'failure',
+                   ?, ?, 'https://github.com/owner/repo/actions/runs/1', 'dev', '{}',
+                   ?, ?, 1)""",
+        (now_ms, now_ms + 60_000, now_ms, now_ms),
+    )
+    content = json.dumps(
+        {
+            "summary": "CI failed: clippy lint error in main.rs; fix by removing unused import",
+            "intent": "ci",
+            "outcome": "failure",
+            "entities": {"projects": ["repo"], "tools": ["clippy"], "files": ["main.rs"]},
+            "tags": ["ci", "failure"],
+            "key_decisions": [],
+            "problems_encountered": ["clippy lint error"],
+            "design_decisions": [],
+        }
+    )
+    # outcome column holds the raw GitHub conclusion ('failure') by design —
+    # this test locks in that failed runs are still exported.
+    conn.execute(
+        """INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags,
+             enrichment_model, created_at, updated_at)
+           VALUES (1, 'uuid-wf-1', ?, 'ci failure clippy', 'change_outcome', 'failure', '[]',
+                   'model', ?, ?)""",
+        (content, now_ms, now_ms),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_workflow_runs (knowledge_node_id, run_id) VALUES (1, 1)"
+    )
+    conn.commit()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stats = export_training_data(conn, tmpdir)
+        assert stats["total"] == 1
+        assert stats["sources"]["workflow"] == 1
+
+        data = json.loads((Path(tmpdir) / "train.jsonl").read_text().strip())
+        messages = data["messages"]
+        assert messages[0]["content"] == WORKFLOW_SYSTEM_PROMPT
+        assert "owner/repo" in messages[1]["content"]
+        assert "conclusion: failure" in messages[1]["content"]
+        assistant = json.loads(messages[2]["content"])
+        assert "clippy" in assistant["summary"]
+
+
+def test_export_memory_node_matches_live_prompt(tmp_db):
+    """Auto-memory export reproduces the live enrichment input byte-for-byte."""
+    conn, _ = tmp_db
+    now_ms = int(time.time() * 1000)
+
+    conn.execute(
+        """INSERT INTO memory_documents (id, uuid, repository, logical_path, source_path,
+             observed_at, created_at, updated_at)
+           VALUES (1, 'doc-uuid-1', 'hippo', 'MEMORY.md', '/home/user/.claude/MEMORY.md',
+                   ?, ?, ?)""",
+        (now_ms, now_ms, now_ms),
+    )
+    conn.execute(
+        """INSERT INTO memory_revisions (id, document_id, revision_number, content_hash,
+             source_hash, redacted_content, source_mtime_ms, source_size, chunker_name,
+             created_at)
+           VALUES (1, 1, 1, 'hash-1', 'src-hash-1', 'full doc', ?, 100, 'markdown', ?)""",
+        (now_ms, now_ms),
+    )
+    chunk_texts = ["# Preferences\n\nUse Rust for hot paths.", "# Projects\n\nHippo is a daemon."]
+    for i, text in enumerate(chunk_texts):
+        conn.execute(
+            """INSERT INTO memory_chunks (id, revision_id, ordinal, content, content_hash,
+                 created_at)
+               VALUES (?, 1, ?, ?, ?, ?)""",
+            (i + 1, i, text, f"chunk-hash-{i}", now_ms),
+        )
+    content = json.dumps(
+        {
+            "summary": "User prefers Rust for performance-critical code",
+            "intent": "memory",
+            "outcome": "success",
+            "entities": {"projects": ["hippo"], "tools": ["rust"]},
+            "tags": ["memory", "preferences"],
+            "key_decisions": [],
+            "problems_encountered": [],
+            "design_decisions": [],
+        }
+    )
+    conn.execute(
+        """INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags,
+             enrichment_model, created_at, updated_at)
+           VALUES (1, 'uuid-mem-1', ?, 'rust preference', 'observation', 'success', '[]',
+                   'model', ?, ?)""",
+        (content, now_ms, now_ms),
+    )
+    for chunk_id in (1, 2):
+        conn.execute(
+            "INSERT INTO knowledge_node_memory_chunks (knowledge_node_id, memory_chunk_id) VALUES (1, ?)",
+            (chunk_id,),
+        )
+    conn.commit()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stats = export_training_data(conn, tmpdir)
+        assert stats["total"] == 1
+        assert stats["sources"]["auto-memory"] == 1
+
+        data = json.loads((Path(tmpdir) / "train.jsonl").read_text().strip())
+        messages = data["messages"]
+        assert messages[0]["content"] == MEMORY_SYSTEM_PROMPT
+        # The exported user message must be byte-identical to what the live
+        # enrichment loop sends (render_memory_enrichment_input is the shared
+        # single source of truth used by build_memory_enrichment_prompt).
+        expected = render_memory_enrichment_input("hippo", "MEMORY.md", "hash-1", chunk_texts)
+        assert messages[1]["content"] == expected
+        assistant = json.loads(messages[2]["content"])
+        assert "Rust" in assistant["summary"]

--- a/brain/tests/test_training.py
+++ b/brain/tests/test_training.py
@@ -3,7 +3,12 @@ import tempfile
 import time
 from pathlib import Path
 
-from hippo_brain.training import export_training_data
+from hippo_brain.training import (
+    BROWSER_SYSTEM_PROMPT,
+    CLAUDE_SYSTEM_PROMPT,
+    SHELL_SYSTEM_PROMPT,
+    export_training_data,
+)
 
 
 def _seed_db(conn):
@@ -82,9 +87,8 @@ def test_export_training_data(tmp_db):
                 assert messages[1]["role"] == "user"
                 assert messages[2]["role"] == "assistant"
 
-                # System prompt should be the shell enrichment prompt
-                assert "developer activity analyst" in messages[0]["content"]
-                assert "shell command events" in messages[0]["content"]
+                # System prompt should be exactly the live shell enrichment prompt
+                assert messages[0]["content"] == SHELL_SYSTEM_PROMPT
 
                 # User message should contain command text
                 assert "command-" in messages[1]["content"]
@@ -159,8 +163,7 @@ def test_export_agentic_session(tmp_db):
         train_path = Path(tmpdir) / "train.jsonl"
         data = json.loads(train_path.read_text().strip())
         messages = data["messages"]
-        assert "developer activity analyst" in messages[0]["content"]
-        assert "Claude Code" in messages[0]["content"]
+        assert messages[0]["content"] == CLAUDE_SYSTEM_PROMPT
         assert "Fixed a bug" in messages[1]["content"]
         assistant = json.loads(messages[2]["content"])
         assert "Fixed authentication bug" in assistant["summary"]
@@ -211,7 +214,7 @@ def test_export_browser_node(tmp_db):
         train_path = Path(tmpdir) / "train.jsonl"
         data = json.loads(train_path.read_text().strip())
         messages = data["messages"]
-        assert "developer activity analyst" in messages[0]["content"]
+        assert messages[0]["content"] == BROWSER_SYSTEM_PROMPT
         assert "docs.rs" in messages[1]["content"]
         assistant = json.loads(messages[2]["content"])
         assert "Tokio" in assistant["summary"]

--- a/brain/tests/test_training.py
+++ b/brain/tests/test_training.py
@@ -15,7 +15,6 @@ def _seed_db(conn):
         (now_ms,),
     )
 
-    # Insert events
     for i in range(1, 4):
         conn.execute(
             """INSERT INTO events (id, session_id, timestamp, command, exit_code, duration_ms,
@@ -24,22 +23,32 @@ def _seed_db(conn):
             (i, now_ms + i, f"command-{i}", 1000 + i),
         )
 
-    # Insert knowledge nodes
     content = json.dumps(
         {
             "summary": "Ran project commands successfully",
             "intent": "development",
             "outcome": "success",
+            "entities": {
+                "projects": ["hippo"],
+                "tools": ["cargo"],
+                "files": ["src/main.rs"],
+                "services": [],
+                "errors": [],
+                "env_vars": [],
+            },
+            "tags": ["dev", "rust"],
+            "key_decisions": ["Used cargo build"],
+            "problems_encountered": [],
+            "design_decisions": [],
         }
     )
     conn.execute(
-        """INSERT INTO knowledge_nodes (id, uuid, content, embed_text, outcome, tags,
+        """INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags,
                                         enrichment_model, created_at, updated_at)
-           VALUES (1, 'uuid-1', ?, 'ran project commands', 'success', '["dev"]', 'model', ?, ?)""",
+           VALUES (1, 'uuid-1', ?, 'ran project commands', 'observation', 'success', '["dev"]', 'model', ?, ?)""",
         (content, now_ms, now_ms),
     )
 
-    # Link events to knowledge node
     for i in range(1, 4):
         conn.execute(
             "INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (1, ?)",
@@ -58,8 +67,8 @@ def test_export_training_data(tmp_db):
 
         assert stats["total"] == 1
         assert stats["train"] >= 1
+        assert stats["sources"]["shell"] == 1
 
-        # Verify JSONL format
         train_path = Path(tmpdir) / "train.jsonl"
         assert train_path.exists()
 
@@ -72,10 +81,21 @@ def test_export_training_data(tmp_db):
                 assert messages[0]["role"] == "system"
                 assert messages[1]["role"] == "user"
                 assert messages[2]["role"] == "assistant"
+
+                # System prompt should be the shell enrichment prompt
+                assert "developer activity analyst" in messages[0]["content"]
+                assert "shell command events" in messages[0]["content"]
+
                 # User message should contain command text
                 assert "command-" in messages[1]["content"]
-                # Assistant message should be the summary
-                assert "Ran project commands" in messages[2]["content"]
+                assert "developer (human)" in messages[1]["content"]
+
+                # Assistant message should be the full JSON enrichment result
+                assistant = json.loads(messages[2]["content"])
+                assert assistant["summary"] == "Ran project commands successfully"
+                assert "entities" in assistant
+                assert "tags" in assistant
+                assert "key_decisions" in assistant
 
 
 def test_export_empty_db(tmp_db):
@@ -83,4 +103,115 @@ def test_export_empty_db(tmp_db):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         stats = export_training_data(conn, tmpdir)
-        assert stats == {"total": 0, "train": 0, "valid": 0, "test": 0}
+        assert stats["total"] == 0
+        assert stats["train"] == 0
+        assert stats["valid"] == 0
+        assert stats["test"] == 0
+        assert stats["sources"] == {}
+
+
+def test_export_agentic_session(tmp_db):
+    """Agentic session (Claude/OpenCode) nodes should export with correct prompt."""
+    conn, _ = tmp_db
+    now_ms = int(time.time() * 1000)
+
+    conn.execute(
+        """INSERT INTO agentic_sessions (id, session_id, harness, segment_index, cwd,
+             project_dir, summary_text, start_time, end_time, model)
+           VALUES (1, 'sess-1', 'claude-code', 0, '/project', '/project',
+                   'Fixed a bug in the auth module', ?, ?, 'claude-sonnet-4-20250514')""",
+        (now_ms, now_ms + 5000),
+    )
+    content = json.dumps(
+        {
+            "summary": "Fixed authentication bug by updating token validation",
+            "intent": "bug fix",
+            "outcome": "success",
+            "entities": {
+                "projects": ["api"],
+                "tools": [],
+                "files": ["auth.py"],
+                "services": [],
+                "errors": [],
+            },
+            "tags": ["auth", "bugfix"],
+            "key_decisions": [],
+            "problems_encountered": ["Token expired mid-debug"],
+            "design_decisions": [],
+        }
+    )
+    conn.execute(
+        """INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags,
+             enrichment_model, created_at, updated_at)
+           VALUES (1, 'uuid-agentic-1', ?, 'fixed auth bug', 'observation', 'success', '[]', 'model', ?, ?)""",
+        (content, now_ms, now_ms),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_agentic_sessions (knowledge_node_id, agentic_session_id) VALUES (1, 1)"
+    )
+    conn.commit()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stats = export_training_data(conn, tmpdir)
+        assert stats["total"] == 1
+        assert stats["sources"]["agentic"] == 1
+
+        train_path = Path(tmpdir) / "train.jsonl"
+        data = json.loads(train_path.read_text().strip())
+        messages = data["messages"]
+        assert "developer activity analyst" in messages[0]["content"]
+        assert "Claude Code" in messages[0]["content"]
+        assert "Fixed a bug" in messages[1]["content"]
+        assistant = json.loads(messages[2]["content"])
+        assert "Fixed authentication bug" in assistant["summary"]
+
+
+def test_export_browser_node(tmp_db):
+    """Browser enrichment nodes should export with correct prompt."""
+    conn, _ = tmp_db
+    now_ms = int(time.time() * 1000)
+
+    conn.execute(
+        """INSERT INTO browser_events (id, timestamp, url, title, domain, dwell_ms, scroll_depth)
+           VALUES (1, ?, 'https://docs.rs/tokio', 'Tokio docs', 'docs.rs', 30000, 0.5)""",
+        (now_ms,),
+    )
+    content = json.dumps(
+        {
+            "summary": "Researched Tokio async runtime documentation",
+            "intent": "research",
+            "outcome": "success",
+            "entities": {
+                "topics": ["async-rust"],
+                "urls": ["https://docs.rs/tokio"],
+                "projects": ["hippo"],
+            },
+            "tags": ["rust", "async", "research"],
+            "key_decisions": [],
+            "problems_encountered": [],
+            "design_decisions": [],
+        }
+    )
+    conn.execute(
+        """INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags,
+             enrichment_model, created_at, updated_at)
+           VALUES (1, 'uuid-browser-1', ?, 'tokio docs research', 'observation', 'success', '[]', 'model', ?, ?)""",
+        (content, now_ms, now_ms),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_browser_events (knowledge_node_id, browser_event_id) VALUES (1, 1)"
+    )
+    conn.commit()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stats = export_training_data(conn, tmpdir)
+        assert stats["total"] == 1
+        assert stats["sources"]["browser"] == 1
+
+        train_path = Path(tmpdir) / "train.jsonl"
+        data = json.loads(train_path.read_text().strip())
+        messages = data["messages"]
+        assert "developer activity analyst" in messages[0]["content"]
+        assert "docs.rs" in messages[1]["content"]
+        assistant = json.loads(messages[2]["content"])
+        assert "Tokio" in assistant["summary"]

--- a/brain/tests/test_training_extended.py
+++ b/brain/tests/test_training_extended.py
@@ -20,7 +20,6 @@ def _seed_many(conn, count: int, base_ts: int | None = None):
 
     for i in range(1, count + 1):
         ts = now_ms + i * 1000
-        # Insert event
         conn.execute(
             "INSERT INTO events (id, session_id, timestamp, command, exit_code, duration_ms, "
             "cwd, hostname, shell, git_branch) "
@@ -28,18 +27,16 @@ def _seed_many(conn, count: int, base_ts: int | None = None):
             (i, ts, f"cmd-{i}", 500 + i),
         )
 
-        # Insert knowledge node
         content = json.dumps(
             {"summary": f"Summary for node {i}", "intent": "testing", "outcome": "success"}
         )
         conn.execute(
-            "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, outcome, tags, "
+            "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags, "
             "enrichment_model, created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, 'success', '[\"test\"]', 'model', ?, ?)",
+            "VALUES (?, ?, ?, ?, 'observation', 'success', '[\"test\"]', 'model', ?, ?)",
             (i, f"uuid-{i}", content, f"embed text {i}", ts, ts),
         )
 
-        # Link event to knowledge node
         conn.execute(
             "INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (?, ?)",
             (i, i),
@@ -55,7 +52,6 @@ def test_export_with_since_ms_filter(tmp_db):
     _seed_many(conn, 5, base_ts=base_ts)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Filter: only nodes created at or after the 4th node's timestamp
         cutoff = base_ts + 4 * 1000
         stats = export_training_data(conn, tmpdir, since_ms=cutoff)
         assert stats["total"] == 2  # nodes 4 and 5
@@ -68,7 +64,8 @@ def test_export_since_ms_no_matches(tmp_db):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         stats = export_training_data(conn, tmpdir, since_ms=99_999_999_999_999)
-        assert stats == {"total": 0, "train": 0, "valid": 0, "test": 0}
+        assert stats["total"] == 0
+        assert stats["sources"] == {}
 
 
 def test_80_10_10_split_with_enough_examples(tmp_db):
@@ -82,8 +79,8 @@ def test_80_10_10_split_with_enough_examples(tmp_db):
         assert stats["train"] == 16  # int(20 * 0.8) = 16
         assert stats["valid"] == 2  # int(20 * 0.1) = 2
         assert stats["test"] == 2  # remainder
+        assert stats["sources"]["shell"] == 20
 
-        # Verify all three files exist and have correct line counts
         for split, expected_count in [("train", 16), ("valid", 2), ("test", 2)]:
             path = Path(tmpdir) / f"{split}.jsonl"
             assert path.exists()
@@ -110,13 +107,12 @@ def test_min_events_filter(tmp_db):
     _seed_many(conn, 3)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Each node has exactly 1 event, so min_events=2 excludes all
         stats = export_training_data(conn, tmpdir, min_events=2)
         assert stats["total"] == 0
 
 
-def test_export_non_json_content_falls_back_to_embed_text(tmp_db):
-    """When content is not valid JSON, assistant message falls back to embed_text."""
+def test_export_non_json_content_is_skipped(tmp_db):
+    """When content is not valid JSON, the node is skipped entirely."""
     conn, _ = tmp_db
     now_ms = int(time.time() * 1000)
 
@@ -130,11 +126,11 @@ def test_export_non_json_content_falls_back_to_embed_text(tmp_db):
         "cwd, hostname, shell) VALUES (1, 1, ?, 'make build', 0, 1000, '/project', 'laptop', 'zsh')",
         (now_ms,),
     )
-    # Content is NOT valid JSON — raw text
     conn.execute(
-        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, outcome, tags, "
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags, "
         "enrichment_model, created_at, updated_at) "
-        "VALUES (1, 'uuid-x', 'not json', 'the embed fallback text', 'success', '[]', 'model', ?, ?)",
+        "VALUES (1, 'uuid-x', 'not json', 'the embed fallback text', 'observation', 'success', '[]', "
+        "'model', ?, ?)",
         (now_ms, now_ms),
     )
     conn.execute("INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (1, 1)")
@@ -142,13 +138,7 @@ def test_export_non_json_content_falls_back_to_embed_text(tmp_db):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         stats = export_training_data(conn, tmpdir)
-        assert stats["total"] == 1
-
-        train_path = Path(tmpdir) / "train.jsonl"
-        line = train_path.read_text().strip()
-        data = json.loads(line)
-        # Should fall back to embed_text since content is not JSON
-        assert data["messages"][2]["content"] == "the embed fallback text"
+        assert stats["total"] == 0
 
 
 def test_export_skips_failure_outcome(tmp_db):
@@ -167,9 +157,9 @@ def test_export_skips_failure_outcome(tmp_db):
         (now_ms,),
     )
     conn.execute(
-        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, outcome, tags, "
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags, "
         "enrichment_model, created_at, updated_at) "
-        "VALUES (1, 'uuid-fail', '{}', 'text', 'failure', '[]', 'model', ?, ?)",
+        "VALUES (1, 'uuid-fail', '{}', 'text', 'observation', 'failure', '[]', 'model', ?, ?)",
         (now_ms, now_ms),
     )
     conn.execute("INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (1, 1)")
@@ -177,4 +167,68 @@ def test_export_skips_failure_outcome(tmp_db):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         stats = export_training_data(conn, tmpdir)
+        assert stats["total"] == 0
+
+
+def test_export_multi_source(tmp_db):
+    """Shell and agentic nodes both appear in a single export."""
+    conn, _ = tmp_db
+    now_ms = int(time.time() * 1000)
+
+    # Shell node
+    conn.execute(
+        "INSERT INTO sessions (id, start_time, shell, hostname, username) "
+        "VALUES (1, ?, 'zsh', 'laptop', 'user')",
+        (now_ms,),
+    )
+    conn.execute(
+        "INSERT INTO events (id, session_id, timestamp, command, exit_code, duration_ms, "
+        "cwd, hostname, shell) "
+        "VALUES (1, 1, ?, 'cargo build', 0, 500, '/p', 'laptop', 'zsh')",
+        (now_ms,),
+    )
+    shell_content = json.dumps(
+        {"summary": "Built project", "intent": "build", "outcome": "success"}
+    )
+    conn.execute(
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags, "
+        "enrichment_model, created_at, updated_at) "
+        "VALUES (1, 'uuid-shell', ?, 'build', 'observation', 'success', '[]', 'm', ?, ?)",
+        (shell_content, now_ms, now_ms),
+    )
+    conn.execute("INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (1, 1)")
+
+    # Agentic node
+    conn.execute(
+        "INSERT INTO agentic_sessions (id, session_id, harness, segment_index, cwd, project_dir, "
+        "summary_text, start_time, end_time) "
+        "VALUES (1, 's-1', 'claude-code', 0, '/p', '/p', 'Refactored auth', ?, ?)",
+        (now_ms, now_ms + 5000),
+    )
+    agentic_content = json.dumps(
+        {"summary": "Refactored auth module", "intent": "refactor", "outcome": "success"}
+    )
+    conn.execute(
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, outcome, tags, "
+        "enrichment_model, created_at, updated_at) "
+        "VALUES (2, 'uuid-agentic', ?, 'refactor', 'observation', 'success', '[]', 'm', ?, ?)",
+        (agentic_content, now_ms, now_ms),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_agentic_sessions (knowledge_node_id, agentic_session_id) VALUES (2, 1)"
+    )
+    conn.commit()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stats = export_training_data(conn, tmpdir)
+        assert stats["total"] == 2
+        assert stats["sources"]["shell"] == 1
+        assert stats["sources"]["agentic"] == 1
+
+
+def test_empty_output_zero_sources(tmp_db):
+    conn, _ = tmp_db
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stats = export_training_data(conn, tmpdir)
+        assert stats["sources"] == {}
         assert stats["total"] == 0

--- a/crates/hippo-daemon/src/main.rs
+++ b/crates/hippo-daemon/src/main.rs
@@ -980,10 +980,18 @@ async fn main() -> Result<()> {
                 _ => eprintln!("Unexpected response"),
             }
         }
-        Commands::ExportTraining { out: _, since: _ } => {
-            anyhow::bail!(
-                "Training export is not yet implemented. Use: uv run --project brain hippo-brain export"
-            );
+        Commands::ExportTraining { out, since } => {
+            let mut cmd = std::process::Command::new("uv");
+            cmd.args(["run", "--project", "brain", "hippo-brain", "export"])
+                .arg("--out")
+                .arg(&out);
+            if let Some(s) = &since {
+                cmd.arg("--since").arg(s);
+            }
+            let status = cmd.status()?;
+            if !status.success() {
+                anyhow::bail!("hippo-brain export failed (exit {status})");
+            }
         }
         Commands::Config { action } => match action {
             ConfigAction::Edit => {


### PR DESCRIPTION
Export training data from all 5 enrichment sources (shell, agentic sessions, browser, CI workflows, auto-memory) instead of just shell events. Each example includes the source-specific system prompt, a reconstructed user prompt matching the live enrichment input format, and the full validated JSON output the enrichment model produced.

## Changes

- **training.py**: export shell, agentic, browser, workflow, auto-memory nodes with source-appropriate system prompts and full JSON responses. Return value includes per-source counts.
- **__init__.py**: add `hippo-brain export --out DIR --since 30d` subcommand
- **main.rs**: wire `hippo export-training` to delegate to brain export instead of bailing
- **Tests**: 13 pass (8 updated for new format, 3 new: agentic sessions, browser nodes, multi-source coexistence)

## Before

Only shell-event nodes were exported. Assistant responses were just the summary string. One generic system prompt.

## After

All 5 sources produce training pairs with:
- Source-specific system prompts imported from the live enrichment modules
- Reconstructed user prompts matching the enrichment input format
- Full `EnrichmentResult` JSON as the assistant response

Output now includes a `sources` breakdown:
```
Exported 150 examples to ./export/
  train: 120
  valid: 15
  test:  15
  sources:
    agentic: 45
    auto-memory: 12
    browser: 23
    shell: 50
    workflow: 20
```