### PR TITLE
fix(mcp): gate read connections on accepted schema version (SNUG-120)

### DIFF
--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -32,6 +32,7 @@ from hippo_brain.mcp_queries import (
     shape_semantic_results,
 )
 from hippo_brain.rag import ask as rag_ask, format_rag_response
+from hippo_brain.schema_version import require_accepted_schema
 from hippo_brain.telemetry import get_tracer as _get_tracer
 
 logger = setup_logging("hippo-mcp")
@@ -140,6 +141,7 @@ def _get_conn(db_path: str = "") -> sqlite3.Connection:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
     conn.execute("PRAGMA busy_timeout=5000")
+    require_accepted_schema(conn)
     return conn
 
 
@@ -670,10 +672,13 @@ def _open_retrieval_conn() -> sqlite3.Connection:
     try:
         from hippo_brain.vector_store import open_conn
 
-        return open_conn(_state.db_path)
-    except Exception:
+        conn = open_conn(_state.db_path)
+    except ImportError:
         # vector_store may be missing in older deploys; fall back to plain conn
         return _get_conn()
+    # Gate outside the try so a schema mismatch cannot be masked by fallback.
+    require_accepted_schema(conn)
+    return conn
 
 
 @mcp.tool()

--- a/brain/src/hippo_brain/schema_version.py
+++ b/brain/src/hippo_brain/schema_version.py
@@ -50,6 +50,8 @@ revision, chunk, enrichment queue, and knowledge-node link.
 
 from __future__ import annotations
 
+import sqlite3
+
 EXPECTED_SCHEMA_VERSION: int = 19
 
 # Versions brain can read without erroring.
@@ -65,3 +67,14 @@ EXPECTED_SCHEMA_VERSION: int = 19
 # deployment the daemon always migrates the DB to EXPECTED_SCHEMA_VERSION
 # before brain attaches.
 ACCEPTED_READ_VERSIONS: frozenset[int] = frozenset({EXPECTED_SCHEMA_VERSION})
+
+
+def require_accepted_schema(conn: sqlite3.Connection) -> None:
+    """Reject connections to DBs the brain cannot read safely."""
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    if version not in ACCEPTED_READ_VERSIONS:
+        conn.close()
+        raise RuntimeError(
+            f"DB schema version mismatch: expected {EXPECTED_SCHEMA_VERSION}, found {version}. "
+            "Please run migrations or delete the database."
+        )

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -16,7 +16,11 @@ from starlette.routing import Route
 
 from hippo_brain.client import InferenceClient
 from hippo_brain.openapi import build_openapi_spec
-from hippo_brain.schema_version import EXPECTED_SCHEMA_VERSION, ACCEPTED_READ_VERSIONS
+from hippo_brain.schema_version import (
+    ACCEPTED_READ_VERSIONS,
+    EXPECTED_SCHEMA_VERSION,
+    require_accepted_schema,
+)
 from hippo_brain.version import get_version
 from hippo_brain.embeddings import (
     embed_dict_from_result,
@@ -304,13 +308,7 @@ class BrainServer:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA foreign_keys=ON")
         conn.execute("PRAGMA busy_timeout=5000")
-        version = conn.execute("PRAGMA user_version").fetchone()[0]
-        if version not in ACCEPTED_READ_VERSIONS:
-            conn.close()
-            raise RuntimeError(
-                f"DB schema version mismatch: expected {EXPECTED_SCHEMA_VERSION}, found {version}. "
-                "Please run migrations or delete the database."
-            )
+        require_accepted_schema(conn)
         return conn
 
     async def health(self, request: Request) -> JSONResponse:

--- a/brain/tests/test_mcp_server.py
+++ b/brain/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ from hippo_brain.embeddings import EMBED_DIM
 from hippo_brain.mcp import (
     _get_conn,
     _load_config,
+    _open_retrieval_conn,
     _state,
     ask,
     get_entities,
@@ -25,6 +26,7 @@ from hippo_brain.mcp import (
     search_knowledge,
 )
 from hippo_brain.retrieval import SearchResult
+from hippo_brain.schema_version import EXPECTED_SCHEMA_VERSION
 
 
 class TestToolRegistration:
@@ -53,12 +55,19 @@ class TestToolRegistration:
         assert len(mcp._tool_manager._tools) == 9
 
 
+def _stamp_readable_schema_version(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(f"PRAGMA user_version = {EXPECTED_SCHEMA_VERSION}")
+    conn.close()
+
+
 class TestGetConn:
     def test_returns_working_connection(self):
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
             db_path = f.name
 
         try:
+            _stamp_readable_schema_version(db_path)
             conn = _get_conn(db_path=db_path)
             assert isinstance(conn, sqlite3.Connection)
             # Verify we can execute a query
@@ -73,6 +82,7 @@ class TestGetConn:
             db_path = f.name
 
         try:
+            _stamp_readable_schema_version(db_path)
             conn = _get_conn(db_path=db_path)
             mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
             assert mode == "wal"
@@ -81,6 +91,29 @@ class TestGetConn:
             Path(db_path).unlink(missing_ok=True)
             Path(db_path + "-wal").unlink(missing_ok=True)
             Path(db_path + "-shm").unlink(missing_ok=True)
+
+    def test_rejects_wrong_schema_version(self, tmp_path):
+        db_path = tmp_path / "stale.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA user_version = 11")
+        conn.close()
+
+        with pytest.raises(RuntimeError, match="schema version mismatch"):
+            _get_conn(db_path=str(db_path))
+
+    def test_open_retrieval_conn_rejects_wrong_schema_version(self, tmp_path):
+        db_path = tmp_path / "stale.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA user_version = 11")
+        conn.close()
+
+        previous_db_path = _state.db_path
+        _state.db_path = str(db_path)
+        try:
+            with pytest.raises(RuntimeError, match="schema version mismatch"):
+                _open_retrieval_conn()
+        finally:
+            _state.db_path = previous_db_path
 
 
 class TestMCPStdioProtocol:

--- a/brain/tests/test_schema_version.py
+++ b/brain/tests/test_schema_version.py
@@ -1,0 +1,30 @@
+"""Tests for schema_version.require_accepted_schema."""
+
+import sqlite3
+
+import pytest
+
+from hippo_brain.schema_version import EXPECTED_SCHEMA_VERSION, require_accepted_schema
+
+
+def test_require_accepted_schema_allows_expected_version(tmp_path):
+    db_path = tmp_path / "ok.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(f"PRAGMA user_version = {EXPECTED_SCHEMA_VERSION}")
+    conn.close()
+
+    conn = sqlite3.connect(str(db_path))
+    require_accepted_schema(conn)
+    assert conn.execute("SELECT 1").fetchone() == (1,)
+    conn.close()
+
+
+def test_require_accepted_schema_rejects_stale_version(tmp_path):
+    db_path = tmp_path / "stale.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA user_version = 11")
+    conn.close()
+
+    conn = sqlite3.connect(str(db_path))
+    with pytest.raises(RuntimeError, match="schema version mismatch"):
+        require_accepted_schema(conn)


### PR DESCRIPTION
## Summary
- Add canonical `require_accepted_schema()` in `schema_version.py`
- Apply schema gate to MCP `_get_conn` / `_open_retrieval_conn` and server `_get_conn`
- Narrow MCP retrieval fallback to `ImportError` so schema mismatches cannot be masked
- Add unit + integration tests for rejection on stale DBs

Closes SNUG-120.

## Test plan
- [x] `pytest brain/tests/test_schema_version.py brain/tests/test_mcp_server.py::TestGetConn`
- [x] `pytest brain/tests/test_server.py::test_brain_server_rejects_wrong_schema_version brain/tests/test_server.py::test_brain_server_rejects_v11_db`
- [x] `ruff check` on touched files