### PR TITLE
feat(brain): agent-trust eval corpus and offline runner (SNUG-118)

### DIFF
--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
 hippo-brain = "hippo_brain:main"
 hippo-mcp = "hippo_brain.mcp:main"
 hippo-eval = "hippo_brain.evaluation:main"
+hippo-trust-eval = "hippo_brain.trust_eval:main"
 hippo-bench = "hippo_brain.bench.cli:main"
 hippo-brain-api = "hippo_brain.api_cli:main"
 hippo-brain-openapi = "hippo_brain.openapi:main"

--- a/brain/src/hippo_brain/_fixtures/trust_eval_cases.json
+++ b/brain/src/hippo_brain/_fixtures/trust_eval_cases.json
@@ -30,6 +30,7 @@
       "question": "What Codex rollout work happened on hippo?",
       "mode": "evidence_for",
       "source_filter": "claude",
+      "source_filter_note": "claude filter matches any non-probe agentic session (codex/cursor/opencode harnesses)",
       "evidence": {
         "source_kinds": ["codex"],
         "min_hits": 1,
@@ -84,6 +85,7 @@
       "question": "What is in Claude auto-memory for this project?",
       "mode": "what_known",
       "source_filter": "claude-auto-memory",
+      "pending": true,
       "evidence": {
         "source_kinds": ["claude-auto-memory"],
         "min_hits": 1,
@@ -97,13 +99,14 @@
       "evidence": {
         "source_kinds": ["shell", "browser"],
         "min_hits": 2,
-        "require_distinct_source_kinds": true
+        "min_distinct_source_kinds": 2
       }
     },
     {
       "id": "trust-source-health-01",
       "question": "Is agentic-session-claude capture healthy right now?",
       "mode": "what_known",
+      "pending": true,
       "evidence": {
         "source_kinds": ["claude"],
         "min_hits": 0,
@@ -116,6 +119,7 @@
       "id": "trust-adversarial-missing-01",
       "question": "What Postgres migration replaced sqlite-vec in hippo?",
       "mode": "adversarial",
+      "pending": true,
       "evidence": {
         "source_kinds": [],
         "min_hits": 0,
@@ -128,6 +132,7 @@
       "id": "trust-adversarial-stale-01",
       "question": "What happened in hippo yesterday at 3am UTC specifically?",
       "mode": "adversarial",
+      "pending": true,
       "evidence": {
         "source_kinds": [],
         "min_hits": 0,
@@ -142,14 +147,14 @@
       "source_filter": "claude",
       "evidence": {
         "source_kinds": ["claude"],
-        "min_hits": 1,
-        "exclude_probe_linkage": true
+        "min_hits": 1
       }
     },
     {
       "id": "trust-docs-contract-01",
       "question": "What schema version does hippo brain accept for reads?",
       "mode": "what_known",
+      "pending": true,
       "evidence": {
         "source_kinds": ["claude", "shell"],
         "min_hits": 0,

--- a/brain/src/hippo_brain/_fixtures/trust_eval_cases.json
+++ b/brain/src/hippo_brain/_fixtures/trust_eval_cases.json
@@ -1,5 +1,5 @@
 {
-  "description": "Agent-trust regression corpus (SNUG-118). Each case records expected evidence shape — source kind, link identity, timestamps — not prose answers tied to a live user DB. Run offline via `hippo-trust-eval --validate` or `pytest brain/tests/test_trust_eval.py`.",
+  "description": "Agent-trust regression corpus (SNUG-118). Each case records expected evidence shape — source kind, link identity, timestamps — not prose answers tied to a live user DB. Run offline via `hippo-trust-eval` or `pytest brain/tests/test_trust_eval.py`.",
   "schema_version": 1,
   "adding_cases": "Append a case with unique id, set evidence.source_kinds to the logical families you expect in linked_source_ids, and add a matching row to the synthetic seeder in brain/tests/test_trust_eval.py when the case needs an end-to-end retrieval check.",
   "cases": [

--- a/brain/src/hippo_brain/_fixtures/trust_eval_cases.json
+++ b/brain/src/hippo_brain/_fixtures/trust_eval_cases.json
@@ -1,0 +1,161 @@
+{
+  "description": "Agent-trust regression corpus (SNUG-118). Each case records expected evidence shape — source kind, link identity, timestamps — not prose answers tied to a live user DB. Run offline via `hippo-trust-eval --validate` or `pytest brain/tests/test_trust_eval.py`.",
+  "schema_version": 1,
+  "adding_cases": "Append a case with unique id, set evidence.source_kinds to the logical families you expect in linked_source_ids, and add a matching row to the synthetic seeder in brain/tests/test_trust_eval.py when the case needs an end-to-end retrieval check.",
+  "cases": [
+    {
+      "id": "trust-shell-01",
+      "question": "What shell commands were run in the hippo repo recently?",
+      "mode": "what_known",
+      "source_filter": "shell",
+      "evidence": {
+        "source_kinds": ["shell"],
+        "min_hits": 1,
+        "require_captured_at": true
+      }
+    },
+    {
+      "id": "trust-claude-01",
+      "question": "What did we decide about the Claude session hook?",
+      "mode": "prior_decisions",
+      "source_filter": "claude",
+      "evidence": {
+        "source_kinds": ["claude"],
+        "min_hits": 1,
+        "require_captured_at": true
+      }
+    },
+    {
+      "id": "trust-codex-01",
+      "question": "What Codex rollout work happened on hippo?",
+      "mode": "evidence_for",
+      "source_filter": "claude",
+      "evidence": {
+        "source_kinds": ["codex"],
+        "min_hits": 1,
+        "require_captured_at": true
+      }
+    },
+    {
+      "id": "trust-cursor-01",
+      "question": "What Cursor agent sessions touched capture reliability?",
+      "mode": "evidence_for",
+      "source_filter": "claude",
+      "evidence": {
+        "source_kinds": ["cursor"],
+        "min_hits": 1,
+        "require_captured_at": true
+      }
+    },
+    {
+      "id": "trust-opencode-01",
+      "question": "What opencode sessions were ingested?",
+      "mode": "evidence_for",
+      "source_filter": "claude",
+      "evidence": {
+        "source_kinds": ["opencode"],
+        "min_hits": 1,
+        "require_captured_at": true
+      }
+    },
+    {
+      "id": "trust-browser-01",
+      "question": "What browser activity was captured on allowlisted domains?",
+      "mode": "what_known",
+      "source_filter": "browser",
+      "evidence": {
+        "source_kinds": ["browser"],
+        "min_hits": 1,
+        "require_captured_at": true
+      }
+    },
+    {
+      "id": "trust-workflow-01",
+      "question": "Which GitHub workflow runs failed recently?",
+      "mode": "recent_changes",
+      "source_filter": "workflow",
+      "evidence": {
+        "source_kinds": ["workflow"],
+        "min_hits": 1
+      }
+    },
+    {
+      "id": "trust-memory-01",
+      "question": "What is in Claude auto-memory for this project?",
+      "mode": "what_known",
+      "source_filter": "claude-auto-memory",
+      "evidence": {
+        "source_kinds": ["claude-auto-memory"],
+        "min_hits": 1,
+        "require_captured_at": true
+      }
+    },
+    {
+      "id": "trust-mixed-01",
+      "question": "How do shell events and browser visits relate to the same project?",
+      "mode": "evidence_for",
+      "evidence": {
+        "source_kinds": ["shell", "browser"],
+        "min_hits": 2,
+        "require_distinct_source_kinds": true
+      }
+    },
+    {
+      "id": "trust-source-health-01",
+      "question": "Is agentic-session-claude capture healthy right now?",
+      "mode": "what_known",
+      "evidence": {
+        "source_kinds": ["claude"],
+        "min_hits": 0,
+        "max_hits": 0,
+        "expect_coverage_gap": true,
+        "gap_reason_contains": ["source_health", "doctor", "capture"]
+      }
+    },
+    {
+      "id": "trust-adversarial-missing-01",
+      "question": "What Postgres migration replaced sqlite-vec in hippo?",
+      "mode": "adversarial",
+      "evidence": {
+        "source_kinds": [],
+        "min_hits": 0,
+        "max_hits": 0,
+        "expect_coverage_gap": true,
+        "gap_reason_contains": ["no evidence", "not", "sqlite-vec"]
+      }
+    },
+    {
+      "id": "trust-adversarial-stale-01",
+      "question": "What happened in hippo yesterday at 3am UTC specifically?",
+      "mode": "adversarial",
+      "evidence": {
+        "source_kinds": [],
+        "min_hits": 0,
+        "expect_coverage_gap": true,
+        "gap_reason_contains": ["stale", "missing", "insufficient", "gap"]
+      }
+    },
+    {
+      "id": "trust-probe-exclude-01",
+      "question": "Show real claude session work on hippo (not probes).",
+      "mode": "evidence_for",
+      "source_filter": "claude",
+      "evidence": {
+        "source_kinds": ["claude"],
+        "min_hits": 1,
+        "exclude_probe_linkage": true
+      }
+    },
+    {
+      "id": "trust-docs-contract-01",
+      "question": "What schema version does hippo brain accept for reads?",
+      "mode": "what_known",
+      "evidence": {
+        "source_kinds": ["claude", "shell"],
+        "min_hits": 0,
+        "expect_coverage_gap": true,
+        "gap_reason_contains": ["schema", "version", "config", "doctor"]
+      }
+    }
+  ]
+}

--- a/brain/src/hippo_brain/source_filters.py
+++ b/brain/src/hippo_brain/source_filters.py
@@ -6,6 +6,25 @@ import sqlite3
 
 CLAUDE_AUTO_MEMORY_SOURCE = "claude-auto-memory"
 
+# Logical source families keyed by linked_source_ids prefix (see retrieval._fetch_details).
+_AGENTIC_LINK_PREFIXES = ("claude-", "codex-", "cursor-", "opencode-")
+
+
+def source_kind_from_linked_id(link: str) -> str | None:
+    """Map a ``SearchResult.linked_source_ids`` entry to a logical source family."""
+    if link.startswith("shell-"):
+        return "shell"
+    if link.startswith("browser-"):
+        return "browser"
+    if link.startswith("workflow-"):
+        return "workflow"
+    if link.startswith("memory-"):
+        return CLAUDE_AUTO_MEMORY_SOURCE
+    for prefix in _AGENTIC_LINK_PREFIXES:
+        if link.startswith(prefix):
+            return prefix.removesuffix("-")
+    return None
+
 _MEMORY_SOURCE_EXISTS = (
     "EXISTS (SELECT 1 FROM knowledge_node_memory_chunks knmc "
     "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "

--- a/brain/src/hippo_brain/source_filters.py
+++ b/brain/src/hippo_brain/source_filters.py
@@ -25,6 +25,7 @@ def source_kind_from_linked_id(link: str) -> str | None:
             return prefix.removesuffix("-")
     return None
 
+
 _MEMORY_SOURCE_EXISTS = (
     "EXISTS (SELECT 1 FROM knowledge_node_memory_chunks knmc "
     "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "

--- a/brain/src/hippo_brain/trust_eval.py
+++ b/brain/src/hippo_brain/trust_eval.py
@@ -1,0 +1,297 @@
+"""Agent-trust eval corpus loader and evidence-shape checker (SNUG-118).
+
+This module defines the regression bar for agent-trust work: each case records
+*expected evidence requirements* (source kinds, hit counts, gap semantics) rather
+than prose answers tied to a live user database.
+
+**Adding cases:** append to ``_fixtures/trust_eval_cases.json`` with a unique ``id``,
+set ``evidence.source_kinds`` to the logical families you expect in
+``SearchResult.linked_source_ids`` (``shell-``, ``claude-``, ``codex-``, etc.),
+and extend the synthetic seeder in ``brain/tests/test_trust_eval.py`` when the case
+needs an end-to-end retrieval assertion.
+
+Run offline::
+
+    hippo-trust-eval --validate
+    pytest brain/tests/test_trust_eval.py -q
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from hippo_brain.retrieval import Filters, SearchResult, search
+
+_DEFAULT_CASES = Path(__file__).parent / "_fixtures" / "trust_eval_cases.json"
+
+_REQUIRED_SOURCE_FAMILIES = frozenset(
+    {
+        "shell",
+        "claude",
+        "codex",
+        "cursor",
+        "opencode",
+        "browser",
+        "workflow",
+        "claude-auto-memory",
+    }
+)
+
+_VALID_MODES = frozenset(
+    {"what_known", "evidence_for", "recent_changes", "prior_decisions", "adversarial"}
+)
+
+
+@dataclass(frozen=True)
+class EvidenceSpec:
+    source_kinds: tuple[str, ...] = ()
+    min_hits: int = 1
+    max_hits: int | None = None
+    require_captured_at: bool = False
+    require_distinct_source_kinds: bool = False
+    exclude_probe_linkage: bool = False
+    expect_coverage_gap: bool = False
+    gap_reason_contains: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> EvidenceSpec:
+        kinds = raw.get("source_kinds") or []
+        gap = raw.get("gap_reason_contains") or []
+        return cls(
+            source_kinds=tuple(str(k) for k in kinds),
+            min_hits=int(raw.get("min_hits", 1)),
+            max_hits=raw.get("max_hits"),
+            require_captured_at=bool(raw.get("require_captured_at", False)),
+            require_distinct_source_kinds=bool(raw.get("require_distinct_source_kinds", False)),
+            exclude_probe_linkage=bool(raw.get("exclude_probe_linkage", False)),
+            expect_coverage_gap=bool(raw.get("expect_coverage_gap", False)),
+            gap_reason_contains=tuple(str(g) for g in gap),
+        )
+
+
+@dataclass(frozen=True)
+class TrustEvalCase:
+    id: str
+    question: str
+    mode: str
+    evidence: EvidenceSpec
+    source_filter: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> TrustEvalCase:
+        return cls(
+            id=str(raw["id"]),
+            question=str(raw["question"]),
+            mode=str(raw.get("mode", "what_known")),
+            source_filter=raw.get("source_filter"),
+            evidence=EvidenceSpec.from_dict(raw.get("evidence") or {}),
+        )
+
+
+@dataclass
+class EvidenceCheckResult:
+    case_id: str
+    passed: bool
+    detail: str
+
+
+def load_cases(path: Path | str | None = None) -> list[TrustEvalCase]:
+    """Load and parse trust eval cases from JSON."""
+    p = Path(path) if path is not None else _DEFAULT_CASES
+    data = json.loads(p.read_text(encoding="utf-8"))
+    return [TrustEvalCase.from_dict(c) for c in data["cases"]]
+
+
+def validate_corpus(cases: Sequence[TrustEvalCase]) -> list[str]:
+    """Return human-readable validation errors; empty list means corpus is well-formed."""
+    errors: list[str] = []
+    if len(cases) < 12:
+        errors.append(f"expected at least 12 cases, found {len(cases)}")
+
+    seen: set[str] = set()
+    covered: set[str] = set()
+    has_negative = False
+
+    for case in cases:
+        if case.id in seen:
+            errors.append(f"duplicate case id: {case.id}")
+        seen.add(case.id)
+
+        if case.mode not in _VALID_MODES:
+            errors.append(f"{case.id}: invalid mode {case.mode!r}")
+
+        if case.evidence.min_hits < 0:
+            errors.append(f"{case.id}: min_hits must be >= 0")
+        if case.evidence.max_hits is not None and case.evidence.max_hits < case.evidence.min_hits:
+            errors.append(f"{case.id}: max_hits < min_hits")
+
+        for kind in case.evidence.source_kinds:
+            covered.add(kind)
+
+        if case.evidence.expect_coverage_gap or case.mode == "adversarial":
+            has_negative = True
+
+    missing = _REQUIRED_SOURCE_FAMILIES - covered
+    if missing:
+        errors.append(f"missing source family coverage: {sorted(missing)}")
+
+    if not has_negative:
+        errors.append("corpus must include at least one negative/gap case")
+
+    return errors
+
+
+def _source_kind_from_link(link: str) -> str | None:
+    if link.startswith("shell-"):
+        return "shell"
+    if link.startswith("browser-"):
+        return "browser"
+    if link.startswith("workflow-"):
+        return "workflow"
+    if link.startswith("memory-"):
+        return "claude-auto-memory"
+    for prefix in ("claude-", "codex-", "cursor-", "opencode-"):
+        if link.startswith(prefix):
+            return prefix.removesuffix("-")
+    return None
+
+
+def kinds_in_results(results: Sequence[SearchResult]) -> set[str]:
+    kinds: set[str] = set()
+    for r in results:
+        for link in r.linked_source_ids:
+            kind = _source_kind_from_link(link)
+            if kind:
+                kinds.add(kind)
+    return kinds
+
+
+def check_evidence(
+    case: TrustEvalCase,
+    results: Sequence[SearchResult],
+    *,
+    gap_reason: str | None = None,
+) -> EvidenceCheckResult:
+    """Assert retrieval results satisfy a case's evidence requirements."""
+    spec = case.evidence
+    n = len(results)
+
+    if n < spec.min_hits:
+        return EvidenceCheckResult(
+            case.id,
+            False,
+            f"expected >= {spec.min_hits} hits, got {n}",
+        )
+    if spec.max_hits is not None and n > spec.max_hits:
+        return EvidenceCheckResult(
+            case.id,
+            False,
+            f"expected <= {spec.max_hits} hits, got {n}",
+        )
+
+    if spec.expect_coverage_gap:
+        if not gap_reason:
+            return EvidenceCheckResult(case.id, False, "expected coverage gap reason")
+        lower = gap_reason.lower()
+        if spec.gap_reason_contains and not any(
+            tok.lower() in lower for tok in spec.gap_reason_contains
+        ):
+            return EvidenceCheckResult(
+                case.id,
+                False,
+                f"gap reason {gap_reason!r} missing tokens {spec.gap_reason_contains}",
+            )
+
+    found_kinds = kinds_in_results(results)
+    for required in spec.source_kinds:
+        if required not in found_kinds:
+            return EvidenceCheckResult(
+                case.id,
+                False,
+                f"missing source kind {required!r} in {sorted(found_kinds)}",
+            )
+
+    if spec.require_distinct_source_kinds:
+        needed = set(spec.source_kinds)
+        if not needed.issubset(found_kinds):
+            return EvidenceCheckResult(
+                case.id,
+                False,
+                f"need distinct kinds {sorted(needed)}, got {sorted(found_kinds)}",
+            )
+
+    if spec.require_captured_at:
+        if not any(r.captured_at > 0 for r in results):
+            return EvidenceCheckResult(case.id, False, "no result has captured_at")
+
+    if spec.exclude_probe_linkage:
+        for r in results:
+            for link in r.linked_source_ids:
+                if "probe" in link.lower():
+                    return EvidenceCheckResult(
+                        case.id,
+                        False,
+                        f"probe linkage leaked: {link}",
+                    )
+
+    return EvidenceCheckResult(case.id, True, "ok")
+
+
+def run_case_search(
+    conn: sqlite3.Connection,
+    case: TrustEvalCase,
+    query_vec: Sequence[float],
+    *,
+    backend: Any,
+    limit: int = 5,
+) -> list[SearchResult]:
+    """Run retrieval for one trust-eval case using an injected backend."""
+    filters = Filters(source=case.source_filter) if case.source_filter else Filters()
+    return search(
+        conn,
+        case.question,
+        query_vec,
+        filters,
+        mode="hybrid",
+        limit=limit,
+        backend=backend,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="hippo-trust-eval", description="Agent-trust eval corpus")
+    parser.add_argument(
+        "--cases",
+        default=str(_DEFAULT_CASES),
+        help="Path to trust_eval_cases.json",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate corpus schema and coverage (offline, no DB required)",
+    )
+    args = parser.parse_args(argv)
+
+    cases = load_cases(args.cases)
+    errors = validate_corpus(cases)
+    if errors:
+        for err in errors:
+            print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    print(f"ok: {len(cases)} trust eval cases validated")
+    if not args.validate:
+        print(
+            "hint: use --validate (default) or pytest brain/tests/test_trust_eval.py for retrieval checks"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brain/src/hippo_brain/trust_eval.py
+++ b/brain/src/hippo_brain/trust_eval.py
@@ -34,7 +34,7 @@ from hippo_brain.source_filters import source_kind_from_linked_id
 
 _DEFAULT_CASES = Path(__file__).parent / "_fixtures" / "trust_eval_cases.json"
 _EXPECTED_SCHEMA_VERSION = 1
-_MIN_ACTIVE_CASES = 12
+_MIN_CORPUS_CASES = 12
 
 # Enforced on non-pending cases only (claude-auto-memory pending until retrieval
 # hydrates memory linked_source_ids).
@@ -134,13 +134,11 @@ def load_cases(path: Path | str | None = None) -> list[TrustEvalCase]:
 def validate_corpus(cases: Sequence[TrustEvalCase]) -> list[str]:
     """Return human-readable validation errors; empty list means corpus is well-formed."""
     errors: list[str] = []
-    active = [c for c in cases if not c.pending]
-    if len(cases) < _MIN_ACTIVE_CASES:
-        errors.append(f"expected at least {_MIN_ACTIVE_CASES} cases, found {len(cases)}")
+    if len(cases) < _MIN_CORPUS_CASES:
+        errors.append(f"expected at least {_MIN_CORPUS_CASES} cases, found {len(cases)}")
 
     seen: set[str] = set()
     covered: set[str] = set()
-    has_negative_doc = False
 
     for case in cases:
         if case.id in seen:
@@ -153,8 +151,6 @@ def validate_corpus(cases: Sequence[TrustEvalCase]) -> list[str]:
             errors.append(f"{case.id}: max_hits < min_hits")
 
         if case.pending:
-            if case.evidence.expect_coverage_gap or case.mode == "adversarial":
-                has_negative_doc = True
             continue
 
         for kind in case.evidence.source_kinds:
@@ -164,13 +160,10 @@ def validate_corpus(cases: Sequence[TrustEvalCase]) -> list[str]:
     if missing:
         errors.append(f"missing active source family coverage: {sorted(missing)}")
 
-    pending_negative = any(
-        c.pending and (c.evidence.expect_coverage_gap or c.mode == "adversarial") for c in cases
+    has_negative_doc = any(
+        c.evidence.expect_coverage_gap or c.mode == "adversarial" for c in cases
     )
-    active_negative = any(
-        (not c.pending) and c.evidence.expect_coverage_gap for c in active
-    )
-    if not (has_negative_doc or pending_negative or active_negative):
+    if not has_negative_doc:
         errors.append("corpus must document at least one negative/gap case (pending ok)")
 
     return errors

--- a/brain/src/hippo_brain/trust_eval.py
+++ b/brain/src/hippo_brain/trust_eval.py
@@ -1,18 +1,21 @@
 """Agent-trust eval corpus loader and evidence-shape checker (SNUG-118).
 
 This module defines the regression bar for agent-trust work: each case records
-*expected evidence requirements* (source kinds, hit counts, gap semantics) rather
-than prose answers tied to a live user database.
+*expected evidence requirements* (source kinds, hit counts) rather than prose
+answers tied to a live user database.
 
-**Adding cases:** append to ``_fixtures/trust_eval_cases.json`` with a unique ``id``,
-set ``evidence.source_kinds`` to the logical families you expect in
-``SearchResult.linked_source_ids`` (``shell-``, ``claude-``, ``codex-``, etc.),
-and extend the synthetic seeder in ``brain/tests/test_trust_eval.py`` when the case
-needs an end-to-end retrieval assertion.
+Cases marked ``"pending": true`` document future trust behavior (gap synthesis,
+auto-memory linkage) but are excluded from the enforced retrieval regression
+subset until later roadmap steps wire those paths.
+
+**Adding cases:** append to ``_fixtures/trust_eval_cases.json`` with a unique
+``id``, set ``evidence.source_kinds`` to logical families from
+:func:`hippo_brain.source_filters.source_kind_from_linked_id`, and extend the
+synthetic seeder in ``brain/tests/test_trust_eval.py`` for end-to-end checks.
 
 Run offline::
 
-    hippo-trust-eval --validate
+    hippo-trust-eval
     pytest brain/tests/test_trust_eval.py -q
 """
 
@@ -24,12 +27,17 @@ import sqlite3
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Protocol, Sequence
 
 from hippo_brain.retrieval import Filters, SearchResult, search
+from hippo_brain.source_filters import source_kind_from_linked_id
 
 _DEFAULT_CASES = Path(__file__).parent / "_fixtures" / "trust_eval_cases.json"
+_EXPECTED_SCHEMA_VERSION = 1
+_MIN_ACTIVE_CASES = 12
 
+# Enforced on non-pending cases only (claude-auto-memory pending until retrieval
+# hydrates memory linked_source_ids).
 _REQUIRED_SOURCE_FAMILIES = frozenset(
     {
         "shell",
@@ -39,13 +47,25 @@ _REQUIRED_SOURCE_FAMILIES = frozenset(
         "opencode",
         "browser",
         "workflow",
-        "claude-auto-memory",
     }
 )
 
-_VALID_MODES = frozenset(
-    {"what_known", "evidence_for", "recent_changes", "prior_decisions", "adversarial"}
-)
+
+class _SearchBackend(Protocol):
+    def knn_search(
+        self,
+        conn: sqlite3.Connection,
+        query_vec: Sequence[float],
+        column: str = ...,
+        limit: int = ...,
+    ) -> list[dict]: ...
+
+    def fts_search(
+        self,
+        conn: sqlite3.Connection,
+        query: str,
+        limit: int = ...,
+    ) -> list[dict]: ...
 
 
 @dataclass(frozen=True)
@@ -54,8 +74,7 @@ class EvidenceSpec:
     min_hits: int = 1
     max_hits: int | None = None
     require_captured_at: bool = False
-    require_distinct_source_kinds: bool = False
-    exclude_probe_linkage: bool = False
+    min_distinct_source_kinds: int = 0
     expect_coverage_gap: bool = False
     gap_reason_contains: tuple[str, ...] = ()
 
@@ -68,8 +87,7 @@ class EvidenceSpec:
             min_hits=int(raw.get("min_hits", 1)),
             max_hits=raw.get("max_hits"),
             require_captured_at=bool(raw.get("require_captured_at", False)),
-            require_distinct_source_kinds=bool(raw.get("require_distinct_source_kinds", False)),
-            exclude_probe_linkage=bool(raw.get("exclude_probe_linkage", False)),
+            min_distinct_source_kinds=int(raw.get("min_distinct_source_kinds", 0)),
             expect_coverage_gap=bool(raw.get("expect_coverage_gap", False)),
             gap_reason_contains=tuple(str(g) for g in gap),
         )
@@ -79,17 +97,19 @@ class EvidenceSpec:
 class TrustEvalCase:
     id: str
     question: str
-    mode: str
     evidence: EvidenceSpec
     source_filter: str | None = None
+    pending: bool = False
+    mode: str | None = None
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> TrustEvalCase:
         return cls(
             id=str(raw["id"]),
             question=str(raw["question"]),
-            mode=str(raw.get("mode", "what_known")),
             source_filter=raw.get("source_filter"),
+            pending=bool(raw.get("pending", False)),
+            mode=raw.get("mode"),
             evidence=EvidenceSpec.from_dict(raw.get("evidence") or {}),
         )
 
@@ -105,68 +125,62 @@ def load_cases(path: Path | str | None = None) -> list[TrustEvalCase]:
     """Load and parse trust eval cases from JSON."""
     p = Path(path) if path is not None else _DEFAULT_CASES
     data = json.loads(p.read_text(encoding="utf-8"))
+    if data.get("schema_version") != _EXPECTED_SCHEMA_VERSION:
+        msg = f"unsupported schema_version {data.get('schema_version')!r}"
+        raise ValueError(msg)
     return [TrustEvalCase.from_dict(c) for c in data["cases"]]
 
 
 def validate_corpus(cases: Sequence[TrustEvalCase]) -> list[str]:
     """Return human-readable validation errors; empty list means corpus is well-formed."""
     errors: list[str] = []
-    if len(cases) < 12:
-        errors.append(f"expected at least 12 cases, found {len(cases)}")
+    active = [c for c in cases if not c.pending]
+    if len(cases) < _MIN_ACTIVE_CASES:
+        errors.append(f"expected at least {_MIN_ACTIVE_CASES} cases, found {len(cases)}")
 
     seen: set[str] = set()
     covered: set[str] = set()
-    has_negative = False
+    has_negative_doc = False
 
     for case in cases:
         if case.id in seen:
             errors.append(f"duplicate case id: {case.id}")
         seen.add(case.id)
 
-        if case.mode not in _VALID_MODES:
-            errors.append(f"{case.id}: invalid mode {case.mode!r}")
-
         if case.evidence.min_hits < 0:
             errors.append(f"{case.id}: min_hits must be >= 0")
         if case.evidence.max_hits is not None and case.evidence.max_hits < case.evidence.min_hits:
             errors.append(f"{case.id}: max_hits < min_hits")
 
+        if case.pending:
+            if case.evidence.expect_coverage_gap or case.mode == "adversarial":
+                has_negative_doc = True
+            continue
+
         for kind in case.evidence.source_kinds:
             covered.add(kind)
 
-        if case.evidence.expect_coverage_gap or case.mode == "adversarial":
-            has_negative = True
-
     missing = _REQUIRED_SOURCE_FAMILIES - covered
     if missing:
-        errors.append(f"missing source family coverage: {sorted(missing)}")
+        errors.append(f"missing active source family coverage: {sorted(missing)}")
 
-    if not has_negative:
-        errors.append("corpus must include at least one negative/gap case")
+    pending_negative = any(
+        c.pending and (c.evidence.expect_coverage_gap or c.mode == "adversarial") for c in cases
+    )
+    active_negative = any(
+        (not c.pending) and c.evidence.expect_coverage_gap for c in active
+    )
+    if not (has_negative_doc or pending_negative or active_negative):
+        errors.append("corpus must document at least one negative/gap case (pending ok)")
 
     return errors
-
-
-def _source_kind_from_link(link: str) -> str | None:
-    if link.startswith("shell-"):
-        return "shell"
-    if link.startswith("browser-"):
-        return "browser"
-    if link.startswith("workflow-"):
-        return "workflow"
-    if link.startswith("memory-"):
-        return "claude-auto-memory"
-    for prefix in ("claude-", "codex-", "cursor-", "opencode-"):
-        if link.startswith(prefix):
-            return prefix.removesuffix("-")
-    return None
 
 
 def kinds_in_results(results: Sequence[SearchResult]) -> set[str]:
     kinds: set[str] = set()
     for r in results:
         for link in r.linked_source_ids:
-            kind = _source_kind_from_link(link)
+            kind = source_kind_from_linked_id(link)
             if kind:
                 kinds.add(kind)
     return kinds
@@ -217,28 +231,17 @@ def check_evidence(
                 f"missing source kind {required!r} in {sorted(found_kinds)}",
             )
 
-    if spec.require_distinct_source_kinds:
-        needed = set(spec.source_kinds)
-        if not needed.issubset(found_kinds):
-            return EvidenceCheckResult(
-                case.id,
-                False,
-                f"need distinct kinds {sorted(needed)}, got {sorted(found_kinds)}",
-            )
+    if spec.min_distinct_source_kinds > 0 and len(found_kinds) < spec.min_distinct_source_kinds:
+        return EvidenceCheckResult(
+            case.id,
+            False,
+            f"expected >= {spec.min_distinct_source_kinds} distinct source kinds, "
+            f"got {sorted(found_kinds)}",
+        )
 
     if spec.require_captured_at:
         if not any(r.captured_at > 0 for r in results):
             return EvidenceCheckResult(case.id, False, "no result has captured_at")
-
-    if spec.exclude_probe_linkage:
-        for r in results:
-            for link in r.linked_source_ids:
-                if "probe" in link.lower():
-                    return EvidenceCheckResult(
-                        case.id,
-                        False,
-                        f"probe linkage leaked: {link}",
-                    )
 
     return EvidenceCheckResult(case.id, True, "ok")
 
@@ -248,7 +251,7 @@ def run_case_search(
     case: TrustEvalCase,
     query_vec: Sequence[float],
     *,
-    backend: Any,
+    backend: _SearchBackend,
     limit: int = 5,
 ) -> list[SearchResult]:
     """Run retrieval for one trust-eval case using an injected backend."""
@@ -265,31 +268,32 @@ def run_case_search(
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="hippo-trust-eval", description="Agent-trust eval corpus")
+    parser = argparse.ArgumentParser(
+        prog="hippo-trust-eval",
+        description="Validate agent-trust eval corpus (offline, no DB required)",
+    )
     parser.add_argument(
         "--cases",
         default=str(_DEFAULT_CASES),
         help="Path to trust_eval_cases.json",
     )
-    parser.add_argument(
-        "--validate",
-        action="store_true",
-        help="Validate corpus schema and coverage (offline, no DB required)",
-    )
     args = parser.parse_args(argv)
 
-    cases = load_cases(args.cases)
+    try:
+        cases = load_cases(args.cases)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
     errors = validate_corpus(cases)
     if errors:
         for err in errors:
             print(f"error: {err}", file=sys.stderr)
         return 1
 
-    print(f"ok: {len(cases)} trust eval cases validated")
-    if not args.validate:
-        print(
-            "hint: use --validate (default) or pytest brain/tests/test_trust_eval.py for retrieval checks"
-        )
+    active = sum(1 for c in cases if not c.pending)
+    pending = len(cases) - active
+    print(f"ok: {len(cases)} trust eval cases validated ({active} active, {pending} pending)")
     return 0
 
 

--- a/brain/src/hippo_brain/trust_eval.py
+++ b/brain/src/hippo_brain/trust_eval.py
@@ -160,9 +160,7 @@ def validate_corpus(cases: Sequence[TrustEvalCase]) -> list[str]:
     if missing:
         errors.append(f"missing active source family coverage: {sorted(missing)}")
 
-    has_negative_doc = any(
-        c.evidence.expect_coverage_gap or c.mode == "adversarial" for c in cases
-    )
+    has_negative_doc = any(c.evidence.expect_coverage_gap or c.mode == "adversarial" for c in cases)
     if not has_negative_doc:
         errors.append("corpus must document at least one negative/gap case (pending ok)")
 

--- a/brain/tests/retrieval_fixtures.py
+++ b/brain/tests/retrieval_fixtures.py
@@ -1,0 +1,104 @@
+"""Shared in-memory schema and fake vector backend for retrieval unit tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+TRUST_EVAL_SCHEMA = """
+CREATE TABLE knowledge_nodes (
+    id INTEGER PRIMARY KEY,
+    uuid TEXT NOT NULL,
+    content TEXT NOT NULL,
+    embed_text TEXT NOT NULL,
+    node_type TEXT NOT NULL DEFAULT 'observation',
+    outcome TEXT,
+    tags TEXT,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE events (
+    id INTEGER PRIMARY KEY,
+    timestamp INTEGER NOT NULL,
+    cwd TEXT NOT NULL,
+    git_repo TEXT,
+    git_branch TEXT
+);
+CREATE TABLE knowledge_node_events (
+    knowledge_node_id INTEGER NOT NULL,
+    event_id INTEGER NOT NULL,
+    PRIMARY KEY (knowledge_node_id, event_id)
+);
+CREATE TABLE agentic_sessions (
+    id INTEGER PRIMARY KEY,
+    harness TEXT NOT NULL DEFAULT 'claude-code',
+    start_time INTEGER NOT NULL,
+    cwd TEXT NOT NULL,
+    project_dir TEXT,
+    git_branch TEXT,
+    probe_tag TEXT
+);
+CREATE TABLE knowledge_node_agentic_sessions (
+    knowledge_node_id INTEGER NOT NULL,
+    agentic_session_id INTEGER NOT NULL,
+    PRIMARY KEY (knowledge_node_id, agentic_session_id)
+);
+CREATE TABLE browser_events (
+    id INTEGER PRIMARY KEY,
+    timestamp INTEGER NOT NULL,
+    probe_tag TEXT
+);
+CREATE TABLE workflow_runs (
+    id INTEGER PRIMARY KEY,
+    repo TEXT,
+    head_sha TEXT
+);
+CREATE TABLE knowledge_node_browser_events (
+    knowledge_node_id INTEGER NOT NULL,
+    browser_event_id INTEGER NOT NULL,
+    PRIMARY KEY (knowledge_node_id, browser_event_id)
+);
+CREATE TABLE entities (
+    id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL,
+    name TEXT NOT NULL,
+    canonical TEXT
+);
+CREATE TABLE knowledge_node_entities (
+    knowledge_node_id INTEGER NOT NULL,
+    entity_id INTEGER NOT NULL,
+    PRIMARY KEY (knowledge_node_id, entity_id)
+);
+CREATE TABLE knowledge_node_workflow_runs (
+    knowledge_node_id INTEGER NOT NULL,
+    run_id INTEGER NOT NULL,
+    PRIMARY KEY (knowledge_node_id, run_id)
+);
+"""
+
+
+@dataclass
+class FakeBackend:
+    """Injectable backend matching :mod:`hippo_brain.vector_store` shape."""
+
+    knn: list[tuple[int, float]] = field(default_factory=list)
+    fts: list[tuple[int, float]] = field(default_factory=list)
+
+    def knn_search(self, _conn, _query_vec, column="vec_knowledge", limit=10):
+        assert column in {"vec_knowledge", "vec_command"}
+        return [
+            {
+                "knowledge_node_id": nid,
+                "distance": dist,
+                "score": max(0.0, 1.0 - dist / 2.0),
+            }
+            for nid, dist in self.knn[:limit]
+        ]
+
+    def fts_search(self, _conn, _query, limit=10):
+        return [
+            {
+                "knowledge_node_id": nid,
+                "bm25": bm25,
+                "score": 1.0 / (1.0 + abs(bm25)),
+            }
+            for nid, bm25 in self.fts[:limit]
+        ]

--- a/brain/tests/test_trust_eval.py
+++ b/brain/tests/test_trust_eval.py
@@ -35,20 +35,48 @@ def test_default_corpus_validates():
     errors = validate_corpus(cases)
     assert errors == [], errors
     assert len(cases) >= 12
+    assert any(c.pending for c in cases)
 
 
-def test_corpus_covers_required_families():
-    cases = load_cases()
-    kinds: set[str] = set()
-    for case in cases:
-        kinds.update(case.evidence.source_kinds)
-    assert "shell" in kinds
-    assert "browser" in kinds
-    assert "workflow" in kinds
-    assert "codex" in kinds
-    assert "cursor" in kinds
-    assert "opencode" in kinds
-    assert "claude-auto-memory" in kinds
+def test_check_evidence_min_distinct_kinds():
+    case = TrustEvalCase.from_dict(
+        {
+            "id": "t",
+            "question": "q",
+            "evidence": {
+                "source_kinds": ["shell", "browser"],
+                "min_hits": 2,
+                "min_distinct_source_kinds": 2,
+            },
+        }
+    )
+    results = [
+        SearchResult(
+            uuid="a",
+            score=0.9,
+            summary="s",
+            embed_text="e",
+            outcome=None,
+            tags=[],
+            cwd="/p",
+            git_branch="main",
+            captured_at=1,
+            linked_source_ids=["shell-1"],
+        ),
+        SearchResult(
+            uuid="b",
+            score=0.8,
+            summary="s",
+            embed_text="e",
+            outcome=None,
+            tags=[],
+            cwd="/p",
+            git_branch="main",
+            captured_at=1,
+            linked_source_ids=["browser-2"],
+        ),
+    ]
+    assert check_evidence(case, results).passed
 
 
 def test_check_evidence_positive():
@@ -56,7 +84,6 @@ def test_check_evidence_positive():
         {
             "id": "t",
             "question": "q",
-            "mode": "what_known",
             "evidence": {"source_kinds": ["shell"], "min_hits": 1, "require_captured_at": True},
         }
     )

--- a/brain/tests/test_trust_eval.py
+++ b/brain/tests/test_trust_eval.py
@@ -1,0 +1,224 @@
+"""Tests for agent-trust eval corpus (SNUG-118)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+
+import pytest
+
+from hippo_brain.retrieval import SearchResult
+from hippo_brain.trust_eval import (
+    TrustEvalCase,
+    check_evidence,
+    kinds_in_results,
+    load_cases,
+    run_case_search,
+    validate_corpus,
+)
+
+# Reuse retrieval test schema shape.
+from tests.test_retrieval import SCHEMA, FakeBackend
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.executescript(SCHEMA)
+    c.commit()
+    return c
+
+
+def test_default_corpus_validates():
+    cases = load_cases()
+    errors = validate_corpus(cases)
+    assert errors == [], errors
+    assert len(cases) >= 12
+
+
+def test_corpus_covers_required_families():
+    cases = load_cases()
+    kinds: set[str] = set()
+    for case in cases:
+        kinds.update(case.evidence.source_kinds)
+    assert "shell" in kinds
+    assert "browser" in kinds
+    assert "workflow" in kinds
+    assert "codex" in kinds
+    assert "cursor" in kinds
+    assert "opencode" in kinds
+    assert "claude-auto-memory" in kinds
+
+
+def test_check_evidence_positive():
+    case = TrustEvalCase.from_dict(
+        {
+            "id": "t",
+            "question": "q",
+            "mode": "what_known",
+            "evidence": {"source_kinds": ["shell"], "min_hits": 1, "require_captured_at": True},
+        }
+    )
+    results = [
+        SearchResult(
+            uuid="u",
+            score=0.9,
+            summary="s",
+            embed_text="e",
+            outcome=None,
+            tags=[],
+            cwd="/p",
+            git_branch="main",
+            captured_at=1_700_000_000_000,
+            linked_source_ids=["shell-1"],
+        )
+    ]
+    out = check_evidence(case, results)
+    assert out.passed, out.detail
+
+
+def test_check_evidence_negative_gap():
+    case = TrustEvalCase.from_dict(
+        {
+            "id": "t",
+            "question": "q",
+            "mode": "adversarial",
+            "evidence": {
+                "min_hits": 0,
+                "max_hits": 0,
+                "expect_coverage_gap": True,
+                "gap_reason_contains": ["no evidence"],
+            },
+        }
+    )
+    out = check_evidence(case, [], gap_reason="no evidence in corpus for this claim")
+    assert out.passed, out.detail
+
+
+def _insert_node(
+    conn: sqlite3.Connection,
+    node_id: int,
+    *,
+    uuid: str = "uuid",
+    created_at: int = 1_700_000_000_000,
+) -> None:
+    conn.execute(
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, created_at) "
+        "VALUES (?, ?, ?, ?, 'observation', ?)",
+        (node_id, uuid, json.dumps({"summary": "s"}), "embed", created_at),
+    )
+
+
+def _link_shell(conn: sqlite3.Connection, node_id: int, event_id: int, ts: int) -> None:
+    conn.execute(
+        "INSERT INTO events (id, timestamp, cwd, git_branch) VALUES (?, ?, '/hippo', 'main')",
+        (event_id, ts),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (?, ?)",
+        (node_id, event_id),
+    )
+
+
+def _link_agentic(
+    conn: sqlite3.Connection,
+    node_id: int,
+    session_id: int,
+    harness: str,
+    *,
+    probe_tag: str | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO agentic_sessions (id, harness, start_time, cwd, probe_tag) "
+        "VALUES (?, ?, ?, '/hippo', ?)",
+        (session_id, harness, 1_700_000_000_000, probe_tag),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_agentic_sessions (knowledge_node_id, agentic_session_id) "
+        "VALUES (?, ?)",
+        (node_id, session_id),
+    )
+
+
+def _link_browser(conn: sqlite3.Connection, node_id: int, event_id: int) -> None:
+    conn.execute(
+        "INSERT INTO browser_events (id, timestamp, probe_tag) VALUES (?, ?, NULL)",
+        (event_id, 1_700_000_000_000),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_browser_events (knowledge_node_id, browser_event_id) "
+        "VALUES (?, ?)",
+        (node_id, event_id),
+    )
+
+
+def _link_workflow(conn: sqlite3.Connection, node_id: int, run_id: int) -> None:
+    conn.execute(
+        "INSERT INTO workflow_runs (id, repo, head_sha) VALUES (?, 'hippo', 'abc')", (run_id,)
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_workflow_runs (knowledge_node_id, run_id) VALUES (?, ?)",
+        (node_id, run_id),
+    )
+
+
+@dataclass
+class _Vec:
+    v: list[float] = field(default_factory=lambda: [0.1] * 8)
+
+
+@pytest.mark.parametrize(
+    ("case_id", "setup"),
+    [
+        ("trust-shell-01", lambda c: _link_shell(c, 1, 10, 1_700_000_000_000)),
+        ("trust-claude-01", lambda c: _link_agentic(c, 1, 20, "claude-code")),
+        ("trust-codex-01", lambda c: _link_agentic(c, 1, 21, "codex")),
+        ("trust-cursor-01", lambda c: _link_agentic(c, 1, 22, "cursor")),
+        ("trust-opencode-01", lambda c: _link_agentic(c, 1, 23, "opencode")),
+        ("trust-browser-01", lambda c: _link_browser(c, 1, 30)),
+        ("trust-workflow-01", lambda c: _link_workflow(c, 1, 40)),
+    ],
+)
+def test_trust_eval_retrieval_evidence(conn: sqlite3.Connection, case_id: str, setup) -> None:
+    _insert_node(conn, 1)
+    setup(conn)
+    conn.commit()
+
+    case = next(c for c in load_cases() if c.id == case_id)
+    backend = FakeBackend(knn=[(1, 0.95)], fts=[(1, 0.9)])
+    results = run_case_search(conn, case, _Vec().v, backend=backend, limit=5)
+    check = check_evidence(case, results)
+    assert check.passed, check.detail
+    assert kinds_in_results(results)
+
+
+def test_probe_sessions_excluded_from_claude_filter(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 1)
+    _insert_node(conn, 2, uuid="real")
+    _link_agentic(conn, 1, 50, "claude-code", probe_tag="probe-canary")
+    _link_agentic(conn, 2, 51, "claude-code")
+    conn.commit()
+
+    case = next(c for c in load_cases() if c.id == "trust-probe-exclude-01")
+    backend = FakeBackend(knn=[(1, 0.9), (2, 0.85)], fts=[(2, 0.95), (1, 0.5)])
+    results = run_case_search(conn, case, _Vec().v, backend=backend, limit=5)
+    # Source filter should exclude probe-linked node when hydration respects probe_tag.
+    kinds = kinds_in_results(results)
+    assert "claude" in kinds
+    check = check_evidence(case, results)
+    assert check.passed, check.detail
+
+
+def test_mixed_source_case(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 1)
+    _insert_node(conn, 2, uuid="b")
+    _link_shell(conn, 1, 60, 1_700_000_000_000)
+    _link_browser(conn, 2, 61)
+    conn.commit()
+
+    case = next(c for c in load_cases() if c.id == "trust-mixed-01")
+    backend = FakeBackend(knn=[(1, 0.9), (2, 0.88)], fts=[(1, 0.8), (2, 0.85)])
+    results = run_case_search(conn, case, _Vec().v, backend=backend, limit=5)
+    check = check_evidence(case, results)
+    assert check.passed, check.detail

--- a/brain/tests/test_trust_eval.py
+++ b/brain/tests/test_trust_eval.py
@@ -18,14 +18,13 @@ from hippo_brain.trust_eval import (
     validate_corpus,
 )
 
-# Reuse retrieval test schema shape.
-from tests.test_retrieval import SCHEMA, FakeBackend
+from tests.retrieval_fixtures import TRUST_EVAL_SCHEMA, FakeBackend
 
 
 @pytest.fixture
 def conn() -> sqlite3.Connection:
     c = sqlite3.connect(":memory:")
-    c.executescript(SCHEMA)
+    c.executescript(TRUST_EVAL_SCHEMA)
     c.commit()
     return c
 
@@ -230,7 +229,8 @@ def test_probe_sessions_excluded_from_claude_filter(conn: sqlite3.Connection) ->
     case = next(c for c in load_cases() if c.id == "trust-probe-exclude-01")
     backend = FakeBackend(knn=[(1, 0.9), (2, 0.85)], fts=[(2, 0.95), (1, 0.5)])
     results = run_case_search(conn, case, _Vec().v, backend=backend, limit=5)
-    # Source filter should exclude probe-linked node when hydration respects probe_tag.
+    assert len(results) == 1
+    assert results[0].uuid == "real"
     kinds = kinds_in_results(results)
     assert "claude" in kinds
     check = check_evidence(case, results)


### PR DESCRIPTION
## Summary
- Add versioned `trust_eval_cases.json` corpus (14 cases: 9 active retrieval regressions, 5 pending for gap/auto-memory/docs paths)
- Add `hippo-trust-eval` CLI and `trust_eval.py` loader/validator/evidence checker
- Canonicalize `source_kind_from_linked_id` in `source_filters.py` for corpus + retrieval
- Synthetic e2e tests per active source family (shell, claude/codex/cursor/opencode, browser, workflow, mixed, probe exclusion)

## Test plan
- [x] `uv run --project brain pytest brain/tests/test_trust_eval.py -v`
- [x] `uv run --project brain hippo-trust-eval`
- [x] `uv run --project brain ruff check brain/`

Linear: SNUG-118