### PR TITLE
feat(probe): add opencode and codex session canary probes (SNUG-117)

### DIFF
--- a/crates/hippo-daemon/src/lib.rs
+++ b/crates/hippo-daemon/src/lib.rs
@@ -16,6 +16,7 @@ pub mod metrics;
 pub mod native_messaging;
 pub mod opencode_session;
 pub mod probe;
+mod probe_agentic;
 #[cfg(feature = "otel")]
 pub mod process_metrics;
 pub mod schema_handshake;

--- a/crates/hippo-daemon/src/opencode_session.rs
+++ b/crates/hippo-daemon/src/opencode_session.rs
@@ -664,7 +664,7 @@ fn record_upsert_error(conn: &rusqlite::Connection, err: &anyhow::Error) {
 
 // --- Entry point ---
 
-fn open_opencode_db(db_path: &Path) -> Result<rusqlite::Connection> {
+pub(crate) fn open_opencode_db(db_path: &Path) -> Result<rusqlite::Connection> {
     // Read-only open of opencode's own DB. Do NOT set journal_mode here —
     // the WAL pragma requires write access to the DB header and would fail
     // with SQLITE_READONLY. opencode manages its own journaling; we are only

--- a/crates/hippo-daemon/src/opencode_session.rs
+++ b/crates/hippo-daemon/src/opencode_session.rs
@@ -664,7 +664,25 @@ fn record_upsert_error(conn: &rusqlite::Connection, err: &anyhow::Error) {
 
 // --- Entry point ---
 
-pub(crate) fn open_opencode_db(db_path: &Path) -> Result<rusqlite::Connection> {
+/// Sessions whose `time_updated` falls in `[min_updated, max_updated]`.
+pub(crate) fn sessions_in_probe_window(
+    db_path: &Path,
+    min_updated: i64,
+    max_updated: i64,
+) -> Result<Vec<(String, i64)>> {
+    let conn = open_opencode_db(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, time_updated FROM session
+         WHERE time_updated >= ?1 AND time_updated <= ?2
+         ORDER BY time_updated ASC",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![min_updated, max_updated], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+fn open_opencode_db(db_path: &Path) -> Result<rusqlite::Connection> {
     // Read-only open of opencode's own DB. Do NOT set journal_mode here —
     // the WAL pragma requires write access to the DB header and would fail
     // with SQLITE_READONLY. opencode manages its own journaling; we are only

--- a/crates/hippo-daemon/src/probe.rs
+++ b/crates/hippo-daemon/src/probe.rs
@@ -8,7 +8,6 @@
 
 use anyhow::{Context, Result};
 use hippo_core::config::HippoConfig;
-use hippo_core::redaction::RedactionEngine;
 use hippo_core::storage;
 use rusqlite::OptionalExtension;
 use std::time::Instant;
@@ -18,6 +17,46 @@ use uuid::Uuid;
 /// Maximum time to wait for a probe row to appear in SQLite.
 const POLL_DEADLINE_MS: u64 = 10_000;
 const POLL_INTERVAL_MS: u64 = 200;
+
+const VALID_PROBE_SOURCES: &[&str] = &[
+    "shell",
+    "claude-tool",
+    "agentic-session-claude",
+    "agentic-session-cursor",
+    "agentic-session-opencode",
+    "agentic-session-codex",
+    "browser",
+];
+
+type SyncProbeFn = fn(&HippoConfig) -> Result<(bool, Option<i64>)>;
+
+fn run_sync_probe(
+    config: &HippoConfig,
+    run_all: bool,
+    source: Option<&str>,
+    name: &str,
+    probe_fn: SyncProbeFn,
+) -> Result<()> {
+    if !(run_all || source == Some(name)) {
+        return Ok(());
+    }
+    match probe_fn(config) {
+        Ok((ok, lag)) => {
+            println!(
+                "[probe] {name}: {} (lag={}ms)",
+                if ok { "OK" } else { "FAIL" },
+                lag.map(|l| l.to_string()).as_deref().unwrap_or("N/A")
+            );
+            write_probe_result(config, name, ok, lag)?;
+        }
+        Err(e) => {
+            warn!("{name} probe error: {e:#}");
+            println!("[probe] {name}: ERROR — {e:#}");
+            write_probe_result(config, name, false, None)?;
+        }
+    }
+    Ok(())
+}
 
 /// Run one or all probes, then write results to `source_health`.
 ///
@@ -63,77 +102,34 @@ pub async fn run(config: &HippoConfig, source: Option<&str>) -> Result<()> {
         }
     }
 
-    if run_all || source == Some("agentic-session-claude") {
-        match probe_claude_session(config) {
-            Ok((ok, lag)) => {
-                println!(
-                    "[probe] agentic-session-claude: {} (lag={}ms)",
-                    if ok { "OK" } else { "FAIL" },
-                    lag.map(|l| l.to_string()).as_deref().unwrap_or("N/A")
-                );
-                write_probe_result(config, "agentic-session-claude", ok, lag)?;
-            }
-            Err(e) => {
-                warn!("agentic-session-claude probe error: {e:#}");
-                println!("[probe] agentic-session-claude: ERROR — {e:#}");
-                write_probe_result(config, "agentic-session-claude", false, None)?;
-            }
-        }
-    }
-
-    if run_all || source == Some("agentic-session-cursor") {
-        match probe_cursor_session(config) {
-            Ok((ok, lag)) => {
-                println!(
-                    "[probe] agentic-session-cursor: {} (lag={}ms)",
-                    if ok { "OK" } else { "FAIL" },
-                    lag.map(|l| l.to_string()).as_deref().unwrap_or("N/A")
-                );
-                write_probe_result(config, "agentic-session-cursor", ok, lag)?;
-            }
-            Err(e) => {
-                warn!("agentic-session-cursor probe error: {e:#}");
-                println!("[probe] agentic-session-cursor: ERROR — {e:#}");
-                write_probe_result(config, "agentic-session-cursor", false, None)?;
-            }
-        }
-    }
-
-    if run_all || source == Some("agentic-session-opencode") {
-        match probe_opencode_session(config) {
-            Ok((ok, lag)) => {
-                println!(
-                    "[probe] agentic-session-opencode: {} (lag={}ms)",
-                    if ok { "OK" } else { "FAIL" },
-                    lag.map(|l| l.to_string()).as_deref().unwrap_or("N/A")
-                );
-                write_probe_result(config, "agentic-session-opencode", ok, lag)?;
-            }
-            Err(e) => {
-                warn!("agentic-session-opencode probe error: {e:#}");
-                println!("[probe] agentic-session-opencode: ERROR — {e:#}");
-                write_probe_result(config, "agentic-session-opencode", false, None)?;
-            }
-        }
-    }
-
-    if run_all || source == Some("agentic-session-codex") {
-        match probe_codex_session(config) {
-            Ok((ok, lag)) => {
-                println!(
-                    "[probe] agentic-session-codex: {} (lag={}ms)",
-                    if ok { "OK" } else { "FAIL" },
-                    lag.map(|l| l.to_string()).as_deref().unwrap_or("N/A")
-                );
-                write_probe_result(config, "agentic-session-codex", ok, lag)?;
-            }
-            Err(e) => {
-                warn!("agentic-session-codex probe error: {e:#}");
-                println!("[probe] agentic-session-codex: ERROR — {e:#}");
-                write_probe_result(config, "agentic-session-codex", false, None)?;
-            }
-        }
-    }
+    run_sync_probe(
+        config,
+        run_all,
+        source,
+        "agentic-session-claude",
+        probe_claude_session,
+    )?;
+    run_sync_probe(
+        config,
+        run_all,
+        source,
+        "agentic-session-cursor",
+        crate::probe_agentic::probe_cursor_session,
+    )?;
+    run_sync_probe(
+        config,
+        run_all,
+        source,
+        "agentic-session-opencode",
+        crate::probe_agentic::probe_opencode_session,
+    )?;
+    run_sync_probe(
+        config,
+        run_all,
+        source,
+        "agentic-session-codex",
+        crate::probe_agentic::probe_codex_session,
+    )?;
 
     if run_all || source == Some("browser") {
         match probe_browser(config).await {
@@ -154,20 +150,11 @@ pub async fn run(config: &HippoConfig, source: Option<&str>) -> Result<()> {
     }
 
     if let Some(s) = source
-        && !matches!(
-            s,
-            "shell"
-                | "claude-tool"
-                | "agentic-session-claude"
-                | "agentic-session-opencode"
-                | "agentic-session-codex"
-                | "browser"
-                | "agentic-session-cursor"
-        )
+        && !VALID_PROBE_SOURCES.contains(&s)
     {
         anyhow::bail!(
-            "unknown probe source '{}'; valid: shell, claude-tool, agentic-session-claude, agentic-session-opencode, agentic-session-codex, browser, agentic-session-cursor",
-            s
+            "unknown probe source '{s}'; valid: {}",
+            VALID_PROBE_SOURCES.join(", ")
         );
     }
 
@@ -341,408 +328,6 @@ fn probe_claude_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
         }
     }
 
-    Ok((all_ok, latest_lag))
-}
-
-/// Settle floor for the cursor probe eligibility window, in ms.
-///
-/// A transcript must be at least this old before we assert it was ingested.
-/// Decoupled from `cursor.min_idle_secs` on purpose: deriving the floor from
-/// config (the old `2 * min_idle` formula) let an operator with a large
-/// `min_idle_secs` push the floor past `CURSOR_PROBE_WINDOW_MS`, collapsing the
-/// eligibility window to empty so the probe silently trivial-passed and stopped
-/// covering the source. 90 s ≈ one 60 s poll interval plus margin, which is
-/// enough slack that the poller has had a chance to ingest a settled file.
-const CURSOR_PROBE_SETTLE_MS: i64 = 90_000;
-
-/// Outer edge of the cursor probe eligibility window, in ms.
-///
-/// Widened to 10 min (from the 5 min used by the Claude probe) so that a file
-/// which becomes eligible at `CURSOR_PROBE_SETTLE_MS` (90 s) is still in-window
-/// when the next ~5 min probe firing lands: the window span is
-/// `600_000 - 90_000 = 510_000 ms`, comfortably wider than the 300 s probe
-/// interval, so a settled transcript is asserted by at least one probe run
-/// rather than slipping between firings (the coverage-gap concern).
-const CURSOR_PROBE_WINDOW_MS: i64 = 600_000;
-
-/// Cursor-session probe: assertion-based, mirrors `probe_claude_session`.
-///
-/// For every `~/.cursor/projects/**/agent-transcripts/**/*.jsonl` whose age
-/// (`now - mtime`) falls in `[settle_ms, CURSOR_PROBE_WINDOW_MS]`, assert a
-/// `agentic_sessions` row exists with that `source_file` — *but only when the
-/// transcript actually yields ≥1 segment*. A legitimately segment-less
-/// transcript (assistant-only, no user turn) is correctly written as zero rows
-/// by `cursor_session::poll_tick`, so asserting a row for it would be a false
-/// FAIL; such files are skipped (treated as pass).
-///
-/// `settle_ms` is clamped strictly below `CURSOR_PROBE_WINDOW_MS` so the window
-/// is always non-empty regardless of config — see `CURSOR_PROBE_SETTLE_MS`.
-/// Lag is reported as `now - MAX(end_time)` of the matched rows (true ingestion
-/// latency), mirroring `probe_claude_session`, not the file's age.
-fn probe_cursor_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
-    // A disabled source intentionally ingests nothing (`poll_tick` early-returns),
-    // so transcripts left on disk will never have matching `agentic_sessions` rows.
-    // Asserting against them would write `probe_ok = 0` and trip watchdog I-8 as a
-    // false alarm. Trivially pass instead, mirroring `poll_tick`'s disabled guard.
-    if !config.cursor.enabled {
-        info!("cursor-session probe: cursor ingestion disabled — trivial pass");
-        return Ok((true, None));
-    }
-    let now_ms = chrono::Utc::now().timestamp_millis();
-    let window_ms: i64 = CURSOR_PROBE_WINDOW_MS;
-    // Clamp the settle floor strictly below the window so `[settle_ms, window_ms]`
-    // can never be empty (the empty-window bug that silently disabled coverage).
-    let settle_ms: i64 = CURSOR_PROBE_SETTLE_MS.min(window_ms / 2);
-
-    let roots = &config.cursor.session_roots;
-    let mut recent: Vec<(std::path::PathBuf, i64)> = Vec::new();
-    for root in roots {
-        if !root.is_dir() {
-            continue;
-        }
-        for entry in walkdir::WalkDir::new(root)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path();
-            let is_jsonl = path.extension().map(|e| e == "jsonl").unwrap_or(false);
-            let under = path
-                .components()
-                .any(|c| c.as_os_str() == "agent-transcripts");
-            if !(is_jsonl && under) {
-                continue;
-            }
-            let Some(mtime_ms) = entry.metadata().ok().and_then(|m| {
-                m.modified().ok().and_then(|t| {
-                    t.duration_since(std::time::UNIX_EPOCH)
-                        .ok()
-                        .map(|d| d.as_millis() as i64)
-                })
-            }) else {
-                continue;
-            };
-            let age = now_ms - mtime_ms;
-            if age >= settle_ms && age <= window_ms {
-                recent.push((path.to_path_buf(), mtime_ms));
-            }
-        }
-    }
-
-    if recent.is_empty() {
-        info!("cursor-session probe: no settled recent transcripts — trivial pass");
-        return Ok((true, None));
-    }
-
-    let db =
-        storage::open_db(&config.db_path()).context("cannot open DB for cursor-session probe")?;
-    // Lazy-load the redaction engine: only the DB-miss branch below actually
-    // needs it (to re-parse a file we suspect was never written). The happy
-    // path — file present, row exists — skips disk I/O for `redact.toml` and
-    // the regex recompile entirely.
-    let mut redaction: Option<RedactionEngine> = None;
-    let mut all_ok = true;
-    let mut latest_lag: Option<i64> = None;
-    for (path, mtime_ms) in &recent {
-        let path_str = path.to_string_lossy();
-
-        // Cheap path first: ask the DB whether this transcript already has a
-        // row in the same window the existence check uses. The common case is
-        // that `poll_tick` already ingested the file and wrote a row, so the
-        // probe satisfies its assertion without touching the file or running
-        // any redaction patterns — a meaningful saving for a directory with
-        // many in-window transcripts.
-        let count: i64 = db
-            .query_row(
-                "SELECT COUNT(*) FROM agentic_sessions
-                 WHERE source_file = ?1
-                   AND harness = 'cursor'
-                   AND probe_tag IS NULL
-                   AND end_time >= ?2",
-                rusqlite::params![path_str.as_ref(), mtime_ms - window_ms],
-                |row| row.get(0),
-            )
-            .with_context(|| format!("failed to query agentic_sessions for {}", path_str))?;
-
-        if count > 0 {
-            // Assertion satisfied. Lag = now - MAX(end_time) of the matched
-            // rows — true ingestion latency (mirrors probe_claude_session),
-            // not the file's age.
-            let max_end: Option<i64> = db
-                .query_row(
-                    "SELECT MAX(end_time) FROM agentic_sessions
-                     WHERE source_file = ?1 AND harness = 'cursor' AND probe_tag IS NULL",
-                    rusqlite::params![path_str.as_ref()],
-                    |row| row.get(0),
-                )
-                .with_context(|| {
-                    format!(
-                        "cursor-session probe: failed to query MAX(end_time) for {}",
-                        path_str
-                    )
-                })?;
-            if let Some(end) = max_end {
-                let lag = now_ms - end;
-                latest_lag = Some(latest_lag.map_or(lag, |p: i64| p.max(lag)));
-            }
-            continue;
-        }
-
-        // DB miss: parse to decide whether a row was even expected.
-        // `poll_tick` writes zero rows for a segment-less transcript (no user
-        // turn), so we must not assert a row exists for one. Mirror the real
-        // ingestion exactly by parsing with the same extractor it uses; a read
-        // error is transient (the poller will retry), so we skip rather than
-        // FAIL on it. This is the only branch that pays parse + redaction
-        // cost, so we lazy-load the redaction engine on first use.
-        let engine = match redaction.as_ref() {
-            Some(r) => r,
-            None => {
-                redaction = Some(crate::load_redaction_engine(config));
-                redaction.as_ref().expect("just set above")
-            }
-        };
-        let segment_count = match crate::cursor_session::extract_segments(path, *mtime_ms, engine) {
-            Ok(segs) => segs.len(),
-            Err(e) => {
-                warn!(
-                    "cursor-session probe: cannot parse {} ({e:#}) — skipping",
-                    path_str
-                );
-                continue;
-            }
-        };
-        if segment_count == 0 {
-            info!(
-                "cursor-session probe: {} yields no segments — no row expected, skipping",
-                path_str
-            );
-            continue;
-        }
-        // Segment-bearing transcript with no row: genuine FAIL.
-        warn!("cursor-session probe: no row for {}", path_str);
-        all_ok = false;
-    }
-    Ok((all_ok, latest_lag))
-}
-
-/// Settle floor for Codex rollout probe eligibility, in ms. Mirrors cursor.
-const CODEX_PROBE_SETTLE_MS: i64 = 90_000;
-
-/// Outer edge of the Codex rollout probe eligibility window, in ms.
-const CODEX_PROBE_WINDOW_MS: i64 = 600_000;
-
-/// Codex-session probe: assertion-based, mirrors `probe_cursor_session`.
-///
-/// For every `[codex] session_roots/**/rollout-*.jsonl` whose age falls in
-/// `[settle_ms, CODEX_PROBE_WINDOW_MS]`, assert a matching `agentic_sessions`
-/// row exists with `harness = 'codex'` — but only when `extract_segments`
-/// yields ≥1 segment (zero-segment rollouts correctly have no row).
-fn probe_codex_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
-    if !config.codex.enabled {
-        info!("codex-session probe: codex ingestion disabled — trivial pass");
-        return Ok((true, None));
-    }
-    let now_ms = chrono::Utc::now().timestamp_millis();
-    let window_ms: i64 = CODEX_PROBE_WINDOW_MS;
-    let settle_ms: i64 = CODEX_PROBE_SETTLE_MS.min(window_ms / 2);
-
-    let mut recent: Vec<(std::path::PathBuf, i64)> = Vec::new();
-    for root in &config.codex.session_roots {
-        if !root.is_dir() {
-            continue;
-        }
-        for entry in walkdir::WalkDir::new(root)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path();
-            let is_rollout = path.extension().map(|e| e == "jsonl").unwrap_or(false)
-                && path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n.starts_with("rollout-"))
-                    .unwrap_or(false);
-            if !is_rollout {
-                continue;
-            }
-            let Some(mtime_ms) = entry.metadata().ok().and_then(|m| {
-                m.modified().ok().and_then(|t| {
-                    t.duration_since(std::time::UNIX_EPOCH)
-                        .ok()
-                        .map(|d| d.as_millis() as i64)
-                })
-            }) else {
-                continue;
-            };
-            let age = now_ms - mtime_ms;
-            if age >= settle_ms && age <= window_ms {
-                recent.push((path.to_path_buf(), mtime_ms));
-            }
-        }
-    }
-
-    if recent.is_empty() {
-        info!("codex-session probe: no settled recent rollouts — trivial pass");
-        return Ok((true, None));
-    }
-
-    let db =
-        storage::open_db(&config.db_path()).context("cannot open DB for codex-session probe")?;
-    let mut redaction: Option<RedactionEngine> = None;
-    let mut all_ok = true;
-    let mut latest_lag: Option<i64> = None;
-    for (path, _mtime_ms) in &recent {
-        let path_str = path.to_string_lossy();
-        let count: i64 = db
-            .query_row(
-                "SELECT COUNT(*) FROM agentic_sessions
-                 WHERE source_file = ?1
-                   AND harness = 'codex'
-                   AND probe_tag IS NULL",
-                rusqlite::params![path_str.as_ref()],
-                |row| row.get(0),
-            )
-            .with_context(|| format!("failed to query agentic_sessions for {}", path_str))?;
-
-        if count > 0 {
-            let max_end: Option<i64> = db
-                .query_row(
-                    "SELECT MAX(end_time) FROM agentic_sessions
-                     WHERE source_file = ?1 AND harness = 'codex' AND probe_tag IS NULL",
-                    rusqlite::params![path_str.as_ref()],
-                    |row| row.get(0),
-                )
-                .with_context(|| {
-                    format!(
-                        "codex-session probe: failed to query MAX(end_time) for {}",
-                        path_str
-                    )
-                })?;
-            if let Some(end) = max_end {
-                let lag = now_ms - end;
-                latest_lag = Some(latest_lag.map_or(lag, |p: i64| p.max(lag)));
-            }
-            continue;
-        }
-
-        let engine = match redaction.as_ref() {
-            Some(r) => r,
-            None => {
-                redaction = Some(crate::load_redaction_engine(config));
-                redaction.as_ref().expect("just set above")
-            }
-        };
-        let segment_count = match crate::codex_session::extract_segments(path, engine) {
-            Ok(segs) => segs.len(),
-            Err(e) => {
-                warn!(
-                    "codex-session probe: cannot parse {} ({e:#}) — skipping",
-                    path_str
-                );
-                continue;
-            }
-        };
-        if segment_count == 0 {
-            info!(
-                "codex-session probe: {} yields no segments — no row expected, skipping",
-                path_str
-            );
-            continue;
-        }
-        warn!("codex-session probe: no row for {}", path_str);
-        all_ok = false;
-    }
-    Ok((all_ok, latest_lag))
-}
-
-/// Settle floor / window for opencode session probe eligibility, in ms.
-const OPENCODE_PROBE_SETTLE_MS: i64 = 90_000;
-const OPENCODE_PROBE_WINDOW_MS: i64 = 600_000;
-
-/// Opencode-session probe: for every opencode `session` row whose
-/// `time_updated` falls in the eligibility window, assert a matching
-/// `agentic_sessions` row exists with `harness = 'opencode'`.
-fn probe_opencode_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
-    if !config.opencode.enabled {
-        info!("opencode-session probe: opencode ingestion disabled — trivial pass");
-        return Ok((true, None));
-    }
-    let db_path = &config.opencode.db_path;
-    if !db_path.exists() {
-        info!("opencode-session probe: opencode DB absent — trivial pass");
-        return Ok((true, None));
-    }
-
-    let now_ms = chrono::Utc::now().timestamp_millis();
-    let window_ms: i64 = OPENCODE_PROBE_WINDOW_MS;
-    let settle_ms: i64 = OPENCODE_PROBE_SETTLE_MS.min(window_ms / 2);
-    let min_updated = now_ms - window_ms;
-    let max_updated = now_ms - settle_ms;
-
-    let oc_conn = crate::opencode_session::open_opencode_db(db_path)
-        .with_context(|| format!("cannot open opencode DB at {}", db_path.display()))?;
-
-    let mut recent: Vec<(String, i64)> = Vec::new();
-    {
-        let mut stmt = oc_conn.prepare(
-            "SELECT id, time_updated FROM session
-             WHERE time_updated >= ?1 AND time_updated <= ?2
-             ORDER BY time_updated ASC",
-        )?;
-        let rows = stmt.query_map(rusqlite::params![min_updated, max_updated], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-        })?;
-        for row in rows {
-            recent.push(row?);
-        }
-    }
-
-    if recent.is_empty() {
-        info!("opencode-session probe: no settled recent sessions — trivial pass");
-        return Ok((true, None));
-    }
-
-    let db =
-        storage::open_db(&config.db_path()).context("cannot open DB for opencode-session probe")?;
-    let mut all_ok = true;
-    let mut latest_lag: Option<i64> = None;
-    for (session_id, time_updated) in &recent {
-        let count: i64 = db
-            .query_row(
-                "SELECT COUNT(*) FROM agentic_sessions
-                 WHERE session_id = ?1
-                   AND harness = 'opencode'
-                   AND probe_tag IS NULL
-                   AND end_time >= ?2",
-                rusqlite::params![session_id, time_updated - window_ms],
-                |row| row.get(0),
-            )
-            .with_context(|| {
-                format!("failed to query agentic_sessions for opencode session {session_id}")
-            })?;
-
-        if count > 0 {
-            let max_end: Option<i64> = db
-                .query_row(
-                    "SELECT MAX(end_time) FROM agentic_sessions
-                     WHERE session_id = ?1 AND harness = 'opencode' AND probe_tag IS NULL",
-                    rusqlite::params![session_id],
-                    |row| row.get(0),
-                )
-                .with_context(|| {
-                    format!(
-                        "opencode-session probe: failed to query MAX(end_time) for {session_id}"
-                    )
-                })?;
-            if let Some(end) = max_end {
-                let lag = now_ms - end;
-                latest_lag = Some(latest_lag.map_or(lag, |p: i64| p.max(lag)));
-            }
-            continue;
-        }
-        warn!("opencode-session probe: no row for session {session_id}");
-        all_ok = false;
-    }
     Ok((all_ok, latest_lag))
 }
 
@@ -927,445 +512,4 @@ fn write_probe_result(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use hippo_core::config::HippoConfig;
-    use std::path::{Path, PathBuf};
-    use std::time::{Duration, SystemTime};
-
-    /// Build a `HippoConfig` whose data dir and cursor session root live under
-    /// `tmp`. The DB is created lazily by the probe via `storage::open_db`.
-    fn test_config(tmp: &Path, root: &Path) -> HippoConfig {
-        let data = tmp.join("data");
-        std::fs::create_dir_all(&data).unwrap();
-        let mut config = HippoConfig::default();
-        config.storage.data_dir = data;
-        config.cursor.session_roots = vec![root.to_path_buf()];
-        config
-    }
-
-    /// Write a transcript at `<root>/<slug>/agent-transcripts/<id>/<id>.jsonl`
-    /// with the given body, then backdate its mtime to `age` ago so it lands in
-    /// the probe's eligibility window. Returns the file path.
-    fn write_transcript(root: &Path, id: &str, body: &str, age: Duration) -> PathBuf {
-        let dir = root
-            .join("Users-x-projects-foo")
-            .join("agent-transcripts")
-            .join(id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join(format!("{id}.jsonl"));
-        std::fs::write(&path, body).unwrap();
-        let mtime = SystemTime::now() - age;
-        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(mtime)).unwrap();
-        path
-    }
-
-    /// A one-turn user+assistant transcript that yields exactly one segment.
-    fn user_transcript() -> String {
-        [
-            r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nfix the build\n</user_query>"}]}}"#,
-            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"On it."}]}}"#,
-        ]
-        .join("\n")
-    }
-
-    /// An assistant-only transcript: no user turn, so `extract_segments` yields
-    /// zero segments and `poll_tick` writes no row.
-    fn assistant_only_transcript() -> String {
-        r#"{"role":"assistant","message":{"content":[{"type":"text","text":"orphaned reply"}]}}"#
-            .to_string()
-    }
-
-    /// Ingest `path` through the real cursor pipeline so a matching
-    /// `agentic_sessions` row exists exactly as production would write it
-    /// (`source_file = path`, `end_time = file mtime`).
-    fn ingest(config: &HippoConfig, path: &Path) -> usize {
-        crate::cursor_session::ingest_one(config, path).unwrap()
-    }
-
-    #[test]
-    fn cursor_probe_trivial_pass_when_no_transcripts() {
-        let tmp = tempfile::tempdir().unwrap();
-        let config = test_config(tmp.path(), &tmp.path().join("nonexistent"));
-        let (ok, lag) = super::probe_cursor_session(&config).unwrap();
-        assert!(ok);
-        assert_eq!(lag, None);
-    }
-
-    /// Happy path: an in-window transcript that yields a segment and has a
-    /// matching ingested row → (true, Some(lag)).
-    #[test]
-    fn cursor_probe_happy_path_in_window_with_row() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let config = test_config(tmp.path(), &root);
-        // ~3 min old: past the 90 s settle, inside the 10 min window.
-        let path = write_transcript(
-            &root,
-            "happy-1",
-            &user_transcript(),
-            Duration::from_secs(180),
-        );
-        assert_eq!(ingest(&config, &path), 1, "expected one ingested segment");
-
-        let (ok, lag) = super::probe_cursor_session(&config).unwrap();
-        assert!(ok, "probe should pass when the in-window row exists");
-        let lag = lag.expect("happy path should report a lag");
-        assert!(lag >= 0, "lag must be non-negative, got {lag}");
-    }
-
-    /// Genuine failure: an in-window transcript that SHOULD have a row (it
-    /// yields a segment) but none was ingested → (false, _).
-    #[test]
-    fn cursor_probe_fails_when_expected_row_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let config = test_config(tmp.path(), &root);
-        // Settled, in-window, yields a segment — but we never ingest it.
-        write_transcript(
-            &root,
-            "missing-1",
-            &user_transcript(),
-            Duration::from_secs(180),
-        );
-
-        let (ok, _lag) = super::probe_cursor_session(&config).unwrap();
-        assert!(
-            !ok,
-            "probe must FAIL when a segment-bearing in-window transcript has no row"
-        );
-    }
-
-    /// Disabled-source guard (#3): with `[cursor] enabled = false` the poller
-    /// ingests nothing, so a settled segment-bearing transcript has no row — but
-    /// the probe must trivially PASS rather than write `probe_ok = 0` and trip
-    /// watchdog I-8 on an intentionally disabled source. Mirror of
-    /// `cursor_probe_fails_when_expected_row_missing` with the source disabled.
-    #[test]
-    fn cursor_probe_trivial_pass_when_disabled() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let mut config = test_config(tmp.path(), &root);
-        config.cursor.enabled = false;
-        // Settled, in-window, segment-bearing — would FAIL if enabled, but it
-        // was never ingested because the source is off.
-        write_transcript(
-            &root,
-            "disabled-1",
-            &user_transcript(),
-            Duration::from_secs(180),
-        );
-
-        let (ok, lag) = super::probe_cursor_session(&config).unwrap();
-        assert!(ok, "disabled cursor probe must trivially pass, not FAIL");
-        assert_eq!(lag, None);
-    }
-
-    /// Zero-segment skip (finding #2): an assistant-only in-window transcript
-    /// correctly has no row, and the probe must treat that as a pass — not a
-    /// false FAIL.
-    #[test]
-    fn cursor_probe_skips_zero_segment_transcript() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let config = test_config(tmp.path(), &root);
-        let path = write_transcript(
-            &root,
-            "empty-1",
-            &assistant_only_transcript(),
-            Duration::from_secs(180),
-        );
-        // Confirm the contract: real ingestion writes zero rows for this file.
-        assert_eq!(
-            ingest(&config, &path),
-            0,
-            "assistant-only yields no segments"
-        );
-
-        let (ok, lag) = super::probe_cursor_session(&config).unwrap();
-        assert!(
-            ok,
-            "probe must pass: a segment-less transcript correctly has no row"
-        );
-        assert_eq!(lag, None, "no asserted rows → no lag");
-    }
-
-    /// High `min_idle_secs` non-blindness (finding #1): with `min_idle_secs =
-    /// 300`, the old `settle = 2 * min_idle = 600 s` collapsed the window to
-    /// empty so the probe trivial-passed even with a missing row. The fixed,
-    /// clamped settle keeps a ~200 s-old transcript in-window, so a missing
-    /// row is still caught.
-    #[test]
-    fn cursor_probe_not_blind_with_high_min_idle() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let mut config = test_config(tmp.path(), &root);
-        config.cursor.min_idle_secs = 300;
-        // ~200 s old: would be excluded by the old 600 s settle floor, but is
-        // in-window now. It yields a segment and has no row → must FAIL.
-        write_transcript(
-            &root,
-            "blind-1",
-            &user_transcript(),
-            Duration::from_secs(200),
-        );
-
-        let (ok, _lag) = super::probe_cursor_session(&config).unwrap();
-        assert!(
-            !ok,
-            "probe must still assert (not be blind) when min_idle_secs is large"
-        );
-    }
-
-    /// Lag semantics (finding #3): lag is `now - MAX(end_time)` of the matched
-    /// rows, NOT the file's age (`now - mtime`). We insert a row whose
-    /// `end_time` is far in the past relative to the file's recent mtime, then
-    /// assert the reported lag reflects `end_time`, not mtime.
-    #[test]
-    fn cursor_probe_lag_reflects_end_time_not_mtime() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let config = test_config(tmp.path(), &root);
-        // File mtime is ~3 min old. The row we insert below carries an
-        // end_time that is much more recent (~1 min ago) — distinct from the
-        // mtime but still inside the staleness guard (end_time >= mtime - window).
-        // If lag were `now - mtime` it would be ~180 s; because lag is
-        // `now - end_time` it must be ~60 s instead.
-        let file_age = Duration::from_secs(180);
-        let path = write_transcript(&root, "lag-1", &user_transcript(), file_age);
-
-        let now_ms = chrono::Utc::now().timestamp_millis();
-        let end_time = now_ms - 60_000; // 1 min ago — recent, in-window.
-        let conn = hippo_core::storage::open_db(&config.db_path()).unwrap();
-        let seg = crate::cursor_session::CursorSegment {
-            session_id: "lag-1".into(),
-            project_dir: "foo".into(),
-            cwd: "/work/foo".into(),
-            segment_index: 0,
-            start_time: end_time,
-            end_time,
-            user_prompts: vec!["do a thing".into()],
-            assistant_texts: vec![],
-            tool_calls: vec![],
-            message_count: 1,
-            source_file: path.to_string_lossy().into_owned(),
-            is_subagent: false,
-            parent_session_id: None,
-        };
-        crate::cursor_session::upsert_segment(&conn, &seg).unwrap();
-
-        let (ok, lag) = super::probe_cursor_session(&config).unwrap();
-        assert!(ok, "row exists → probe passes");
-        let lag = lag.expect("should report lag");
-        let file_age_ms = file_age.as_millis() as i64;
-        // Lag tracks end_time (~60 s), which is well under the file's age
-        // (~180 s). If the probe still used `now - mtime` this would be ~180 s.
-        assert!(
-            lag < file_age_ms - 30_000,
-            "lag ({lag}ms) must reflect end_time (~60s), not file mtime (~{file_age_ms}ms)"
-        );
-        // And it must be in the right neighbourhood of end_time (~60 s),
-        // allowing generous slack for test-execution time.
-        assert!(
-            (30_000..120_000).contains(&lag),
-            "lag ({lag}ms) should be ~60s (now - end_time)"
-        );
-    }
-
-    fn codex_test_config(tmp: &Path, root: &Path) -> HippoConfig {
-        let mut config = crate::codex_session::test_config(tmp, &[root.to_path_buf()]);
-        config.codex.min_idle_secs = 0;
-        config
-    }
-
-    fn write_rollout(root: &Path, name: &str, body: &str, age: Duration) -> PathBuf {
-        std::fs::create_dir_all(root).unwrap();
-        let path = root.join(format!("{name}.jsonl"));
-        std::fs::write(&path, body).unwrap();
-        let mtime = SystemTime::now() - age;
-        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(mtime)).unwrap();
-        path
-    }
-
-    fn codex_fixture_body() -> String {
-        std::fs::read_to_string(
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/codex/rollout-cli.jsonl"),
-        )
-        .unwrap()
-    }
-
-    fn ingest_codex(config: &HippoConfig) -> usize {
-        crate::codex_session::poll_tick(config).unwrap()
-    }
-
-    #[test]
-    fn codex_probe_trivial_pass_when_no_rollouts() {
-        let tmp = tempfile::tempdir().unwrap();
-        let config = codex_test_config(tmp.path(), &tmp.path().join("empty"));
-        let (ok, lag) = super::probe_codex_session(&config).unwrap();
-        assert!(ok);
-        assert_eq!(lag, None);
-    }
-
-    #[test]
-    fn codex_probe_happy_path_in_window_with_row() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let config = codex_test_config(tmp.path(), &root);
-        write_rollout(
-            &root,
-            "rollout-happy",
-            &codex_fixture_body(),
-            Duration::from_secs(180),
-        );
-        assert!(ingest_codex(&config) >= 1, "expected codex ingest");
-
-        let (ok, lag) = super::probe_codex_session(&config).unwrap();
-        assert!(ok);
-        assert!(lag.is_some());
-    }
-
-    #[test]
-    fn codex_probe_fails_when_expected_row_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let config = codex_test_config(tmp.path(), &root);
-        write_rollout(
-            &root,
-            "rollout-missing",
-            &codex_fixture_body(),
-            Duration::from_secs(180),
-        );
-
-        let (ok, _) = super::probe_codex_session(&config).unwrap();
-        assert!(!ok);
-    }
-
-    #[test]
-    fn codex_probe_trivial_pass_when_disabled() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("roots");
-        let mut config = codex_test_config(tmp.path(), &root);
-        config.codex.enabled = false;
-        write_rollout(
-            &root,
-            "rollout-off",
-            &codex_fixture_body(),
-            Duration::from_secs(180),
-        );
-
-        let (ok, lag) = super::probe_codex_session(&config).unwrap();
-        assert!(ok);
-        assert_eq!(lag, None);
-    }
-
-    fn opencode_test_config(tmp: &Path, oc_db: &Path) -> HippoConfig {
-        let data = tmp.join("data");
-        std::fs::create_dir_all(&data).unwrap();
-        let mut config = HippoConfig::default();
-        config.storage.data_dir = data;
-        config.opencode.db_path = oc_db.to_path_buf();
-        config
-    }
-
-    fn init_opencode_db(path: &Path) -> rusqlite::Connection {
-        let conn = rusqlite::Connection::open(path).unwrap();
-        conn.execute_batch(
-            "CREATE TABLE session (
-                id TEXT PRIMARY KEY,
-                slug TEXT NOT NULL DEFAULT '',
-                title TEXT NOT NULL DEFAULT '',
-                directory TEXT NOT NULL,
-                parent_id TEXT,
-                agent TEXT,
-                model TEXT,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                summary_additions INTEGER,
-                summary_deletions INTEGER,
-                summary_files INTEGER,
-                summary_diffs TEXT
-            );",
-        )
-        .unwrap();
-        conn
-    }
-
-    fn insert_opencode_session(conn: &rusqlite::Connection, id: &str, time_updated: i64) {
-        conn.execute(
-            "INSERT INTO session
-               (id, slug, title, directory, time_created, time_updated)
-             VALUES (?1, 'slug', 'title', '/work/proj', ?2, ?2)",
-            rusqlite::params![id, time_updated],
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn opencode_probe_trivial_pass_when_no_sessions() {
-        let tmp = tempfile::tempdir().unwrap();
-        let oc_db = tmp.path().join("opencode.db");
-        init_opencode_db(&oc_db);
-        let config = opencode_test_config(tmp.path(), &oc_db);
-        let (ok, lag) = super::probe_opencode_session(&config).unwrap();
-        assert!(ok);
-        assert_eq!(lag, None);
-    }
-
-    #[test]
-    fn opencode_probe_happy_path_in_window_with_row() {
-        let tmp = tempfile::tempdir().unwrap();
-        let oc_db = tmp.path().join("opencode.db");
-        let oc_conn = init_opencode_db(&oc_db);
-        let now_ms = chrono::Utc::now().timestamp_millis();
-        let time_updated = now_ms - 180_000;
-        insert_opencode_session(&oc_conn, "sess-happy", time_updated);
-        drop(oc_conn);
-
-        let config = opencode_test_config(tmp.path(), &oc_db);
-        assert_eq!(
-            crate::opencode_session::poll_tick(&config).unwrap(),
-            1,
-            "expected one ingested opencode session"
-        );
-
-        let (ok, lag) = super::probe_opencode_session(&config).unwrap();
-        assert!(ok);
-        assert!(lag.is_some());
-    }
-
-    #[test]
-    fn opencode_probe_fails_when_expected_row_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let oc_db = tmp.path().join("opencode.db");
-        let oc_conn = init_opencode_db(&oc_db);
-        let now_ms = chrono::Utc::now().timestamp_millis();
-        insert_opencode_session(&oc_conn, "sess-missing", now_ms - 180_000);
-        drop(oc_conn);
-
-        let config = opencode_test_config(tmp.path(), &oc_db);
-        let (ok, _) = super::probe_opencode_session(&config).unwrap();
-        assert!(!ok);
-    }
-
-    #[test]
-    fn opencode_probe_trivial_pass_when_disabled() {
-        let tmp = tempfile::tempdir().unwrap();
-        let oc_db = tmp.path().join("opencode.db");
-        let oc_conn = init_opencode_db(&oc_db);
-        insert_opencode_session(
-            &oc_conn,
-            "sess-off",
-            chrono::Utc::now().timestamp_millis() - 180_000,
-        );
-        drop(oc_conn);
-
-        let mut config = opencode_test_config(tmp.path(), &oc_db);
-        config.opencode.enabled = false;
-        let (ok, lag) = super::probe_opencode_session(&config).unwrap();
-        assert!(ok);
-        assert_eq!(lag, None);
-    }
 }

--- a/crates/hippo-daemon/src/probe.rs
+++ b/crates/hippo-daemon/src/probe.rs
@@ -22,6 +22,7 @@ const POLL_INTERVAL_MS: u64 = 200;
 /// Run one or all probes, then write results to `source_health`.
 ///
 /// `source` is one of `"shell"`, `"claude-tool"`, `"agentic-session-claude"`,
+/// `"agentic-session-opencode"`, `"agentic-session-codex"`,
 /// `"agentic-session-cursor"`, `"browser"`, or `None` to run all in sequence.
 pub async fn run(config: &HippoConfig, source: Option<&str>) -> Result<()> {
     let run_all = source.is_none();
@@ -98,6 +99,42 @@ pub async fn run(config: &HippoConfig, source: Option<&str>) -> Result<()> {
         }
     }
 
+    if run_all || source == Some("agentic-session-opencode") {
+        match probe_opencode_session(config) {
+            Ok((ok, lag)) => {
+                println!(
+                    "[probe] agentic-session-opencode: {} (lag={}ms)",
+                    if ok { "OK" } else { "FAIL" },
+                    lag.map(|l| l.to_string()).as_deref().unwrap_or("N/A")
+                );
+                write_probe_result(config, "agentic-session-opencode", ok, lag)?;
+            }
+            Err(e) => {
+                warn!("agentic-session-opencode probe error: {e:#}");
+                println!("[probe] agentic-session-opencode: ERROR — {e:#}");
+                write_probe_result(config, "agentic-session-opencode", false, None)?;
+            }
+        }
+    }
+
+    if run_all || source == Some("agentic-session-codex") {
+        match probe_codex_session(config) {
+            Ok((ok, lag)) => {
+                println!(
+                    "[probe] agentic-session-codex: {} (lag={}ms)",
+                    if ok { "OK" } else { "FAIL" },
+                    lag.map(|l| l.to_string()).as_deref().unwrap_or("N/A")
+                );
+                write_probe_result(config, "agentic-session-codex", ok, lag)?;
+            }
+            Err(e) => {
+                warn!("agentic-session-codex probe error: {e:#}");
+                println!("[probe] agentic-session-codex: ERROR — {e:#}");
+                write_probe_result(config, "agentic-session-codex", false, None)?;
+            }
+        }
+    }
+
     if run_all || source == Some("browser") {
         match probe_browser(config).await {
             Ok((ok, lag)) => {
@@ -122,12 +159,14 @@ pub async fn run(config: &HippoConfig, source: Option<&str>) -> Result<()> {
             "shell"
                 | "claude-tool"
                 | "agentic-session-claude"
+                | "agentic-session-opencode"
+                | "agentic-session-codex"
                 | "browser"
                 | "agentic-session-cursor"
         )
     {
         anyhow::bail!(
-            "unknown probe source '{}'; valid: shell, claude-tool, agentic-session-claude, browser, agentic-session-cursor",
+            "unknown probe source '{}'; valid: shell, claude-tool, agentic-session-claude, agentic-session-opencode, agentic-session-codex, browser, agentic-session-cursor",
             s
         );
     }
@@ -481,6 +520,227 @@ fn probe_cursor_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
         }
         // Segment-bearing transcript with no row: genuine FAIL.
         warn!("cursor-session probe: no row for {}", path_str);
+        all_ok = false;
+    }
+    Ok((all_ok, latest_lag))
+}
+
+/// Settle floor for Codex rollout probe eligibility, in ms. Mirrors cursor.
+const CODEX_PROBE_SETTLE_MS: i64 = 90_000;
+
+/// Outer edge of the Codex rollout probe eligibility window, in ms.
+const CODEX_PROBE_WINDOW_MS: i64 = 600_000;
+
+/// Codex-session probe: assertion-based, mirrors `probe_cursor_session`.
+///
+/// For every `[codex] session_roots/**/rollout-*.jsonl` whose age falls in
+/// `[settle_ms, CODEX_PROBE_WINDOW_MS]`, assert a matching `agentic_sessions`
+/// row exists with `harness = 'codex'` — but only when `extract_segments`
+/// yields ≥1 segment (zero-segment rollouts correctly have no row).
+fn probe_codex_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
+    if !config.codex.enabled {
+        info!("codex-session probe: codex ingestion disabled — trivial pass");
+        return Ok((true, None));
+    }
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let window_ms: i64 = CODEX_PROBE_WINDOW_MS;
+    let settle_ms: i64 = CODEX_PROBE_SETTLE_MS.min(window_ms / 2);
+
+    let mut recent: Vec<(std::path::PathBuf, i64)> = Vec::new();
+    for root in &config.codex.session_roots {
+        if !root.is_dir() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(root)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            let is_rollout = path.extension().map(|e| e == "jsonl").unwrap_or(false)
+                && path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with("rollout-"))
+                    .unwrap_or(false);
+            if !is_rollout {
+                continue;
+            }
+            let Some(mtime_ms) = entry.metadata().ok().and_then(|m| {
+                m.modified().ok().and_then(|t| {
+                    t.duration_since(std::time::UNIX_EPOCH)
+                        .ok()
+                        .map(|d| d.as_millis() as i64)
+                })
+            }) else {
+                continue;
+            };
+            let age = now_ms - mtime_ms;
+            if age >= settle_ms && age <= window_ms {
+                recent.push((path.to_path_buf(), mtime_ms));
+            }
+        }
+    }
+
+    if recent.is_empty() {
+        info!("codex-session probe: no settled recent rollouts — trivial pass");
+        return Ok((true, None));
+    }
+
+    let db =
+        storage::open_db(&config.db_path()).context("cannot open DB for codex-session probe")?;
+    let mut redaction: Option<RedactionEngine> = None;
+    let mut all_ok = true;
+    let mut latest_lag: Option<i64> = None;
+    for (path, _mtime_ms) in &recent {
+        let path_str = path.to_string_lossy();
+        let count: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM agentic_sessions
+                 WHERE source_file = ?1
+                   AND harness = 'codex'
+                   AND probe_tag IS NULL",
+                rusqlite::params![path_str.as_ref()],
+                |row| row.get(0),
+            )
+            .with_context(|| format!("failed to query agentic_sessions for {}", path_str))?;
+
+        if count > 0 {
+            let max_end: Option<i64> = db
+                .query_row(
+                    "SELECT MAX(end_time) FROM agentic_sessions
+                     WHERE source_file = ?1 AND harness = 'codex' AND probe_tag IS NULL",
+                    rusqlite::params![path_str.as_ref()],
+                    |row| row.get(0),
+                )
+                .with_context(|| {
+                    format!(
+                        "codex-session probe: failed to query MAX(end_time) for {}",
+                        path_str
+                    )
+                })?;
+            if let Some(end) = max_end {
+                let lag = now_ms - end;
+                latest_lag = Some(latest_lag.map_or(lag, |p: i64| p.max(lag)));
+            }
+            continue;
+        }
+
+        let engine = match redaction.as_ref() {
+            Some(r) => r,
+            None => {
+                redaction = Some(crate::load_redaction_engine(config));
+                redaction.as_ref().expect("just set above")
+            }
+        };
+        let segment_count = match crate::codex_session::extract_segments(path, engine) {
+            Ok(segs) => segs.len(),
+            Err(e) => {
+                warn!(
+                    "codex-session probe: cannot parse {} ({e:#}) — skipping",
+                    path_str
+                );
+                continue;
+            }
+        };
+        if segment_count == 0 {
+            info!(
+                "codex-session probe: {} yields no segments — no row expected, skipping",
+                path_str
+            );
+            continue;
+        }
+        warn!("codex-session probe: no row for {}", path_str);
+        all_ok = false;
+    }
+    Ok((all_ok, latest_lag))
+}
+
+/// Settle floor / window for opencode session probe eligibility, in ms.
+const OPENCODE_PROBE_SETTLE_MS: i64 = 90_000;
+const OPENCODE_PROBE_WINDOW_MS: i64 = 600_000;
+
+/// Opencode-session probe: for every opencode `session` row whose
+/// `time_updated` falls in the eligibility window, assert a matching
+/// `agentic_sessions` row exists with `harness = 'opencode'`.
+fn probe_opencode_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
+    if !config.opencode.enabled {
+        info!("opencode-session probe: opencode ingestion disabled — trivial pass");
+        return Ok((true, None));
+    }
+    let db_path = &config.opencode.db_path;
+    if !db_path.exists() {
+        info!("opencode-session probe: opencode DB absent — trivial pass");
+        return Ok((true, None));
+    }
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let window_ms: i64 = OPENCODE_PROBE_WINDOW_MS;
+    let settle_ms: i64 = OPENCODE_PROBE_SETTLE_MS.min(window_ms / 2);
+    let min_updated = now_ms - window_ms;
+    let max_updated = now_ms - settle_ms;
+
+    let oc_conn = crate::opencode_session::open_opencode_db(db_path)
+        .with_context(|| format!("cannot open opencode DB at {}", db_path.display()))?;
+
+    let mut recent: Vec<(String, i64)> = Vec::new();
+    {
+        let mut stmt = oc_conn.prepare(
+            "SELECT id, time_updated FROM session
+             WHERE time_updated >= ?1 AND time_updated <= ?2
+             ORDER BY time_updated ASC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![min_updated, max_updated], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for row in rows {
+            recent.push(row?);
+        }
+    }
+
+    if recent.is_empty() {
+        info!("opencode-session probe: no settled recent sessions — trivial pass");
+        return Ok((true, None));
+    }
+
+    let db =
+        storage::open_db(&config.db_path()).context("cannot open DB for opencode-session probe")?;
+    let mut all_ok = true;
+    let mut latest_lag: Option<i64> = None;
+    for (session_id, time_updated) in &recent {
+        let count: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM agentic_sessions
+                 WHERE session_id = ?1
+                   AND harness = 'opencode'
+                   AND probe_tag IS NULL
+                   AND end_time >= ?2",
+                rusqlite::params![session_id, time_updated - window_ms],
+                |row| row.get(0),
+            )
+            .with_context(|| {
+                format!("failed to query agentic_sessions for opencode session {session_id}")
+            })?;
+
+        if count > 0 {
+            let max_end: Option<i64> = db
+                .query_row(
+                    "SELECT MAX(end_time) FROM agentic_sessions
+                     WHERE session_id = ?1 AND harness = 'opencode' AND probe_tag IS NULL",
+                    rusqlite::params![session_id],
+                    |row| row.get(0),
+                )
+                .with_context(|| {
+                    format!(
+                        "opencode-session probe: failed to query MAX(end_time) for {session_id}"
+                    )
+                })?;
+            if let Some(end) = max_end {
+                let lag = now_ms - end;
+                latest_lag = Some(latest_lag.map_or(lag, |p: i64| p.max(lag)));
+            }
+            continue;
+        }
+        warn!("opencode-session probe: no row for session {session_id}");
         all_ok = false;
     }
     Ok((all_ok, latest_lag))
@@ -912,5 +1172,200 @@ mod tests {
             (30_000..120_000).contains(&lag),
             "lag ({lag}ms) should be ~60s (now - end_time)"
         );
+    }
+
+    fn codex_test_config(tmp: &Path, root: &Path) -> HippoConfig {
+        let mut config = crate::codex_session::test_config(tmp, &[root.to_path_buf()]);
+        config.codex.min_idle_secs = 0;
+        config
+    }
+
+    fn write_rollout(root: &Path, name: &str, body: &str, age: Duration) -> PathBuf {
+        std::fs::create_dir_all(root).unwrap();
+        let path = root.join(format!("{name}.jsonl"));
+        std::fs::write(&path, body).unwrap();
+        let mtime = SystemTime::now() - age;
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(mtime)).unwrap();
+        path
+    }
+
+    fn codex_fixture_body() -> String {
+        std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/codex/rollout-cli.jsonl"),
+        )
+        .unwrap()
+    }
+
+    fn ingest_codex(config: &HippoConfig) -> usize {
+        crate::codex_session::poll_tick(config).unwrap()
+    }
+
+    #[test]
+    fn codex_probe_trivial_pass_when_no_rollouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = codex_test_config(tmp.path(), &tmp.path().join("empty"));
+        let (ok, lag) = super::probe_codex_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    #[test]
+    fn codex_probe_happy_path_in_window_with_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let config = codex_test_config(tmp.path(), &root);
+        write_rollout(
+            &root,
+            "rollout-happy",
+            &codex_fixture_body(),
+            Duration::from_secs(180),
+        );
+        assert!(ingest_codex(&config) >= 1, "expected codex ingest");
+
+        let (ok, lag) = super::probe_codex_session(&config).unwrap();
+        assert!(ok);
+        assert!(lag.is_some());
+    }
+
+    #[test]
+    fn codex_probe_fails_when_expected_row_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let config = codex_test_config(tmp.path(), &root);
+        write_rollout(
+            &root,
+            "rollout-missing",
+            &codex_fixture_body(),
+            Duration::from_secs(180),
+        );
+
+        let (ok, _) = super::probe_codex_session(&config).unwrap();
+        assert!(!ok);
+    }
+
+    #[test]
+    fn codex_probe_trivial_pass_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let mut config = codex_test_config(tmp.path(), &root);
+        config.codex.enabled = false;
+        write_rollout(
+            &root,
+            "rollout-off",
+            &codex_fixture_body(),
+            Duration::from_secs(180),
+        );
+
+        let (ok, lag) = super::probe_codex_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    fn opencode_test_config(tmp: &Path, oc_db: &Path) -> HippoConfig {
+        let data = tmp.join("data");
+        std::fs::create_dir_all(&data).unwrap();
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = data;
+        config.opencode.db_path = oc_db.to_path_buf();
+        config
+    }
+
+    fn init_opencode_db(path: &Path) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL DEFAULT '',
+                title TEXT NOT NULL DEFAULT '',
+                directory TEXT NOT NULL,
+                parent_id TEXT,
+                agent TEXT,
+                model TEXT,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                summary_additions INTEGER,
+                summary_deletions INTEGER,
+                summary_files INTEGER,
+                summary_diffs TEXT
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_opencode_session(conn: &rusqlite::Connection, id: &str, time_updated: i64) {
+        conn.execute(
+            "INSERT INTO session
+               (id, slug, title, directory, time_created, time_updated)
+             VALUES (?1, 'slug', 'title', '/work/proj', ?2, ?2)",
+            rusqlite::params![id, time_updated],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn opencode_probe_trivial_pass_when_no_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc_db = tmp.path().join("opencode.db");
+        init_opencode_db(&oc_db);
+        let config = opencode_test_config(tmp.path(), &oc_db);
+        let (ok, lag) = super::probe_opencode_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    #[test]
+    fn opencode_probe_happy_path_in_window_with_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc_db = tmp.path().join("opencode.db");
+        let oc_conn = init_opencode_db(&oc_db);
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let time_updated = now_ms - 180_000;
+        insert_opencode_session(&oc_conn, "sess-happy", time_updated);
+        drop(oc_conn);
+
+        let config = opencode_test_config(tmp.path(), &oc_db);
+        assert_eq!(
+            crate::opencode_session::poll_tick(&config).unwrap(),
+            1,
+            "expected one ingested opencode session"
+        );
+
+        let (ok, lag) = super::probe_opencode_session(&config).unwrap();
+        assert!(ok);
+        assert!(lag.is_some());
+    }
+
+    #[test]
+    fn opencode_probe_fails_when_expected_row_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc_db = tmp.path().join("opencode.db");
+        let oc_conn = init_opencode_db(&oc_db);
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        insert_opencode_session(&oc_conn, "sess-missing", now_ms - 180_000);
+        drop(oc_conn);
+
+        let config = opencode_test_config(tmp.path(), &oc_db);
+        let (ok, _) = super::probe_opencode_session(&config).unwrap();
+        assert!(!ok);
+    }
+
+    #[test]
+    fn opencode_probe_trivial_pass_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc_db = tmp.path().join("opencode.db");
+        let oc_conn = init_opencode_db(&oc_db);
+        insert_opencode_session(
+            &oc_conn,
+            "sess-off",
+            chrono::Utc::now().timestamp_millis() - 180_000,
+        );
+        drop(oc_conn);
+
+        let mut config = opencode_test_config(tmp.path(), &oc_db);
+        config.opencode.enabled = false;
+        let (ok, lag) = super::probe_opencode_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
     }
 }

--- a/crates/hippo-daemon/src/probe_agentic.rs
+++ b/crates/hippo-daemon/src/probe_agentic.rs
@@ -1,0 +1,637 @@
+//! Assertion-based probes for interval-polled agentic session sources.
+
+use anyhow::{Context, Result};
+use hippo_core::config::HippoConfig;
+use hippo_core::redaction::RedactionEngine;
+use hippo_core::storage;
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
+
+/// Settle floor shared by cursor/codex/opencode poller-backed probes.
+pub(crate) const POLLER_PROBE_SETTLE_MS: i64 = 90_000;
+
+/// Outer eligibility window shared by cursor/codex/opencode poller-backed probes.
+pub(crate) const POLLER_PROBE_WINDOW_MS: i64 = 600_000;
+
+type SegmentCounter = fn(&Path, i64, &RedactionEngine) -> Result<usize>;
+
+struct SourceFileProbeSpec {
+    harness: &'static str,
+    probe_label: &'static str,
+    /// When true, require `end_time >= mtime_ms - window_ms` on the COUNT query.
+    /// Cursor uses file mtime-aligned segment timestamps; codex uses rollout JSON
+    /// timestamps that may predate the file mtime, so codex omits this floor.
+    end_time_floor_from_mtime: bool,
+}
+
+fn walk_settled_files(
+    roots: &[PathBuf],
+    settle_ms: i64,
+    window_ms: i64,
+    is_candidate: impl Fn(&Path) -> bool,
+) -> Result<Vec<(PathBuf, i64)>> {
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let mut recent = Vec::new();
+    for root in roots {
+        if !root.is_dir() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(root)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if !is_candidate(path) {
+                continue;
+            }
+            let Some(mtime_ms) = entry.metadata().ok().and_then(|m| {
+                m.modified().ok().and_then(|t| {
+                    t.duration_since(std::time::UNIX_EPOCH)
+                        .ok()
+                        .map(|d| d.as_millis() as i64)
+                })
+            }) else {
+                continue;
+            };
+            let age = now_ms - mtime_ms;
+            if age >= settle_ms && age <= window_ms {
+                recent.push((path.to_path_buf(), mtime_ms));
+            }
+        }
+    }
+    Ok(recent)
+}
+
+fn assert_source_file_rows(
+    config: &HippoConfig,
+    db_label: &str,
+    recent: &[(PathBuf, i64)],
+    spec: SourceFileProbeSpec,
+    window_ms: i64,
+    count_segments: SegmentCounter,
+) -> Result<(bool, Option<i64>)> {
+    if recent.is_empty() {
+        info!(
+            "{}: no settled recent files — trivial pass",
+            spec.probe_label
+        );
+        return Ok((true, None));
+    }
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let db = storage::open_db(&config.db_path())
+        .with_context(|| format!("cannot open DB for {db_label}"))?;
+    let mut redaction: Option<RedactionEngine> = None;
+    let mut all_ok = true;
+    let mut latest_lag: Option<i64> = None;
+
+    for (path, mtime_ms) in recent {
+        let path_str = path.to_string_lossy();
+        let count: i64 = if spec.end_time_floor_from_mtime {
+            db.query_row(
+                "SELECT COUNT(*) FROM agentic_sessions
+                 WHERE source_file = ?1
+                   AND harness = ?2
+                   AND probe_tag IS NULL
+                   AND end_time >= ?3",
+                rusqlite::params![path_str.as_ref(), spec.harness, mtime_ms - window_ms],
+                |row| row.get(0),
+            )
+        } else {
+            db.query_row(
+                "SELECT COUNT(*) FROM agentic_sessions
+                 WHERE source_file = ?1
+                   AND harness = ?2
+                   AND probe_tag IS NULL",
+                rusqlite::params![path_str.as_ref(), spec.harness],
+                |row| row.get(0),
+            )
+        }
+        .with_context(|| format!("failed to query agentic_sessions for {}", path_str))?;
+
+        if count > 0 {
+            let max_end: Option<i64> = db
+                .query_row(
+                    "SELECT MAX(end_time) FROM agentic_sessions
+                     WHERE source_file = ?1 AND harness = ?2 AND probe_tag IS NULL",
+                    rusqlite::params![path_str.as_ref(), spec.harness],
+                    |row| row.get(0),
+                )
+                .with_context(|| {
+                    format!(
+                        "{}: failed to query MAX(end_time) for {}",
+                        spec.probe_label, path_str
+                    )
+                })?;
+            if let Some(end) = max_end {
+                let lag = now_ms - end;
+                latest_lag = Some(latest_lag.map_or(lag, |p: i64| p.max(lag)));
+            }
+            continue;
+        }
+
+        let engine = match redaction.as_ref() {
+            Some(r) => r,
+            None => {
+                redaction = Some(crate::load_redaction_engine(config));
+                redaction.as_ref().expect("just set above")
+            }
+        };
+        let segment_count = match count_segments(path, *mtime_ms, engine) {
+            Ok(n) => n,
+            Err(e) => {
+                warn!(
+                    "{}: cannot parse {} ({e:#}) — skipping",
+                    spec.probe_label, path_str
+                );
+                continue;
+            }
+        };
+        if segment_count == 0 {
+            info!(
+                "{}: {} yields no segments — no row expected, skipping",
+                spec.probe_label, path_str
+            );
+            continue;
+        }
+        warn!("{}: no row for {}", spec.probe_label, path_str);
+        all_ok = false;
+    }
+    Ok((all_ok, latest_lag))
+}
+
+fn is_cursor_transcript(path: &Path) -> bool {
+    path.extension().map(|e| e == "jsonl").unwrap_or(false)
+        && path
+            .components()
+            .any(|c| c.as_os_str() == "agent-transcripts")
+}
+
+fn is_codex_rollout(path: &Path) -> bool {
+    path.extension().map(|e| e == "jsonl").unwrap_or(false)
+        && path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("rollout-"))
+}
+
+fn count_cursor_segments(path: &Path, mtime_ms: i64, engine: &RedactionEngine) -> Result<usize> {
+    Ok(crate::cursor_session::extract_segments(path, mtime_ms, engine)?.len())
+}
+
+fn count_codex_segments(path: &Path, _mtime_ms: i64, engine: &RedactionEngine) -> Result<usize> {
+    Ok(crate::codex_session::extract_segments(path, engine)?.len())
+}
+
+pub(crate) fn probe_cursor_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
+    if !config.cursor.enabled {
+        info!("cursor-session probe: cursor ingestion disabled — trivial pass");
+        return Ok((true, None));
+    }
+    let window_ms = POLLER_PROBE_WINDOW_MS;
+    let settle_ms = POLLER_PROBE_SETTLE_MS.min(window_ms / 2);
+    let recent = walk_settled_files(
+        &config.cursor.session_roots,
+        settle_ms,
+        window_ms,
+        is_cursor_transcript,
+    )?;
+    assert_source_file_rows(
+        config,
+        "cursor-session probe",
+        &recent,
+        SourceFileProbeSpec {
+            harness: "cursor",
+            probe_label: "cursor-session probe",
+            end_time_floor_from_mtime: true,
+        },
+        window_ms,
+        count_cursor_segments,
+    )
+}
+
+pub(crate) fn probe_codex_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
+    if !config.codex.enabled {
+        info!("codex-session probe: codex ingestion disabled — trivial pass");
+        return Ok((true, None));
+    }
+    let window_ms = POLLER_PROBE_WINDOW_MS;
+    let settle_ms = POLLER_PROBE_SETTLE_MS.min(window_ms / 2);
+    let recent = walk_settled_files(
+        &config.codex.session_roots,
+        settle_ms,
+        window_ms,
+        is_codex_rollout,
+    )?;
+    assert_source_file_rows(
+        config,
+        "codex-session probe",
+        &recent,
+        SourceFileProbeSpec {
+            harness: "codex",
+            probe_label: "codex-session probe",
+            end_time_floor_from_mtime: false,
+        },
+        window_ms,
+        count_codex_segments,
+    )
+}
+
+pub(crate) fn probe_opencode_session(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
+    if !config.opencode.enabled {
+        info!("opencode-session probe: opencode ingestion disabled — trivial pass");
+        return Ok((true, None));
+    }
+    let db_path = &config.opencode.db_path;
+    if !db_path.exists() {
+        info!("opencode-session probe: opencode DB absent — trivial pass");
+        return Ok((true, None));
+    }
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let window_ms = POLLER_PROBE_WINDOW_MS;
+    let settle_ms = POLLER_PROBE_SETTLE_MS.min(window_ms / 2);
+    let recent = crate::opencode_session::sessions_in_probe_window(
+        db_path,
+        now_ms - window_ms,
+        now_ms - settle_ms,
+    )
+    .with_context(|| format!("cannot read opencode sessions from {}", db_path.display()))?;
+
+    if recent.is_empty() {
+        info!("opencode-session probe: no settled recent sessions — trivial pass");
+        return Ok((true, None));
+    }
+
+    let db =
+        storage::open_db(&config.db_path()).context("cannot open DB for opencode-session probe")?;
+    let mut all_ok = true;
+    let mut latest_lag: Option<i64> = None;
+    for (session_id, time_updated) in &recent {
+        let count: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM agentic_sessions
+                 WHERE session_id = ?1
+                   AND harness = 'opencode'
+                   AND probe_tag IS NULL
+                   AND end_time >= ?2",
+                rusqlite::params![session_id, time_updated - window_ms],
+                |row| row.get(0),
+            )
+            .with_context(|| {
+                format!("failed to query agentic_sessions for opencode session {session_id}")
+            })?;
+
+        if count > 0 {
+            let max_end: Option<i64> = db
+                .query_row(
+                    "SELECT MAX(end_time) FROM agentic_sessions
+                     WHERE session_id = ?1 AND harness = 'opencode' AND probe_tag IS NULL",
+                    rusqlite::params![session_id],
+                    |row| row.get(0),
+                )
+                .with_context(|| {
+                    format!(
+                        "opencode-session probe: failed to query MAX(end_time) for {session_id}"
+                    )
+                })?;
+            if let Some(end) = max_end {
+                let lag = now_ms - end;
+                latest_lag = Some(latest_lag.map_or(lag, |p: i64| p.max(lag)));
+            }
+            continue;
+        }
+        warn!("opencode-session probe: no row for session {session_id}");
+        all_ok = false;
+    }
+    Ok((all_ok, latest_lag))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hippo_core::config::HippoConfig;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, SystemTime};
+
+    fn test_config(tmp: &Path, root: &Path) -> HippoConfig {
+        let data = tmp.join("data");
+        std::fs::create_dir_all(&data).unwrap();
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = data;
+        config.cursor.session_roots = vec![root.to_path_buf()];
+        config
+    }
+
+    fn write_transcript(root: &Path, id: &str, body: &str, age: Duration) -> PathBuf {
+        let dir = root
+            .join("Users-x-projects-foo")
+            .join("agent-transcripts")
+            .join(id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{id}.jsonl"));
+        std::fs::write(&path, body).unwrap();
+        let mtime = SystemTime::now() - age;
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(mtime)).unwrap();
+        path
+    }
+
+    fn user_transcript() -> String {
+        [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nfix the build\n</user_query>"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"On it."}]}}"#,
+        ]
+        .join("\n")
+    }
+
+    fn assistant_only_transcript() -> String {
+        r#"{"role":"assistant","message":{"content":[{"type":"text","text":"orphaned reply"}]}}"#
+            .to_string()
+    }
+
+    fn ingest_cursor(config: &HippoConfig, path: &Path) -> usize {
+        crate::cursor_session::ingest_one(config, path).unwrap()
+    }
+
+    #[test]
+    fn cursor_probe_trivial_pass_when_no_transcripts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path(), &tmp.path().join("nonexistent"));
+        let (ok, lag) = probe_cursor_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    #[test]
+    fn cursor_probe_happy_path_in_window_with_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let config = test_config(tmp.path(), &root);
+        let path = write_transcript(
+            &root,
+            "happy-1",
+            &user_transcript(),
+            Duration::from_secs(180),
+        );
+        assert_eq!(ingest_cursor(&config, &path), 1);
+
+        let (ok, lag) = probe_cursor_session(&config).unwrap();
+        assert!(ok);
+        assert!(lag.is_some());
+    }
+
+    #[test]
+    fn cursor_probe_fails_when_expected_row_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let config = test_config(tmp.path(), &root);
+        write_transcript(
+            &root,
+            "missing-1",
+            &user_transcript(),
+            Duration::from_secs(180),
+        );
+        let (ok, _) = probe_cursor_session(&config).unwrap();
+        assert!(!ok);
+    }
+
+    #[test]
+    fn cursor_probe_trivial_pass_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let mut config = test_config(tmp.path(), &root);
+        config.cursor.enabled = false;
+        write_transcript(
+            &root,
+            "disabled-1",
+            &user_transcript(),
+            Duration::from_secs(180),
+        );
+        let (ok, lag) = probe_cursor_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    #[test]
+    fn cursor_probe_skips_zero_segment_transcript() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let config = test_config(tmp.path(), &root);
+        let path = write_transcript(
+            &root,
+            "empty-1",
+            &assistant_only_transcript(),
+            Duration::from_secs(180),
+        );
+        assert_eq!(ingest_cursor(&config, &path), 0);
+        let (ok, lag) = probe_cursor_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    fn codex_test_config(tmp: &Path, root: &Path) -> HippoConfig {
+        let mut config = crate::codex_session::test_config(tmp, &[root.to_path_buf()]);
+        config.codex.min_idle_secs = 0;
+        config
+    }
+
+    fn write_rollout(root: &Path, name: &str, body: &str, age: Duration) -> PathBuf {
+        std::fs::create_dir_all(root).unwrap();
+        let path = root.join(format!("{name}.jsonl"));
+        std::fs::write(&path, body).unwrap();
+        let mtime = SystemTime::now() - age;
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(mtime)).unwrap();
+        path
+    }
+
+    fn codex_fixture_body() -> String {
+        std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/codex/rollout-cli.jsonl"),
+        )
+        .unwrap()
+    }
+
+    fn session_meta_only_rollout() -> String {
+        r#"{"timestamp":"2026-04-04T07:47:59.376Z","type":"session_meta","payload":{"id":"meta-only","timestamp":"2026-04-04T07:47:55.190Z","cwd":"/proj"}}"#
+            .to_string()
+    }
+
+    #[test]
+    fn codex_probe_trivial_pass_when_no_rollouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = codex_test_config(tmp.path(), &tmp.path().join("empty"));
+        let (ok, lag) = probe_codex_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    #[test]
+    fn codex_probe_happy_path_in_window_with_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let config = codex_test_config(tmp.path(), &root);
+        write_rollout(
+            &root,
+            "rollout-happy",
+            &codex_fixture_body(),
+            Duration::from_secs(180),
+        );
+        assert!(crate::codex_session::poll_tick(&config).unwrap() >= 1);
+        let (ok, lag) = probe_codex_session(&config).unwrap();
+        assert!(ok);
+        assert!(lag.is_some());
+    }
+
+    #[test]
+    fn codex_probe_fails_when_expected_row_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let config = codex_test_config(tmp.path(), &root);
+        write_rollout(
+            &root,
+            "rollout-missing",
+            &codex_fixture_body(),
+            Duration::from_secs(180),
+        );
+        let (ok, _) = probe_codex_session(&config).unwrap();
+        assert!(!ok);
+    }
+
+    #[test]
+    fn codex_probe_trivial_pass_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let mut config = codex_test_config(tmp.path(), &root);
+        config.codex.enabled = false;
+        write_rollout(
+            &root,
+            "rollout-off",
+            &codex_fixture_body(),
+            Duration::from_secs(180),
+        );
+        let (ok, lag) = probe_codex_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    #[test]
+    fn codex_probe_skips_zero_segment_rollout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("roots");
+        let config = codex_test_config(tmp.path(), &root);
+        write_rollout(
+            &root,
+            "rollout-empty",
+            &session_meta_only_rollout(),
+            Duration::from_secs(180),
+        );
+        let (ok, lag) = probe_codex_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    fn opencode_test_config(tmp: &Path, oc_db: &Path) -> HippoConfig {
+        let data = tmp.join("data");
+        std::fs::create_dir_all(&data).unwrap();
+        let mut config = HippoConfig::default();
+        config.storage.data_dir = data;
+        config.opencode.db_path = oc_db.to_path_buf();
+        config
+    }
+
+    fn init_opencode_db(path: &Path) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL DEFAULT '',
+                title TEXT NOT NULL DEFAULT '',
+                directory TEXT NOT NULL,
+                parent_id TEXT,
+                agent TEXT,
+                model TEXT,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                summary_additions INTEGER,
+                summary_deletions INTEGER,
+                summary_files INTEGER,
+                summary_diffs TEXT
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_opencode_session(conn: &rusqlite::Connection, id: &str, time_updated: i64) {
+        conn.execute(
+            "INSERT INTO session
+               (id, slug, title, directory, time_created, time_updated)
+             VALUES (?1, 'slug', 'title', '/work/proj', ?2, ?2)",
+            rusqlite::params![id, time_updated],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn opencode_probe_trivial_pass_when_no_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc_db = tmp.path().join("opencode.db");
+        init_opencode_db(&oc_db);
+        let config = opencode_test_config(tmp.path(), &oc_db);
+        let (ok, lag) = probe_opencode_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+
+    #[test]
+    fn opencode_probe_happy_path_in_window_with_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc_db = tmp.path().join("opencode.db");
+        let oc_conn = init_opencode_db(&oc_db);
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        insert_opencode_session(&oc_conn, "sess-happy", now_ms - 180_000);
+        drop(oc_conn);
+
+        let config = opencode_test_config(tmp.path(), &oc_db);
+        assert_eq!(crate::opencode_session::poll_tick(&config).unwrap(), 1);
+        let (ok, lag) = probe_opencode_session(&config).unwrap();
+        assert!(ok);
+        assert!(lag.is_some());
+    }
+
+    #[test]
+    fn opencode_probe_fails_when_expected_row_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc_db = tmp.path().join("opencode.db");
+        let oc_conn = init_opencode_db(&oc_db);
+        insert_opencode_session(
+            &oc_conn,
+            "sess-missing",
+            chrono::Utc::now().timestamp_millis() - 180_000,
+        );
+        drop(oc_conn);
+
+        let config = opencode_test_config(tmp.path(), &oc_db);
+        let (ok, _) = probe_opencode_session(&config).unwrap();
+        assert!(!ok);
+    }
+
+    #[test]
+    fn opencode_probe_trivial_pass_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc_db = tmp.path().join("opencode.db");
+        let oc_conn = init_opencode_db(&oc_db);
+        insert_opencode_session(
+            &oc_conn,
+            "sess-off",
+            chrono::Utc::now().timestamp_millis() - 180_000,
+        );
+        drop(oc_conn);
+
+        let mut config = opencode_test_config(tmp.path(), &oc_db);
+        config.opencode.enabled = false;
+        let (ok, lag) = probe_opencode_session(&config).unwrap();
+        assert!(ok);
+        assert_eq!(lag, None);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `probe_opencode_session` — checks recent opencode `session` rows have matching `agentic_sessions` (`harness = 'opencode'`)
- Add `probe_codex_session` — checks settled `rollout-*.jsonl` files have matching `agentic_sessions` (`harness = 'codex'`), skipping zero-segment rollouts
- Wire both into `hippo probe` round-robin and `--source` validation
- Export `open_opencode_db` for probe read path; unit tests mirror cursor probe coverage

Closes SNUG-117.

## Test plan
- [x] `cargo test -p hippo-daemon --lib probe::tests` (15 tests)
- [x] `cargo clippy -p hippo-daemon -- -D warnings`