### PR TITLE
fix(brain): expose process pid in /health (SNUG-107)

### DIFF
--- a/brain/src/hippo_brain/openapi.py
+++ b/brain/src/hippo_brain/openapi.py
@@ -214,6 +214,7 @@ def build_openapi_spec() -> dict:
                     ],
                     "properties": {
                         "status": {"type": "string"},
+                        "pid": {"type": "integer"},
                         "version": {"type": "string"},
                         "expected_schema_version": {"type": "integer"},
                         "accepted_read_versions": {

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime as _dt
 import logging
+import os
 import sqlite3
 import time
 from typing import Any
@@ -401,6 +402,7 @@ class BrainServer:
         return JSONResponse(
             {
                 "status": status,
+                "pid": os.getpid(),
                 "version": get_version(),
                 "expected_schema_version": EXPECTED_SCHEMA_VERSION,
                 "accepted_read_versions": sorted(ACCEPTED_READ_VERSIONS),

--- a/brain/tests/test_bench_preflight.py
+++ b/brain/tests/test_bench_preflight.py
@@ -4,8 +4,18 @@ from hippo_brain.bench.preflight import (
     CheckResult,
     check_disk_space,
     check_inference_reachable,
+    check_prod_brain_reachable,
     run_all_preflight,
 )
+
+
+def test_check_prod_brain_reachable_includes_pid():
+    fake_resp = MagicMock(status_code=200)
+    fake_resp.json.return_value = {"pid": 9876}
+    with patch("httpx.get", return_value=fake_resp):
+        r = check_prod_brain_reachable("http://localhost:9175")
+    assert r.status == "pass"
+    assert r.detail == "pid=9876"
 
 
 def test_check_result_is_dict_serializable():

--- a/brain/tests/test_server.py
+++ b/brain/tests/test_server.py
@@ -74,7 +74,8 @@ def _seed_knowledge_nodes(conn):
 # ---- /health ----
 
 
-def test_health_endpoint(tmp_db):
+def test_health_endpoint(tmp_db, monkeypatch):
+    monkeypatch.setattr("hippo_brain.server.os.getpid", lambda: 4242)
     conn, db_path = tmp_db
     app = _make_app(str(db_path))
     client = TestClient(app)
@@ -83,6 +84,7 @@ def test_health_endpoint(tmp_db):
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
+    assert data["pid"] == 4242
     assert "version" in data
     assert data["version"] == get_version()
     assert "inference_reachable" in data


### PR DESCRIPTION
## Summary
- Add `pid` (current process id) to brain `/health` JSON so bench preflight `prod_brain_reachable` and run manifests can correlate the probed brain against `ps` output instead of `pid=unknown`.
- Document field in OpenAPI `HealthResponse`; tests cover producer and preflight consumer.

## Test plan
- [x] `pytest brain/tests/test_server.py::test_health_endpoint`
- [x] `pytest brain/tests/test_bench_preflight.py::test_check_prod_brain_reachable_includes_pid`
- [x] ruff clean