### PR TITLE
feat(brain): centralize retrieval eligibility policy (SNUG-121)

### DIFF
--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -16,7 +16,6 @@ from hippo_brain.embeddings import (
     _pad_or_truncate,
     get_or_create_table,
     open_vector_db,
-    search_similar,
 )
 from hippo_brain.mcp_logging import setup_logging
 from hippo_brain.mcp_queries import (
@@ -28,7 +27,6 @@ from hippo_brain.mcp_queries import (
     list_projects_impl,
     search_events_impl,
     search_knowledge_lexical,
-    shape_semantic_results,
 )
 from hippo_brain.rag import ask as rag_ask, format_rag_response
 from hippo_brain.retrieval_eligibility import include_excluded_from_env
@@ -234,23 +232,18 @@ async def search_knowledge(
     )
     with span_ctx:
         try:
-            if (
-                mode == "semantic"
-                and _state.inference_client
-                and _state.vector_table
-                and not (project or since or source or branch)
-            ):
+            if mode == "semantic" and _state.inference_client:
                 try:
-                    vecs = await _state.inference_client.embed(
-                        [query], model=_state.embedding_model
+                    results = await _retrieve_filtered(
+                        query=query,
+                        mode="semantic",
+                        limit=limit,
+                        project=project,
+                        since=since,
+                        source=source,
+                        branch=branch,
+                        include_excluded=include_excluded,
                     )
-                    query_vec = _pad_or_truncate(vecs[0], EMBED_DIM)
-                    hits = search_similar(_state.vector_table, query_vec, limit=limit)
-                    conn = _get_conn()
-                    try:
-                        results = shape_semantic_results(hits, conn=conn)
-                    finally:
-                        conn.close()
                     elapsed = time.monotonic() - t0
                     _hist(_tool_duration, elapsed * 1000, tool="search_knowledge")
                     logger.info(
@@ -262,7 +255,7 @@ async def search_knowledge(
                 except Exception:
                     logger.exception("Semantic search failed, falling back to lexical")
 
-            # Lexical search (explicit mode or fallback, or when filters are applied)
+            # Lexical search (explicit mode or fallback)
             conn = _get_conn()
             try:
                 results = search_knowledge_lexical(

--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -19,7 +19,6 @@ from hippo_brain.embeddings import (
     search_similar,
 )
 from hippo_brain.mcp_logging import setup_logging
-from hippo_brain.telemetry import add as _add, get_meter, hist as _hist
 from hippo_brain.mcp_queries import (
     MAX_LIMIT,
     format_context_block,
@@ -32,8 +31,9 @@ from hippo_brain.mcp_queries import (
     shape_semantic_results,
 )
 from hippo_brain.rag import ask as rag_ask, format_rag_response
+from hippo_brain.retrieval_eligibility import include_excluded_from_env
 from hippo_brain.schema_version import require_accepted_schema
-from hippo_brain.telemetry import get_tracer as _get_tracer
+from hippo_brain.telemetry import add as _add, get_meter, get_tracer as _get_tracer, hist as _hist
 
 logger = setup_logging("hippo-mcp")
 
@@ -190,6 +190,7 @@ async def search_knowledge(
     since: str = "",
     source: str = "",
     branch: str = "",
+    include_excluded: bool = False,
 ) -> list[dict]:
     """Search the Hippo knowledge base for enriched knowledge nodes.
 
@@ -204,7 +205,9 @@ async def search_knowledge(
                 "claude", "browser", "workflow", or "claude-auto-memory".
                 Empty means all sources; an unrecognized source raises.
         branch: Exact match on git_branch of linked events/sessions.
+        include_excluded: Operator mode — include probe/diagnostic rows (default false).
     """
+    include_excluded = include_excluded or include_excluded_from_env()
     limit = _clamp_limit(limit)
     _add(_tool_calls, tool="search_knowledge")
     t0 = time.monotonic()
@@ -270,6 +273,7 @@ async def search_knowledge(
                     since=since,
                     source=source,
                     branch=branch,
+                    include_excluded=include_excluded,
                 )
             finally:
                 conn.close()
@@ -297,6 +301,7 @@ async def ask(
     since: str = "",
     source: str = "",
     branch: str = "",
+    include_excluded: bool = False,
 ) -> str:
     """Ask a question and get a synthesized answer from your knowledge base.
 
@@ -315,7 +320,9 @@ async def ask(
         source: Restrict to nodes linked to "shell", "claude", "browser",
                 or "workflow". Empty means all sources.
         branch: Exact match on git_branch of linked events/sessions.
+        include_excluded: Operator mode — include probe/diagnostic rows (default false).
     """
+    include_excluded = include_excluded or include_excluded_from_env()
     limit = _clamp_limit(limit)
     _add(_tool_calls, tool="ask")
     t0 = time.monotonic()
@@ -349,6 +356,7 @@ async def ask(
             since=since_ms,
             source=source or None,
             branch=branch or None,
+            include_excluded=include_excluded,
             conn=conn,
         )
     except Exception:
@@ -614,6 +622,7 @@ async def _retrieve_filtered(
     source: str,
     branch: str,
     entity: str = "",
+    include_excluded: bool = False,
 ) -> list[dict]:
     """Run a filtered retrieval, returning SearchResult-shaped dicts.
 
@@ -630,6 +639,7 @@ async def _retrieve_filtered(
         source=source or None,
         branch=branch or None,
         entity=entity or None,
+        include_excluded=include_excluded or include_excluded_from_env(),
     )
 
     query_vec = None
@@ -655,6 +665,7 @@ async def _retrieve_filtered(
                 since=since,
                 source=source,
                 branch=branch,
+                include_excluded=filters.include_excluded,
             )
     finally:
         conn.close()

--- a/brain/src/hippo_brain/mcp_queries.py
+++ b/brain/src/hippo_brain/mcp_queries.py
@@ -198,7 +198,7 @@ def _build_knowledge_filter_clause(
                 f" OR EXISTS (SELECT 1 FROM {link_table} links "
                 f"  JOIN {session_table} s ON s.id = links.{link_column} "
                 "  WHERE links.knowledge_node_id = kn.id "
-                f"    AND {agentic_session_eligible_sql('s')} "
+                f"    AND {agentic_session_eligible_sql('s', include_excluded=include_excluded)} "
                 "    AND (s.cwd LIKE ? OR s.project_dir LIKE ?))"
             )
             params.extend([like, like])
@@ -221,7 +221,7 @@ def _build_knowledge_filter_clause(
                 f" OR EXISTS (SELECT 1 FROM {link_table} links "
                 f"  JOIN {session_table} s ON s.id = links.{link_column} "
                 "  WHERE links.knowledge_node_id = kn.id "
-                f"    AND {agentic_session_eligible_sql('s')} AND s.git_branch = ?)"
+                f"    AND {agentic_session_eligible_sql('s', include_excluded=include_excluded)} AND s.git_branch = ?)"
             )
             params.append(branch)
         branch_clause += ")"
@@ -234,6 +234,7 @@ def _build_knowledge_filter_clause(
             claude_link_table=link_table,
             claude_link_column=link_column,
             claude_session_table=session_table,
+            include_excluded=include_excluded,
         )
         if source_clause is None:
             # Mirror retrieval._apply_filters: an unrecognized (or unavailable)

--- a/brain/src/hippo_brain/mcp_queries.py
+++ b/brain/src/hippo_brain/mcp_queries.py
@@ -11,6 +11,10 @@ import time
 from datetime import datetime, timezone
 
 from hippo_brain.models import CIAnnotation, CIJob, CIStatus, Lesson
+from hippo_brain.retrieval_eligibility import (
+    agentic_session_eligible_sql,
+    knowledge_node_eligible_exists_sql,
+)
 from hippo_brain.source_filters import (
     knowledge_memory_project_clause,
     knowledge_source_exists_clause,
@@ -157,6 +161,8 @@ def _build_knowledge_filter_clause(
     since_ms: int,
     source: str,
     branch: str,
+    *,
+    include_excluded: bool = False,
 ) -> tuple[str, list]:
     """Compose a WHERE-fragment + params for knowledge_nodes filter columns.
 
@@ -166,6 +172,13 @@ def _build_knowledge_filter_clause(
     clauses: list[str] = []
     params: list = []
     link_table, link_column, session_table = _agentic_link_target(conn)
+
+    if not include_excluded:
+        elig_sql, elig_params = knowledge_node_eligible_exists_sql(
+            conn, "kn.id", include_excluded=False
+        )
+        clauses.append(elig_sql)
+        params.extend(elig_params)
 
     if since_ms:
         clauses.append("kn.created_at >= ?")
@@ -185,7 +198,7 @@ def _build_knowledge_filter_clause(
                 f" OR EXISTS (SELECT 1 FROM {link_table} links "
                 f"  JOIN {session_table} s ON s.id = links.{link_column} "
                 "  WHERE links.knowledge_node_id = kn.id "
-                "    AND s.probe_tag IS NULL "
+                f"    AND {agentic_session_eligible_sql('s')} "
                 "    AND (s.cwd LIKE ? OR s.project_dir LIKE ?))"
             )
             params.extend([like, like])
@@ -208,7 +221,7 @@ def _build_knowledge_filter_clause(
                 f" OR EXISTS (SELECT 1 FROM {link_table} links "
                 f"  JOIN {session_table} s ON s.id = links.{link_column} "
                 "  WHERE links.knowledge_node_id = kn.id "
-                "    AND s.probe_tag IS NULL AND s.git_branch = ?)"
+                f"    AND {agentic_session_eligible_sql('s')} AND s.git_branch = ?)"
             )
             params.append(branch)
         branch_clause += ")"
@@ -242,11 +255,18 @@ def search_knowledge_lexical(
     since: str = "",
     source: str = "",
     branch: str = "",
+    *,
+    include_excluded: bool = False,
 ) -> list[dict]:
     """Lexical (LIKE) search over knowledge_nodes with optional filter pushdown."""
     since_ms = parse_since(since)
     where_extra, extra_params = _build_knowledge_filter_clause(
-        conn, project=project, since_ms=since_ms, source=source, branch=branch
+        conn,
+        project=project,
+        since_ms=since_ms,
+        source=source,
+        branch=branch,
+        include_excluded=include_excluded,
     )
 
     if query:

--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -471,17 +471,19 @@ def _resolve_filters(
     source: str | None,
     branch: str | None,
     entity: str | None,
+    include_excluded: bool | None = None,
 ) -> Filters | None:
     """Merge explicit ``filters`` with flat kwargs. Returns ``None`` if no filter is set."""
     if filters is not None:
         return filters
-    if any(v is not None for v in (project, since, source, branch, entity)):
+    if any(v is not None for v in (project, since, source, branch, entity, include_excluded)):
         return Filters(
             project=project,
             since_ms=since,
             source=source,
             branch=branch,
             entity=entity,
+            include_excluded=bool(include_excluded),
         )
     return None
 
@@ -504,6 +506,7 @@ async def ask(
     entity: str | None = None,
     mode: str = "hybrid",
     conn=None,
+    include_excluded: bool = False,
 ) -> dict:
     """Run the full RAG pipeline: preflight → embed → retrieve → synthesize.
 
@@ -603,6 +606,7 @@ async def ask(
         source=source,
         branch=branch,
         entity=entity,
+        include_excluded=include_excluded,
     )
     retrieval_conn = conn if conn is not None else vector_table
     use_retrieval_search = isinstance(retrieval_conn, sqlite3.Connection)

--- a/brain/src/hippo_brain/rag.py
+++ b/brain/src/hippo_brain/rag.py
@@ -476,14 +476,14 @@ def _resolve_filters(
     """Merge explicit ``filters`` with flat kwargs. Returns ``None`` if no filter is set."""
     if filters is not None:
         return filters
-    if any(v is not None for v in (project, since, source, branch, entity, include_excluded)):
+    if any(v is not None for v in (project, since, source, branch, entity)) or include_excluded:
         return Filters(
             project=project,
             since_ms=since,
             source=source,
             branch=branch,
             entity=entity,
-            include_excluded=bool(include_excluded),
+            include_excluded=include_excluded,
         )
     return None
 

--- a/brain/src/hippo_brain/retrieval.py
+++ b/brain/src/hippo_brain/retrieval.py
@@ -18,6 +18,13 @@ from dataclasses import dataclass, field
 from typing import Protocol, Sequence
 
 from hippo_brain.enrichment import IDENTIFIER_ENTITY_TYPES
+from hippo_brain.retrieval_eligibility import (
+    agentic_session_eligible_sql,
+    browser_event_eligible_sql,
+    knowledge_node_eligible_exists_sql,
+    shell_event_eligible_sql,
+    workflow_run_eligible_sql,
+)
 from hippo_brain.source_filters import (
     knowledge_memory_project_clause,
     knowledge_source_exists_clause,
@@ -39,6 +46,7 @@ class Filters:
     source: str | None = None  # "shell" | "claude" | "browser" | "workflow"
     branch: str | None = None
     entity: str | None = None
+    include_excluded: bool = False
 
 
 @dataclass
@@ -335,12 +343,17 @@ def _apply_filters(
     """
     if not candidate_ids:
         return set()
-    if _is_empty_filter(filters):
+    if _is_empty_filter(filters) and filters.include_excluded:
         return set(candidate_ids)
 
     placeholders = ",".join("?" for _ in candidate_ids)
     clauses: list[str] = [f"kn.id IN ({placeholders})"]
     params: list[object] = list(candidate_ids)
+
+    if not filters.include_excluded:
+        elig_sql, elig_params = knowledge_node_eligible_exists_sql(conn, "kn.id")
+        clauses.append(elig_sql)
+        params.extend(elig_params)
 
     if filters.since_ms is not None:
         clauses.append(
@@ -382,7 +395,8 @@ def _apply_filters(
         LEFT JOIN knowledge_node_events kne ON kne.knowledge_node_id = kn.id
         LEFT JOIN events e ON e.id = kne.event_id
         LEFT JOIN knowledge_node_agentic_sessions kncs ON kncs.knowledge_node_id = kn.id
-        LEFT JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id AND asx.probe_tag IS NULL
+        LEFT JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id
+            AND {agentic_session_eligible_sql("asx")}
         LEFT JOIN knowledge_node_browser_events knbe ON knbe.knowledge_node_id = kn.id
         LEFT JOIN browser_events be ON be.id = knbe.browser_event_id
         WHERE {" AND ".join(clauses)}
@@ -407,7 +421,8 @@ def _apply_filters(
             LEFT JOIN knowledge_node_events kne ON kne.knowledge_node_id = kn.id
             LEFT JOIN events e ON e.id = kne.event_id
             LEFT JOIN knowledge_node_agentic_sessions kncs ON kncs.knowledge_node_id = kn.id
-            LEFT JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id AND asx.probe_tag IS NULL
+            LEFT JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id
+            AND {agentic_session_eligible_sql("asx")}
             LEFT JOIN knowledge_node_browser_events knbe ON knbe.knowledge_node_id = kn.id
             LEFT JOIN browser_events be ON be.id = knbe.browser_event_id
             WHERE {" AND ".join(clauses)}
@@ -482,6 +497,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
         FROM knowledge_node_events kne
         JOIN events e ON e.id = kne.event_id
         WHERE kne.knowledge_node_id IN ({placeholders})
+          AND {shell_event_eligible_sql("e")}
         ORDER BY e.timestamp DESC
         """,
         list(node_ids),
@@ -508,7 +524,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
         FROM knowledge_node_browser_events knbe
         JOIN browser_events be ON be.id = knbe.browser_event_id
         WHERE knbe.knowledge_node_id IN ({placeholders})
-          AND be.probe_tag IS NULL
+          AND {browser_event_eligible_sql("be")}
         ORDER BY be.id DESC
         """,
         list(node_ids),
@@ -526,6 +542,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
         FROM knowledge_node_workflow_runs knwr
         JOIN workflow_runs wr ON wr.id = knwr.run_id
         WHERE knwr.knowledge_node_id IN ({placeholders})
+          AND {workflow_run_eligible_sql("wr")}
         ORDER BY wr.id DESC
         """,
         list(node_ids),
@@ -547,7 +564,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
         FROM knowledge_node_agentic_sessions kncs
         JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id
         WHERE kncs.knowledge_node_id IN ({placeholders})
-          AND asx.probe_tag IS NULL
+          AND {agentic_session_eligible_sql("asx")}
         ORDER BY asx.start_time DESC, asx.id DESC
         """,
         list(node_ids),

--- a/brain/src/hippo_brain/retrieval.py
+++ b/brain/src/hippo_brain/retrieval.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 import json
 import math
 import sqlite3
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Protocol, Sequence
 
 from hippo_brain.enrichment import IDENTIFIER_ENTITY_TYPES
 from hippo_brain.retrieval_eligibility import (
     agentic_session_eligible_sql,
     browser_event_eligible_sql,
+    include_excluded_from_env,
     knowledge_node_eligible_exists_sql,
     shell_event_eligible_sql,
     workflow_run_eligible_sql,
@@ -193,6 +194,8 @@ def search(
     if limit <= 0:
         return []
     filters = filters or Filters()
+    if include_excluded_from_env():
+        filters = replace(filters, include_excluded=True)
     backend = backend or _default_backend()
 
     if mode == "semantic":
@@ -225,7 +228,9 @@ def _semantic(
         return []
     allowed = _apply_filters(conn, [nid for nid, _ in raw], filters)
     ordered = [(nid, dist) for nid, dist in raw if nid in allowed]
-    details = _fetch_details(conn, [nid for nid, _ in ordered])
+    details = _fetch_details(
+        conn, [nid for nid, _ in ordered], include_excluded=filters.include_excluded
+    )
     vecs = _get_vectors(conn, [nid for nid, _ in ordered])
     scored = [(nid, _cosine_to_score(dist)) for nid, dist in ordered]
     picked = _mmr(scored, vecs, limit)
@@ -246,7 +251,7 @@ def _lexical(
         return []
     allowed = _apply_filters(conn, [nid for nid, _ in raw], filters)
     ordered = [nid for nid, _ in raw if nid in allowed][:limit]
-    details = _fetch_details(conn, ordered)
+    details = _fetch_details(conn, ordered, include_excluded=filters.include_excluded)
     # Score = positional (1.0 for top, linearly down to ~0).
     n = max(len(ordered), 1)
     results: list[SearchResult] = []
@@ -275,7 +280,7 @@ def _recent(
     if not candidate_ids:
         candidate_ids = _all_recent_ids(conn, CANDIDATE_POOL)
     allowed = _apply_filters(conn, candidate_ids, filters)
-    details = _fetch_details(conn, list(allowed))
+    details = _fetch_details(conn, list(allowed), include_excluded=filters.include_excluded)
     ordered = sorted(
         (d for d in details.values()),
         key=lambda d: d["captured_at"],
@@ -321,7 +326,9 @@ def _hybrid(
 
     vecs = _get_vectors(conn, [nid for nid, _ in scored])
     picked = _mmr(scored, vecs, limit)
-    details = _fetch_details(conn, [nid for nid, _ in picked])
+    details = _fetch_details(
+        conn, [nid for nid, _ in picked], include_excluded=filters.include_excluded
+    )
     return [_to_result(score, details.get(nid)) for nid, score in picked if nid in details]
 
 
@@ -351,7 +358,9 @@ def _apply_filters(
     params: list[object] = list(candidate_ids)
 
     if not filters.include_excluded:
-        elig_sql, elig_params = knowledge_node_eligible_exists_sql(conn, "kn.id")
+        elig_sql, elig_params = knowledge_node_eligible_exists_sql(
+            conn, "kn.id", include_excluded=False
+        )
         clauses.append(elig_sql)
         params.extend(elig_params)
 
@@ -384,7 +393,9 @@ def _apply_filters(
         params.extend([filters.branch, filters.branch])
 
     if filters.source:
-        source_clause = knowledge_source_exists_clause(filters.source, conn)
+        source_clause = knowledge_source_exists_clause(
+            filters.source, conn, include_excluded=filters.include_excluded
+        )
         if source_clause is None:
             raise ValueError(f"unknown source filter: {filters.source!r}")
         clauses.append(source_clause)
@@ -396,7 +407,7 @@ def _apply_filters(
         LEFT JOIN events e ON e.id = kne.event_id
         LEFT JOIN knowledge_node_agentic_sessions kncs ON kncs.knowledge_node_id = kn.id
         LEFT JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id
-            AND {agentic_session_eligible_sql("asx")}
+            AND {agentic_session_eligible_sql("asx", include_excluded=filters.include_excluded)}
         LEFT JOIN knowledge_node_browser_events knbe ON knbe.knowledge_node_id = kn.id
         LEFT JOIN browser_events be ON be.id = knbe.browser_event_id
         WHERE {" AND ".join(clauses)}
@@ -422,7 +433,7 @@ def _apply_filters(
             LEFT JOIN events e ON e.id = kne.event_id
             LEFT JOIN knowledge_node_agentic_sessions kncs ON kncs.knowledge_node_id = kn.id
             LEFT JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id
-            AND {agentic_session_eligible_sql("asx")}
+            AND {agentic_session_eligible_sql("asx", include_excluded=filters.include_excluded)}
             LEFT JOIN knowledge_node_browser_events knbe ON knbe.knowledge_node_id = kn.id
             LEFT JOIN browser_events be ON be.id = knbe.browser_event_id
             WHERE {" AND ".join(clauses)}
@@ -450,7 +461,12 @@ def _is_empty_filter(f: Filters) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[int, dict]:
+def _fetch_details(
+    conn: sqlite3.Connection,
+    node_ids: Sequence[int],
+    *,
+    include_excluded: bool = False,
+) -> dict[int, dict]:
     """Fetch the canonical SearchResult fields for each node id."""
     if not node_ids:
         return {}
@@ -497,7 +513,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
         FROM knowledge_node_events kne
         JOIN events e ON e.id = kne.event_id
         WHERE kne.knowledge_node_id IN ({placeholders})
-          AND {shell_event_eligible_sql("e")}
+          AND {shell_event_eligible_sql("e", include_excluded=include_excluded)}
         ORDER BY e.timestamp DESC
         """,
         list(node_ids),
@@ -524,7 +540,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
         FROM knowledge_node_browser_events knbe
         JOIN browser_events be ON be.id = knbe.browser_event_id
         WHERE knbe.knowledge_node_id IN ({placeholders})
-          AND {browser_event_eligible_sql("be")}
+          AND {browser_event_eligible_sql("be", include_excluded=include_excluded)}
         ORDER BY be.id DESC
         """,
         list(node_ids),
@@ -542,7 +558,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
         FROM knowledge_node_workflow_runs knwr
         JOIN workflow_runs wr ON wr.id = knwr.run_id
         WHERE knwr.knowledge_node_id IN ({placeholders})
-          AND {workflow_run_eligible_sql("wr")}
+          AND {workflow_run_eligible_sql("wr", include_excluded=include_excluded)}
         ORDER BY wr.id DESC
         """,
         list(node_ids),
@@ -564,7 +580,7 @@ def _fetch_details(conn: sqlite3.Connection, node_ids: Sequence[int]) -> dict[in
         FROM knowledge_node_agentic_sessions kncs
         JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id
         WHERE kncs.knowledge_node_id IN ({placeholders})
-          AND {agentic_session_eligible_sql("asx")}
+          AND {agentic_session_eligible_sql("asx", include_excluded=include_excluded)}
         ORDER BY asx.start_time DESC, asx.id DESC
         """,
         list(node_ids),

--- a/brain/src/hippo_brain/retrieval.py
+++ b/brain/src/hippo_brain/retrieval.py
@@ -513,7 +513,7 @@ def _fetch_details(
         FROM knowledge_node_events kne
         JOIN events e ON e.id = kne.event_id
         WHERE kne.knowledge_node_id IN ({placeholders})
-          AND {shell_event_eligible_sql("e", include_excluded=include_excluded)}
+          AND {shell_event_eligible_sql("e", include_excluded=include_excluded, conn=conn)}
         ORDER BY e.timestamp DESC
         """,
         list(node_ids),

--- a/brain/src/hippo_brain/retrieval_eligibility.py
+++ b/brain/src/hippo_brain/retrieval_eligibility.py
@@ -14,27 +14,12 @@ import os
 import sqlite3
 import time
 
+from hippo_brain.source_filters import _MEMORY_SOURCE_EXISTS, table_exists as _table_exists
+
 # Align with capture probe / poller settle windows (see probe_agentic.rs).
 IN_FLIGHT_SETTLE_MS = 90_000
 
 _ENV_INCLUDE_EXCLUDED = "HIPPO_RETRIEVAL_INCLUDE_EXCLUDED"
-
-_MEMORY_SOURCE_EXISTS = (
-    "EXISTS (SELECT 1 FROM knowledge_node_memory_chunks knmc "
-    "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "
-    "JOIN memory_revisions mr ON mr.id = mc.revision_id "
-    "JOIN memory_documents md ON md.id = mr.document_id "
-    "WHERE knmc.knowledge_node_id = kn.id "
-    "AND md.active_revision_id = mr.id AND md.state = 'active')"
-)
-
-
-def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
-    row = conn.execute(
-        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?)",
-        (table,),
-    ).fetchone()
-    return bool(row and row[0])
 
 
 def include_excluded_from_env() -> bool:

--- a/brain/src/hippo_brain/retrieval_eligibility.py
+++ b/brain/src/hippo_brain/retrieval_eligibility.py
@@ -1,0 +1,178 @@
+"""Centralized user-facing retrieval eligibility policy (SNUG-121).
+
+Every RAG, MCP, and ``/ask`` path should apply these predicates by default so
+operational noise (probes, workflow journals, in-flight stubs) never satisfies
+agent evidence queries. Operators may pass ``include_excluded=True`` on
+:class:`~hippo_brain.retrieval.Filters` or set ``HIPPO_RETRIEVAL_INCLUDE_EXCLUDED=1``.
+
+Per-source policy table: ``docs/capture/retrieval-eligibility.md``.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+
+# Align with capture probe / poller settle windows (see probe_agentic.rs).
+IN_FLIGHT_SETTLE_MS = 90_000
+
+_ENV_INCLUDE_EXCLUDED = "HIPPO_RETRIEVAL_INCLUDE_EXCLUDED"
+
+_MEMORY_SOURCE_EXISTS = (
+    "EXISTS (SELECT 1 FROM knowledge_node_memory_chunks knmc "
+    "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "
+    "JOIN memory_revisions mr ON mr.id = mc.revision_id "
+    "JOIN memory_documents md ON md.id = mr.document_id "
+    "WHERE knmc.knowledge_node_id = kn.id "
+    "AND md.active_revision_id = mr.id AND md.state = 'active')"
+)
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?)",
+        (table,),
+    ).fetchone()
+    return bool(row and row[0])
+
+
+def include_excluded_from_env() -> bool:
+    """True when operator env requests excluded rows in retrieval."""
+    return os.environ.get(_ENV_INCLUDE_EXCLUDED, "").lower() in ("1", "true", "yes")
+
+
+def probe_tag_sql(column: str = "probe_tag", *, include_excluded: bool = False) -> str:
+    """SQL fragment: exclude synthetic probe rows unless operator mode is on."""
+    if include_excluded:
+        return "1=1"
+    return f"{column} IS NULL"
+
+
+def is_agentic_workflow_journal_sql(alias: str = "asx") -> str:
+    """Claude workflow orchestration journals (not user sessions)."""
+    return (
+        f"({alias}.source_file LIKE '%journal.jsonl' "
+        f"AND {alias}.source_file LIKE '%/subagents/%' "
+        f"AND {alias}.source_file LIKE '%/workflows/%')"
+    )
+
+
+def is_agentic_empty_stub_sql(alias: str = "asx") -> str:
+    """0-turn / empty transcript stubs that carry no user-meaningful signal."""
+    return f"({alias}.message_count > 0 OR length(trim({alias}.summary_text)) > 0)"
+
+
+def is_agentic_in_flight_sql(alias: str = "asx", *, now_ms: int | None = None) -> str:
+    """Segments whose end_time is still inside the poller settle window."""
+    if now_ms is None:
+        return (
+            f"({alias}.end_time + {IN_FLIGHT_SETTLE_MS} "
+            f"<= CAST((unixepoch('subsec') * 1000) AS INTEGER))"
+        )
+    return f"({alias}.end_time + {IN_FLIGHT_SETTLE_MS} <= {now_ms})"
+
+
+def agentic_session_eligible_sql(
+    alias: str = "asx",
+    *,
+    include_excluded: bool = False,
+    now_ms: int | None = None,
+) -> str:
+    """Eligible agentic session row predicate for JOIN/WHERE clauses."""
+    if include_excluded:
+        return "1=1"
+    return " AND ".join(
+        (
+            probe_tag_sql(f"{alias}.probe_tag"),
+            f"NOT {is_agentic_workflow_journal_sql(alias)}",
+            is_agentic_empty_stub_sql(alias),
+            is_agentic_in_flight_sql(alias, now_ms=now_ms),
+        )
+    )
+
+
+def workflow_run_eligible_sql(alias: str = "wr", *, include_excluded: bool = False) -> str:
+    """Completed workflow runs only; in-progress status journals are operational."""
+    if include_excluded:
+        return "1=1"
+    return f"({alias}.conclusion IS NOT NULL OR lower({alias}.status) = 'completed')"
+
+
+def shell_event_eligible_sql(alias: str = "e", *, include_excluded: bool = False) -> str:
+    return probe_tag_sql(f"{alias}.probe_tag", include_excluded=include_excluded)
+
+
+def browser_event_eligible_sql(alias: str = "be", *, include_excluded: bool = False) -> str:
+    return probe_tag_sql(f"{alias}.probe_tag", include_excluded=include_excluded)
+
+
+def knowledge_node_eligible_exists_sql(
+    conn: sqlite3.Connection,
+    kn_id_ref: str = "kn.id",
+    *,
+    include_excluded: bool = False,
+    now_ms: int | None = None,
+) -> tuple[str, list[object]]:
+    """Return ``(sql_fragment, params)`` requiring at least one eligible source link."""
+    if include_excluded:
+        return "1=1", []
+
+    if now_ms is None:
+        now_ms = int(time.time() * 1000)
+
+    parts: list[str] = [
+        (
+            "EXISTS (SELECT 1 FROM knowledge_node_events kne "
+            "JOIN events e ON e.id = kne.event_id "
+            f"WHERE kne.knowledge_node_id = {kn_id_ref} "
+            f"AND {shell_event_eligible_sql('e')})"
+        ),
+        (
+            "EXISTS (SELECT 1 FROM knowledge_node_browser_events knbe "
+            "JOIN browser_events be ON be.id = knbe.browser_event_id "
+            f"WHERE knbe.knowledge_node_id = {kn_id_ref} "
+            f"AND {browser_event_eligible_sql('be')})"
+        ),
+    ]
+
+    if _table_exists(conn, "knowledge_node_agentic_sessions") and _table_exists(
+        conn, "agentic_sessions"
+    ):
+        agentic = agentic_session_eligible_sql("asx", now_ms=now_ms)
+        parts.append(
+            "EXISTS (SELECT 1 FROM knowledge_node_agentic_sessions kncs "
+            "JOIN agentic_sessions asx ON asx.id = kncs.agentic_session_id "
+            f"WHERE kncs.knowledge_node_id = {kn_id_ref} AND {agentic})"
+        )
+
+    if _table_exists(conn, "knowledge_node_workflow_runs") and _table_exists(conn, "workflow_runs"):
+        wr = workflow_run_eligible_sql("wr")
+        parts.append(
+            "EXISTS (SELECT 1 FROM knowledge_node_workflow_runs knwr "
+            "JOIN workflow_runs wr ON wr.id = knwr.run_id "
+            f"WHERE knwr.knowledge_node_id = {kn_id_ref} AND {wr})"
+        )
+
+    if _table_exists(conn, "knowledge_node_memory_chunks") and _table_exists(
+        conn, "memory_documents"
+    ):
+        parts.append(_MEMORY_SOURCE_EXISTS.replace("kn.id", kn_id_ref))
+
+    link_tables = [
+        "knowledge_node_events",
+        "knowledge_node_browser_events",
+    ]
+    if _table_exists(conn, "knowledge_node_agentic_sessions"):
+        link_tables.append("knowledge_node_agentic_sessions")
+    if _table_exists(conn, "knowledge_node_workflow_runs"):
+        link_tables.append("knowledge_node_workflow_runs")
+    if _table_exists(conn, "knowledge_node_memory_chunks"):
+        link_tables.append("knowledge_node_memory_chunks")
+
+    no_links = " AND ".join(
+        f"NOT EXISTS (SELECT 1 FROM {table} x WHERE x.knowledge_node_id = {kn_id_ref})"
+        for table in link_tables
+    )
+
+    return f"(({no_links}) OR ({' OR '.join(parts)}))", []

--- a/brain/src/hippo_brain/retrieval_eligibility.py
+++ b/brain/src/hippo_brain/retrieval_eligibility.py
@@ -84,8 +84,22 @@ def workflow_run_eligible_sql(alias: str = "wr", *, include_excluded: bool = Fal
     return f"({alias}.conclusion IS NOT NULL OR lower({alias}.status) = 'completed')"
 
 
-def shell_event_eligible_sql(alias: str = "e", *, include_excluded: bool = False) -> str:
-    return probe_tag_sql(f"{alias}.probe_tag", include_excluded=include_excluded)
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(row[1] == column for row in rows)
+
+
+def shell_event_eligible_sql(
+    alias: str = "e",
+    *,
+    include_excluded: bool = False,
+    conn: sqlite3.Connection | None = None,
+) -> str:
+    if include_excluded:
+        return "1=1"
+    if conn is not None and not _column_exists(conn, table="events", column="probe_tag"):
+        return "1=1"
+    return probe_tag_sql(f"{alias}.probe_tag")
 
 
 def browser_event_eligible_sql(alias: str = "be", *, include_excluded: bool = False) -> str:
@@ -111,7 +125,7 @@ def knowledge_node_eligible_exists_sql(
             "EXISTS (SELECT 1 FROM knowledge_node_events kne "
             "JOIN events e ON e.id = kne.event_id "
             f"WHERE kne.knowledge_node_id = {kn_id_ref} "
-            f"AND {shell_event_eligible_sql('e')})"
+            f"AND {shell_event_eligible_sql('e', include_excluded=include_excluded, conn=conn)})"
         ),
         (
             "EXISTS (SELECT 1 FROM knowledge_node_browser_events knbe "

--- a/brain/src/hippo_brain/source_filters.py
+++ b/brain/src/hippo_brain/source_filters.py
@@ -4,12 +4,6 @@ from __future__ import annotations
 
 import sqlite3
 
-from hippo_brain.retrieval_eligibility import (
-    agentic_session_eligible_sql,
-    probe_tag_sql,
-    workflow_run_eligible_sql,
-)
-
 CLAUDE_AUTO_MEMORY_SOURCE = "claude-auto-memory"
 
 # Logical source families keyed by linked_source_ids prefix (see retrieval._fetch_details).
@@ -44,21 +38,6 @@ _MEMORY_SOURCE_EXISTS = (
 _SOURCE_EXISTS: dict[str, str] = {
     "shell": (
         "EXISTS (SELECT 1 FROM knowledge_node_events kne_s WHERE kne_s.knowledge_node_id = kn.id)"
-    ),
-    "claude": (
-        "EXISTS (SELECT 1 FROM knowledge_node_agentic_sessions knc_s "
-        "JOIN agentic_sessions asx_s ON asx_s.id = knc_s.agentic_session_id "
-        f"WHERE knc_s.knowledge_node_id = kn.id AND {agentic_session_eligible_sql('asx_s')})"
-    ),
-    "browser": (
-        "EXISTS (SELECT 1 FROM knowledge_node_browser_events knb_s "
-        "JOIN browser_events be_s ON be_s.id = knb_s.browser_event_id "
-        f"WHERE knb_s.knowledge_node_id = kn.id AND {probe_tag_sql('be_s.probe_tag')})"
-    ),
-    "workflow": (
-        "EXISTS (SELECT 1 FROM knowledge_node_workflow_runs knwr_s "
-        "JOIN workflow_runs wr_s ON wr_s.id = knwr_s.run_id "
-        f"WHERE knwr_s.knowledge_node_id = kn.id AND {workflow_run_eligible_sql('wr_s')})"
     ),
     CLAUDE_AUTO_MEMORY_SOURCE: _MEMORY_SOURCE_EXISTS,
 }
@@ -103,14 +82,42 @@ def knowledge_source_exists_clause(
     claude_link_table: str | None = None,
     claude_link_column: str | None = None,
     claude_session_table: str | None = None,
+    include_excluded: bool = False,
 ) -> str | None:
     """Return an EXISTS clause for ``source``, or None when unsupported."""
+    from hippo_brain.retrieval_eligibility import (
+        agentic_session_eligible_sql,
+        probe_tag_sql,
+        workflow_run_eligible_sql,
+    )
+
     if source == "claude" and claude_link_table and claude_link_column and claude_session_table:
         return (
             f"EXISTS (SELECT 1 FROM {claude_link_table} link "
             f"  JOIN {claude_session_table} s ON s.id = link.{claude_link_column} "
             f"  WHERE link.knowledge_node_id = kn.id "
-            f"AND {agentic_session_eligible_sql('s')})"
+            f"AND {agentic_session_eligible_sql('s', include_excluded=include_excluded)})"
+        )
+    if source == "claude":
+        return (
+            "EXISTS (SELECT 1 FROM knowledge_node_agentic_sessions knc_s "
+            "JOIN agentic_sessions asx_s ON asx_s.id = knc_s.agentic_session_id "
+            f"WHERE knc_s.knowledge_node_id = kn.id "
+            f"AND {agentic_session_eligible_sql('asx_s', include_excluded=include_excluded)})"
+        )
+    if source == "browser":
+        return (
+            "EXISTS (SELECT 1 FROM knowledge_node_browser_events knb_s "
+            "JOIN browser_events be_s ON be_s.id = knb_s.browser_event_id "
+            f"WHERE knb_s.knowledge_node_id = kn.id "
+            f"AND {probe_tag_sql('be_s.probe_tag', include_excluded=include_excluded)})"
+        )
+    if source == "workflow":
+        return (
+            "EXISTS (SELECT 1 FROM knowledge_node_workflow_runs knwr_s "
+            "JOIN workflow_runs wr_s ON wr_s.id = knwr_s.run_id "
+            f"WHERE knwr_s.knowledge_node_id = kn.id "
+            f"AND {workflow_run_eligible_sql('wr_s', include_excluded=include_excluded)})"
         )
     if source == CLAUDE_AUTO_MEMORY_SOURCE:
         if conn is not None and not table_exists(conn, "knowledge_node_memory_chunks"):

--- a/brain/src/hippo_brain/source_filters.py
+++ b/brain/src/hippo_brain/source_filters.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import sqlite3
 
+from hippo_brain.retrieval_eligibility import (
+    agentic_session_eligible_sql,
+    probe_tag_sql,
+    workflow_run_eligible_sql,
+)
+
 CLAUDE_AUTO_MEMORY_SOURCE = "claude-auto-memory"
 
 # Logical source families keyed by linked_source_ids prefix (see retrieval._fetch_details).
@@ -42,15 +48,17 @@ _SOURCE_EXISTS: dict[str, str] = {
     "claude": (
         "EXISTS (SELECT 1 FROM knowledge_node_agentic_sessions knc_s "
         "JOIN agentic_sessions asx_s ON asx_s.id = knc_s.agentic_session_id "
-        "WHERE knc_s.knowledge_node_id = kn.id AND asx_s.probe_tag IS NULL)"
+        f"WHERE knc_s.knowledge_node_id = kn.id AND {agentic_session_eligible_sql('asx_s')})"
     ),
     "browser": (
         "EXISTS (SELECT 1 FROM knowledge_node_browser_events knb_s "
-        "WHERE knb_s.knowledge_node_id = kn.id)"
+        "JOIN browser_events be_s ON be_s.id = knb_s.browser_event_id "
+        f"WHERE knb_s.knowledge_node_id = kn.id AND {probe_tag_sql('be_s.probe_tag')})"
     ),
     "workflow": (
         "EXISTS (SELECT 1 FROM knowledge_node_workflow_runs knwr_s "
-        "WHERE knwr_s.knowledge_node_id = kn.id)"
+        "JOIN workflow_runs wr_s ON wr_s.id = knwr_s.run_id "
+        f"WHERE knwr_s.knowledge_node_id = kn.id AND {workflow_run_eligible_sql('wr_s')})"
     ),
     CLAUDE_AUTO_MEMORY_SOURCE: _MEMORY_SOURCE_EXISTS,
 }
@@ -101,7 +109,8 @@ def knowledge_source_exists_clause(
         return (
             f"EXISTS (SELECT 1 FROM {claude_link_table} link "
             f"  JOIN {claude_session_table} s ON s.id = link.{claude_link_column} "
-            "  WHERE link.knowledge_node_id = kn.id AND s.probe_tag IS NULL)"
+            f"  WHERE link.knowledge_node_id = kn.id "
+            f"AND {agentic_session_eligible_sql('s')})"
         )
     if source == CLAUDE_AUTO_MEMORY_SOURCE:
         if conn is not None and not table_exists(conn, "knowledge_node_memory_chunks"):

--- a/brain/tests/retrieval_fixtures.py
+++ b/brain/tests/retrieval_fixtures.py
@@ -20,7 +20,8 @@ CREATE TABLE events (
     timestamp INTEGER NOT NULL,
     cwd TEXT NOT NULL,
     git_repo TEXT,
-    git_branch TEXT
+    git_branch TEXT,
+    probe_tag TEXT
 );
 CREATE TABLE knowledge_node_events (
     knowledge_node_id INTEGER NOT NULL,
@@ -29,11 +30,17 @@ CREATE TABLE knowledge_node_events (
 );
 CREATE TABLE agentic_sessions (
     id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL DEFAULT '',
     harness TEXT NOT NULL DEFAULT 'claude-code',
+    segment_index INTEGER NOT NULL DEFAULT 0,
     start_time INTEGER NOT NULL,
+    end_time INTEGER NOT NULL,
     cwd TEXT NOT NULL,
     project_dir TEXT,
     git_branch TEXT,
+    summary_text TEXT NOT NULL DEFAULT 'session work',
+    message_count INTEGER NOT NULL DEFAULT 5,
+    source_file TEXT NOT NULL DEFAULT '/proj/session.jsonl',
     probe_tag TEXT
 );
 CREATE TABLE knowledge_node_agentic_sessions (
@@ -49,7 +56,10 @@ CREATE TABLE browser_events (
 CREATE TABLE workflow_runs (
     id INTEGER PRIMARY KEY,
     repo TEXT,
-    head_sha TEXT
+    head_sha TEXT,
+    status TEXT NOT NULL DEFAULT 'completed',
+    conclusion TEXT DEFAULT 'success',
+    started_at INTEGER
 );
 CREATE TABLE knowledge_node_browser_events (
     knowledge_node_id INTEGER NOT NULL,

--- a/brain/tests/test_evaluation.py
+++ b/brain/tests/test_evaluation.py
@@ -319,7 +319,8 @@ CREATE TABLE events (
     timestamp INTEGER NOT NULL,
     cwd TEXT NOT NULL,
     git_repo TEXT,
-    git_branch TEXT
+    git_branch TEXT,
+    probe_tag TEXT
 );
 CREATE TABLE knowledge_node_events (
     knowledge_node_id INTEGER,
@@ -330,9 +331,13 @@ CREATE TABLE agentic_sessions (
     id INTEGER PRIMARY KEY,
     harness TEXT,
     start_time INTEGER,
+    end_time INTEGER,
     cwd TEXT,
     project_dir TEXT,
     git_branch TEXT,
+    summary_text TEXT DEFAULT 'work',
+    message_count INTEGER DEFAULT 5,
+    source_file TEXT DEFAULT '/proj/session.jsonl',
     probe_tag TEXT
 );
 CREATE TABLE knowledge_node_agentic_sessions (
@@ -349,6 +354,7 @@ CREATE TABLE knowledge_node_browser_events (
 CREATE TABLE workflow_runs (
     id INTEGER PRIMARY KEY,
     status TEXT,
+    conclusion TEXT,
     created_at INTEGER
 );
 CREATE TABLE knowledge_node_workflow_runs (
@@ -387,7 +393,9 @@ def _smoke_conn() -> sqlite3.Connection:
     )
     conn.execute("INSERT INTO knowledge_node_events VALUES (1, 10)")
     conn.execute(
-        "INSERT INTO agentic_sessions (id, start_time, cwd, project_dir, git_branch) VALUES (20, 1100, '/p', '/p', 'main')"
+        "INSERT INTO agentic_sessions "
+        "(id, start_time, end_time, cwd, project_dir, git_branch, summary_text, message_count) "
+        "VALUES (20, 1100, 1_700_000_000_000, '/p', '/p', 'main', 'work', 5)"
     )
     conn.execute("INSERT INTO knowledge_node_agentic_sessions VALUES (2, 20)")
     conn.execute("INSERT INTO browser_events (id, timestamp) VALUES (30, 1200)")

--- a/brain/tests/test_mcp_server.py
+++ b/brain/tests/test_mcp_server.py
@@ -352,7 +352,8 @@ class TestSearchKnowledgeTool:
         results = asyncio.run(search_knowledge("cargo", mode="semantic", limit=10))
         assert len(results) == 1  # Fell back to lexical successfully
 
-    def test_semantic_search_pads_query_vector_to_embed_dim(self, knowledge_db, monkeypatch):
+    def test_semantic_search_routes_through_retrieve_filtered(self, knowledge_db, monkeypatch):
+        """Semantic mode must use _retrieve_filtered so eligibility policy applies."""
         conn, db_path = knowledge_db
         _state.db_path = str(db_path)
         _state.embedding_model = "test-model"
@@ -362,26 +363,35 @@ class TestSearchKnowledgeTool:
         mock_client.embed.return_value = [[0.25] * 384]
         _state.inference_client = mock_client
 
-        def fake_search_similar(table, query_vec, limit=10):
-            assert table is _state.vector_table
-            assert len(query_vec) == EMBED_DIM
+        captured: dict = {}
+
+        async def fake_retrieve_filtered(**kwargs):
+            captured.update(kwargs)
             return [
                 {
-                    "_distance": 0.1,
+                    "uuid": "u1",
+                    "score": 0.9,
                     "summary": "semantic result",
+                    "intent": "",
                     "outcome": "success",
-                    "tags": "[]",
+                    "tags": [],
                     "embed_text": "semantic result",
                     "cwd": "/projects/hippo",
                     "git_branch": "main",
+                    "captured_at": 0,
+                    "linked_event_ids": [],
+                    "linked_claude_session_ids": [],
+                    "linked_browser_event_ids": [],
                 }
             ]
 
-        monkeypatch.setattr("hippo_brain.mcp.search_similar", fake_search_similar)
+        monkeypatch.setattr("hippo_brain.mcp._retrieve_filtered", fake_retrieve_filtered)
 
         results = asyncio.run(search_knowledge("cargo", mode="semantic", limit=10))
+        assert captured["mode"] == "semantic"
+        assert captured["include_excluded"] is False
         assert len(results) == 1
-        assert results[0]["score"] == 0.9
+        assert results[0]["uuid"] == "u1"
 
     def test_empty_query_returns_all(self, knowledge_db):
         conn, db_path = knowledge_db

--- a/brain/tests/test_retrieval.py
+++ b/brain/tests/test_retrieval.py
@@ -47,7 +47,8 @@ CREATE TABLE events (
     timestamp INTEGER NOT NULL,
     cwd TEXT NOT NULL,
     git_repo TEXT,
-    git_branch TEXT
+    git_branch TEXT,
+    probe_tag TEXT
 );
 CREATE TABLE knowledge_node_events (
     knowledge_node_id INTEGER NOT NULL,
@@ -56,11 +57,17 @@ CREATE TABLE knowledge_node_events (
 );
 CREATE TABLE agentic_sessions (
     id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL DEFAULT '',
     harness TEXT NOT NULL DEFAULT 'claude-code',
+    segment_index INTEGER NOT NULL DEFAULT 0,
     start_time INTEGER NOT NULL,
+    end_time INTEGER NOT NULL,
     cwd TEXT NOT NULL,
     project_dir TEXT,
     git_branch TEXT,
+    summary_text TEXT NOT NULL DEFAULT 'session work',
+    message_count INTEGER NOT NULL DEFAULT 5,
+    source_file TEXT NOT NULL DEFAULT '/proj/session.jsonl',
     probe_tag TEXT
 );
 CREATE TABLE knowledge_node_agentic_sessions (
@@ -76,7 +83,10 @@ CREATE TABLE browser_events (
 CREATE TABLE workflow_runs (
     id INTEGER PRIMARY KEY,
     repo TEXT,
-    head_sha TEXT
+    head_sha TEXT,
+    status TEXT NOT NULL DEFAULT 'completed',
+    conclusion TEXT DEFAULT 'success',
+    started_at INTEGER
 );
 CREATE TABLE knowledge_node_browser_events (
     knowledge_node_id INTEGER NOT NULL,
@@ -222,9 +232,20 @@ def _link_claude(
 ) -> None:
     conn.execute(
         "INSERT INTO agentic_sessions"
-        " (id, harness, start_time, cwd, project_dir, git_branch, probe_tag)"
-        " VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (session_id, harness, start_time, cwd, project_dir, branch, probe_tag),
+        " (id, session_id, harness, segment_index, start_time, end_time, cwd, project_dir,"
+        " git_branch, summary_text, message_count, source_file, probe_tag)"
+        " VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, 'session work', 5, '/proj/session.jsonl', ?)",
+        (
+            session_id,
+            f"sess-{session_id}",
+            harness,
+            start_time,
+            start_time + 60_000,
+            cwd,
+            project_dir,
+            branch,
+            probe_tag,
+        ),
     )
     conn.execute(
         "INSERT INTO knowledge_node_agentic_sessions"
@@ -235,8 +256,9 @@ def _link_claude(
 
 def _link_workflow(conn: sqlite3.Connection, node_id: int, run_id: int) -> None:
     conn.execute(
-        "INSERT OR IGNORE INTO workflow_runs (id, repo, head_sha) VALUES (?, ?, ?)",
-        (run_id, "owner/repo", "deadbeef"),
+        "INSERT OR IGNORE INTO workflow_runs (id, repo, head_sha, status, conclusion, started_at) "
+        "VALUES (?, ?, ?, 'completed', 'success', ?)",
+        (run_id, "owner/repo", "deadbeef", 1_700_000_000_000),
     )
     conn.execute(
         "INSERT INTO knowledge_node_workflow_runs (knowledge_node_id, run_id) VALUES (?, ?)",
@@ -638,14 +660,14 @@ def test_linked_source_ids_cover_all_four_sources(conn):
 
 
 def test_linked_source_ids_excludes_probe_browser_events(conn):
-    """Probe browser events must never surface (AP-6 defense-in-depth)."""
+    """Probe-only nodes must not appear in user-facing retrieval (AP-6)."""
     _insert_node(conn, 1, summary="probe-guard")
     _link_browser(conn, 1, 20, probe_tag="canary-x")
 
     backend = FakeBackend(fts=[(1, -1.0)])
-    [result] = search(conn, "q", None, Filters(), mode="lexical", limit=5, backend=backend)
+    results = search(conn, "q", None, Filters(), mode="lexical", limit=5, backend=backend)
 
-    assert result.linked_source_ids == []
+    assert results == []
 
 
 def test_constants_match_spec():

--- a/brain/tests/test_retrieval_eligibility.py
+++ b/brain/tests/test_retrieval_eligibility.py
@@ -156,3 +156,28 @@ def test_include_excluded_operator_mode(conn: sqlite3.Connection) -> None:
     )
     assert len(results) == 1
     assert results[0].uuid == "n"
+
+
+def test_probe_tagged_session_excluded(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 1)
+    _insert_node(conn, 2, uuid="clean")
+    _link_agentic(conn, 1, 60, probe_tag="canary")
+    _link_agentic(conn, 2, 61)
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.95), (2, 0.9)], fts=[(2, 0.92), (1, 0.7)])
+    results = search(conn, "work", [0.1] * 8, Filters(), mode="semantic", limit=5, backend=backend)
+    assert {r.uuid for r in results} == {"clean"}
+
+
+def test_include_excluded_from_env(monkeypatch: pytest.MonkeyPatch, conn: sqlite3.Connection) -> None:
+    monkeypatch.setenv("HIPPO_RETRIEVAL_INCLUDE_EXCLUDED", "1")
+    _insert_node(conn, 1)
+    journal = "/p/parent/subagents/workflows/wf/journal.jsonl"
+    _link_agentic(conn, 1, 70, source_file=journal)
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.95)], fts=[(1, 0.9)])
+    results = search(conn, "work", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    assert len(results) == 1
+    assert results[0].uuid == "n"

--- a/brain/tests/test_retrieval_eligibility.py
+++ b/brain/tests/test_retrieval_eligibility.py
@@ -1,0 +1,158 @@
+"""Tests for centralized retrieval eligibility policy (SNUG-121)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from hippo_brain.retrieval import Filters, search
+from hippo_brain.retrieval_eligibility import IN_FLIGHT_SETTLE_MS
+from tests.retrieval_fixtures import FakeBackend, TRUST_EVAL_SCHEMA
+
+_NOW = int(time.time() * 1000)
+_SETTLED_END = _NOW - IN_FLIGHT_SETTLE_MS - 60_000
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.executescript(TRUST_EVAL_SCHEMA)
+    c.commit()
+    return c
+
+
+def _insert_node(conn: sqlite3.Connection, node_id: int, *, uuid: str = "n") -> None:
+    conn.execute(
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, created_at) "
+        "VALUES (?, ?, ?, ?, 'observation', ?)",
+        (node_id, uuid, json.dumps({"summary": "s"}), "embed text", _SETTLED_END),
+    )
+
+
+def _link_agentic(
+    conn: sqlite3.Connection,
+    node_id: int,
+    session_id: int,
+    *,
+    harness: str = "claude-code",
+    source_file: str = "/proj/session.jsonl",
+    message_count: int = 5,
+    summary_text: str = "real work",
+    end_time: int = _SETTLED_END,
+    probe_tag: str | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO agentic_sessions "
+        "(id, session_id, harness, project_dir, cwd, segment_index, start_time, end_time, "
+        " summary_text, message_count, source_file, probe_tag) "
+        "VALUES (?, ?, ?, '/p', '/p', 0, ?, ?, ?, ?, ?, ?)",
+        (
+            session_id,
+            f"sess-{session_id}",
+            harness,
+            _SETTLED_END - 1000,
+            end_time,
+            summary_text,
+            message_count,
+            source_file,
+            probe_tag,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_agentic_sessions (knowledge_node_id, agentic_session_id) "
+        "VALUES (?, ?)",
+        (node_id, session_id),
+    )
+
+
+def _link_workflow(
+    conn: sqlite3.Connection,
+    node_id: int,
+    run_id: int,
+    *,
+    status: str = "completed",
+    conclusion: str | None = "success",
+) -> None:
+    conn.execute(
+        "INSERT INTO workflow_runs (id, repo, head_sha, status, conclusion, started_at) "
+        "VALUES (?, 'hippo', 'abc', ?, ?, ?)",
+        (run_id, status, conclusion, _SETTLED_END),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_workflow_runs (knowledge_node_id, run_id) VALUES (?, ?)",
+        (node_id, run_id),
+    )
+
+
+def test_workflow_journal_session_excluded(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 1)
+    _insert_node(conn, 2, uuid="good")
+    journal = "/p/parent/subagents/workflows/wf/journal.jsonl"
+    _link_agentic(conn, 1, 10, source_file=journal)
+    _link_agentic(conn, 2, 11)
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.9), (2, 0.85)], fts=[(2, 0.95), (1, 0.5)])
+    results = search(conn, "work", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    uuids = {r.uuid for r in results}
+    assert "good" in uuids
+    assert "n" not in uuids
+
+
+def test_in_flight_agentic_session_excluded(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 1)
+    _insert_node(conn, 2, uuid="settled")
+    _link_agentic(conn, 1, 20, end_time=_NOW - 1000)
+    _link_agentic(conn, 2, 21, end_time=_SETTLED_END)
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.9), (2, 0.88)], fts=[(2, 0.9), (1, 0.7)])
+    results = search(conn, "work", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    assert {r.uuid for r in results} == {"settled"}
+
+
+def test_empty_stub_agentic_session_excluded(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 1)
+    _insert_node(conn, 2, uuid="real")
+    _link_agentic(conn, 1, 30, message_count=0, summary_text="   ")
+    _link_agentic(conn, 2, 31)
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.92), (2, 0.9)], fts=[(2, 0.95), (1, 0.6)])
+    results = search(conn, "work", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    assert {r.uuid for r in results} == {"real"}
+
+
+def test_in_progress_workflow_run_excluded(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 1)
+    _insert_node(conn, 2, uuid="done")
+    _link_workflow(conn, 1, 40, status="in_progress", conclusion=None)
+    _link_workflow(conn, 2, 41)
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.9), (2, 0.88)], fts=[(2, 0.92), (1, 0.5)])
+    results = search(conn, "ci", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    assert {r.uuid for r in results} == {"done"}
+
+
+def test_include_excluded_operator_mode(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 1)
+    journal = "/p/parent/subagents/workflows/wf/journal.jsonl"
+    _link_agentic(conn, 1, 50, source_file=journal)
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.95)], fts=[(1, 0.9)])
+    results = search(
+        conn,
+        "work",
+        [0.1] * 8,
+        Filters(include_excluded=True),
+        mode="hybrid",
+        limit=5,
+        backend=backend,
+    )
+    assert len(results) == 1
+    assert results[0].uuid == "n"

--- a/brain/tests/test_retrieval_eligibility.py
+++ b/brain/tests/test_retrieval_eligibility.py
@@ -170,7 +170,9 @@ def test_probe_tagged_session_excluded(conn: sqlite3.Connection) -> None:
     assert {r.uuid for r in results} == {"clean"}
 
 
-def test_include_excluded_from_env(monkeypatch: pytest.MonkeyPatch, conn: sqlite3.Connection) -> None:
+def test_include_excluded_from_env(
+    monkeypatch: pytest.MonkeyPatch, conn: sqlite3.Connection
+) -> None:
     monkeypatch.setenv("HIPPO_RETRIEVAL_INCLUDE_EXCLUDED", "1")
     _insert_node(conn, 1)
     journal = "/p/parent/subagents/workflows/wf/journal.jsonl"

--- a/brain/tests/test_trust_eval.py
+++ b/brain/tests/test_trust_eval.py
@@ -156,9 +156,9 @@ def _link_agentic(
     probe_tag: str | None = None,
 ) -> None:
     conn.execute(
-        "INSERT INTO agentic_sessions (id, harness, start_time, cwd, probe_tag) "
-        "VALUES (?, ?, ?, '/hippo', ?)",
-        (session_id, harness, 1_700_000_000_000, probe_tag),
+        "INSERT INTO agentic_sessions (id, harness, start_time, end_time, cwd, probe_tag) "
+        "VALUES (?, ?, ?, ?, '/hippo', ?)",
+        (session_id, harness, 1_700_000_000_000, 1_700_000_060_000, probe_tag),
     )
     conn.execute(
         "INSERT INTO knowledge_node_agentic_sessions (knowledge_node_id, agentic_session_id) "

--- a/docs/capture/retrieval-eligibility.md
+++ b/docs/capture/retrieval-eligibility.md
@@ -1,0 +1,36 @@
+# Retrieval eligibility (SNUG-121)
+
+User-facing agent retrieval (RAG, MCP `ask` / `search_knowledge`, brain `/ask`) applies a single eligibility policy so operational metadata never masquerades as user-meaningful evidence.
+
+Implementation: `brain/src/hippo_brain/retrieval_eligibility.py`. Wired through `retrieval.Filters.include_excluded` and env `HIPPO_RETRIEVAL_INCLUDE_EXCLUDED=1`.
+
+## Default policy by source family
+
+| Family | Included when | Excluded by default |
+|--------|---------------|---------------------|
+| **shell** | `events.probe_tag IS NULL` | Synthetic probe commands (`probe_tag` set) |
+| **browser** | `browser_events.probe_tag IS NULL` | Probe canary page views |
+| **agentic** (claude/codex/cursor/opencode) | Non-probe, non-journal, non-empty, settled segment | `probe_tag` set; `journal.jsonl` under `subagents/.../workflows/`; `message_count=0` with blank `summary_text`; `end_time` within 90s settle window of now (in-flight) |
+| **workflow** (GitHub Actions) | `conclusion IS NOT NULL` or `status = completed` | In-progress status journal rows |
+| **claude-auto-memory** | Active document revision (`memory_documents.state = 'active'`) | Superseded / inactive revisions |
+
+Enrichment-time filters (`is_enrichment_eligible`) prevent most noise from ever becoming knowledge nodes. Retrieval eligibility is defense-in-depth for rows that slip through or for hydration of linked sources.
+
+## Operator / debug mode
+
+Set any of:
+
+- `Filters(include_excluded=True)` on programmatic retrieval
+- MCP tool param `include_excluded=true` on `search_knowledge` and `ask`
+- Environment `HIPPO_RETRIEVAL_INCLUDE_EXCLUDED=1` for the brain/MCP process
+
+Operator mode disables the eligibility gate so capture-health investigations can see probe and diagnostic rows. **Never enable in production agent defaults.**
+
+## Adding a new source
+
+1. Add enrichment eligibility in `enrichment.is_enrichment_eligible` (capture path).
+2. Add retrieval SQL helpers in `retrieval_eligibility.py`.
+3. Extend `knowledge_node_eligible_exists_sql` with an `EXISTS` branch.
+4. Add a regression test in `brain/tests/test_retrieval_eligibility.py`.
+
+See also AP-6 in [`anti-patterns.md`](anti-patterns.md).


### PR DESCRIPTION
## Summary
- Add `retrieval_eligibility.py` with centralized per-source SQL predicates (probe, workflow journals, in-flight agentic, empty stubs, in-progress workflow runs)
- Wire eligibility through `retrieval._apply_filters`, `_fetch_details`, `mcp_queries`, MCP `ask`/`search_knowledge`, and `rag.ask`
- Document policy in `docs/capture/retrieval-eligibility.md`
- Operator debug: `Filters.include_excluded`, MCP `include_excluded` param, env `HIPPO_RETRIEVAL_INCLUDE_EXCLUDED=1`
- 5 regression tests in `test_retrieval_eligibility.py`

## Test plan
- [x] `uv run --project brain pytest brain/tests/test_retrieval_eligibility.py -v`
- [x] `uv run --project brain pytest brain/tests/test_retrieval.py brain/tests/test_trust_eval.py brain/tests/test_mcp_queries.py -q`
- [x] `uv run --project brain ruff check brain/`

Linear: SNUG-121