### PR TITLE
docs(capture): publish agent source trust contracts (SNUG-122)

### DIFF
--- a/brain/src/hippo_brain/_fixtures/source_trust_contracts.json
+++ b/brain/src/hippo_brain/_fixtures/source_trust_contracts.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": 1,
+  "doc": "docs/capture/source-trust-contracts.md",
+  "families": [
+    {
+      "id": "shell",
+      "tables": ["events", "sessions", "knowledge_node_events", "knowledge_nodes"],
+      "identity_fields": ["events.id", "linked_source_ids:shell-<id>"],
+      "timestamp_fields": ["events.timestamp", "events.duration_ms"],
+      "probe_filter": "events.probe_tag IS NULL",
+      "source_health_key": "shell",
+      "freshness_invariant": "I-1",
+      "safe_citation_fields": ["command", "cwd", "git_repo", "git_branch", "exit_code", "duration_ms", "timestamp"],
+      "citation_example": "Shell event shell-18442: cargo test -p hippo-core in /Users/me/projects/hippo on main exited 0 after 12.4s."
+    },
+    {
+      "id": "claude-tool",
+      "tables": ["events", "knowledge_node_events"],
+      "identity_fields": ["events.id", "events.tool_name", "linked_source_ids:shell-<id>"],
+      "timestamp_fields": ["events.timestamp"],
+      "probe_filter": "events.probe_tag IS NULL",
+      "source_health_key": "claude-tool",
+      "notes": "MCP search_events source=claude does not include claude-tool rows; use source=all or shell."
+    },
+    {
+      "id": "claude",
+      "harness": "claude-code",
+      "tables": ["agentic_sessions", "knowledge_node_agentic_sessions"],
+      "identity_fields": ["session_id", "harness", "segment_index", "linked_source_ids:claude-<id>"],
+      "timestamp_fields": ["start_time", "end_time"],
+      "probe_filter": "agentic_sessions.probe_tag IS NULL",
+      "in_flight": "end_time within 90s settle window; workflow journal.jsonl paths excluded",
+      "source_health_key": "agentic-session-claude",
+      "freshness_invariant": "I-2",
+      "safe_citation_fields": ["session_id", "harness", "segment_index", "summary_text", "cwd", "git_branch", "source_file"],
+      "citation_example": "Claude segment claude-1204 (session_id=sess-abc, segment 0): fixed retrieval filter in hippo, ended 2026-07-05T10:00:00Z."
+    },
+    {
+      "id": "codex",
+      "harness": "codex",
+      "tables": ["agentic_sessions", "knowledge_node_agentic_sessions"],
+      "identity_fields": ["session_id", "harness", "segment_index", "linked_source_ids:codex-<id>"],
+      "timestamp_fields": ["start_time", "end_time"],
+      "probe_filter": "agentic_sessions.probe_tag IS NULL",
+      "in_flight": "end_time within 90s settle window",
+      "source_health_key": "agentic-session-codex",
+      "freshness_invariant": "I-13",
+      "safe_citation_fields": ["session_id", "summary_text", "source_file", "start_time", "end_time"],
+      "citation_example": "Codex segment codex-5021 (rollout-7f3a, segment 2): dependency bump work in hippo, ended 2026-07-04T18:22:00Z."
+    },
+    {
+      "id": "cursor",
+      "harness": "cursor",
+      "tables": ["agentic_sessions", "knowledge_node_agentic_sessions"],
+      "identity_fields": ["session_id", "harness", "segment_index", "linked_source_ids:cursor-<id>"],
+      "timestamp_fields": ["start_time", "end_time"],
+      "probe_filter": "agentic_sessions.probe_tag IS NULL",
+      "in_flight": "end_time within 90s settle window; file mtime used when JSONL lacks per-line times",
+      "source_health_key": "agentic-session-cursor",
+      "freshness_invariant": "I-15",
+      "safe_citation_fields": ["session_id", "summary_text", "is_subagent", "parent_session_id", "source_file"]
+    },
+    {
+      "id": "opencode",
+      "harness": "opencode",
+      "tables": ["agentic_sessions", "knowledge_node_agentic_sessions"],
+      "identity_fields": ["session_id", "harness", "segment_index", "linked_source_ids:opencode-<id>"],
+      "timestamp_fields": ["start_time", "end_time"],
+      "probe_filter": "agentic_sessions.probe_tag IS NULL",
+      "source_health_key": "agentic-session-opencode",
+      "freshness_invariant": "I-11",
+      "expected_absent": "sessions with fewer than 3 messages and no diffs/commits"
+    },
+    {
+      "id": "browser",
+      "tables": ["browser_events", "knowledge_node_browser_events"],
+      "identity_fields": ["browser_events.id", "linked_source_ids:browser-<id>"],
+      "timestamp_fields": ["timestamp", "dwell_ms"],
+      "probe_filter": "browser_events.probe_tag IS NULL",
+      "source_health_key": "browser",
+      "freshness_invariant": "I-4",
+      "safe_citation_fields": ["domain", "title", "url", "dwell_ms", "timestamp"],
+      "citation_example": "Browser event browser-3301: read SQLite WAL mode on sqlite.org for 4m 12s."
+    },
+    {
+      "id": "workflow",
+      "tables": ["workflow_runs", "workflow_jobs", "knowledge_node_workflow_runs"],
+      "identity_fields": ["workflow_runs.id", "run_id", "linked_source_ids:workflow-<id>"],
+      "timestamp_fields": ["started_at", "completed_at"],
+      "in_flight": "status in_progress without conclusion excluded from retrieval",
+      "source_health_key": "workflow",
+      "safe_citation_fields": ["repo", "head_sha", "head_branch", "name", "conclusion", "html_url"],
+      "citation_example": "Workflow run workflow-88 on stevencarpenter/hippo @ abc1234 (main): CI success."
+    },
+    {
+      "id": "claude-auto-memory",
+      "tables": ["memory_documents", "memory_revisions", "memory_chunks", "knowledge_node_memory_chunks"],
+      "identity_fields": ["memory_documents.id", "linked_source_ids:memory-<chunk_id>"],
+      "timestamp_fields": ["memory_revisions.created_at", "memory_documents.updated_at"],
+      "eligibility": "memory_documents.state = active AND active_revision_id match"
+    },
+    {
+      "id": "source_health",
+      "tables": ["source_health"],
+      "identity_fields": ["source"],
+      "timestamp_fields": ["last_event_ts", "updated_at", "probe_last_run_ts"],
+      "notes": "Operational telemetry only; not user-activity evidence",
+      "safe_citation_fields": ["source", "last_event_ts", "consecutive_failures", "probe_ok", "probe_lag_ms"],
+      "citation_example": "source_health agentic-session-cursor: last_event_ts 45m ago, probe_ok=1."
+    },
+    {
+      "id": "watchdog-probe",
+      "tables": ["source_health", "capture_alarms", "events.probe_tag", "browser_events.probe_tag", "agentic_sessions.probe_tag"],
+      "identity_fields": ["capture_alarms.id", "invariant_id"],
+      "timestamp_fields": ["capture_alarms.raised_at", "probe_last_run_ts"],
+      "source_health_key": "watchdog",
+      "freshness_invariant": "I-7",
+      "notes": "Probe rows carry probe_tag UUID; excluded from user-facing retrieval (AP-6)"
+    }
+  ]
+}

--- a/brain/src/hippo_brain/retrieval_eligibility.py
+++ b/brain/src/hippo_brain/retrieval_eligibility.py
@@ -6,6 +6,7 @@ agent evidence queries. Operators may pass ``include_excluded=True`` on
 :class:`~hippo_brain.retrieval.Filters` or set ``HIPPO_RETRIEVAL_INCLUDE_EXCLUDED=1``.
 
 Per-source policy table: ``docs/capture/retrieval-eligibility.md``.
+Agent-facing source semantics: ``docs/capture/source-trust-contracts.md``.
 """
 
 from __future__ import annotations

--- a/brain/tests/test_source_trust_contracts.py
+++ b/brain/tests/test_source_trust_contracts.py
@@ -1,0 +1,89 @@
+"""Regression checks for agent source trust contracts (SNUG-122)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONTRACTS_JSON = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "hippo_brain"
+    / "_fixtures"
+    / "source_trust_contracts.json"
+)
+_CONTRACTS_MD = _REPO_ROOT / "docs" / "capture" / "source-trust-contracts.md"
+
+_REQUIRED_FAMILIES = frozenset(
+    {
+        "shell",
+        "claude-tool",
+        "claude",
+        "codex",
+        "cursor",
+        "opencode",
+        "browser",
+        "workflow",
+        "source_health",
+        "watchdog-probe",
+    }
+)
+
+_REQUIRED_MD_HEADINGS = (
+    "## Shell commands",
+    "## Claude tool events",
+    "## Agentic sessions",
+    "## Browser visits",
+    "## GitHub CI",
+    "## `source_health`",
+    "## Watchdog and probe metadata",
+)
+
+_MIN_CITATION_EXAMPLES = 4
+
+
+@pytest.fixture
+def contracts_data() -> dict:
+    return json.loads(_CONTRACTS_JSON.read_text())
+
+
+@pytest.fixture
+def contracts_md() -> str:
+    return _CONTRACTS_MD.read_text()
+
+
+def test_contracts_json_covers_required_families(contracts_data: dict) -> None:
+    ids = {f["id"] for f in contracts_data["families"]}
+    missing = _REQUIRED_FAMILIES - ids
+    assert not missing, f"missing contract families: {sorted(missing)}"
+
+
+def test_contracts_json_has_citation_examples(contracts_data: dict) -> None:
+    with_examples = [f for f in contracts_data["families"] if f.get("citation_example")]
+    assert len(with_examples) >= _MIN_CITATION_EXAMPLES
+
+
+def test_contracts_json_entries_have_core_fields(contracts_data: dict) -> None:
+    for family in contracts_data["families"]:
+        assert "id" in family
+        assert "tables" in family and family["tables"]
+        assert "identity_fields" in family or family["id"] in ("watchdog-probe",)
+
+
+def test_contracts_md_exists_and_has_sections(contracts_md: str) -> None:
+    for heading in _REQUIRED_MD_HEADINGS:
+        assert heading in contracts_md, f"missing section: {heading}"
+
+
+def test_contracts_md_links_mcp_and_eligibility(contracts_md: str) -> None:
+    assert "mcp-reference.md" in contracts_md
+    assert "retrieval-eligibility.md" in contracts_md
+    assert "issues/114" in contracts_md
+
+
+def test_mcp_reference_links_trust_contracts() -> None:
+    mcp_ref = (_REPO_ROOT / "docs" / "mcp-reference.md").read_text()
+    assert "source-trust-contracts.md" in mcp_ref

--- a/docs/capture/README.md
+++ b/docs/capture/README.md
@@ -6,6 +6,7 @@ Reference documentation for hippo's capture-reliability stack — what every sou
 
 | Audience | Entry point |
 |---|---|
+| **Agent using MCP/RAG** — "what does this evidence mean?" | [`source-trust-contracts.md`](source-trust-contracts.md) |
 | **New contributor** — "what does the system do?" | [`architecture.md`](architecture.md) |
 | **Operator** — "something looks wrong" | [`operator-runbook.md`](operator-runbook.md) |
 | **Source author** — "I want to add a new capture path" | [`adding-a-source.md`](adding-a-source.md) (the full eleven-step contract). Read [`anti-patterns.md`](anti-patterns.md) first if you haven't. |
@@ -16,6 +17,8 @@ Reference documentation for hippo's capture-reliability stack — what every sou
 
 | Doc | Topic |
 |---|---|
+| [`retrieval-eligibility.md`](retrieval-eligibility.md) | Default eligibility policy for agent retrieval (probes, journals, in-flight). |
+| [`source-trust-contracts.md`](source-trust-contracts.md) | Agent-facing per-source semantics: identity, timestamps, freshness, safe citations. |
 | [`architecture.md`](architecture.md) | The four layers (capture path / `source_health` / watchdog / probe / alarms), I-1..I-12 invariants with thresholds, how the pieces interact. |
 | [`sources.md`](sources.md) | Per-source coverage matrix: shell, claude-session, browser, workflow runs, and the rest. Entry point, tables, invariants, probe coverage. |
 | [`anti-patterns.md`](anti-patterns.md) | AP-1..AP-12: forbidden patterns with rationale and the right alternative. Review blockers. |

--- a/docs/capture/retrieval-eligibility.md
+++ b/docs/capture/retrieval-eligibility.md
@@ -33,4 +33,4 @@ Operator mode disables the eligibility gate so capture-health investigations can
 3. Extend `knowledge_node_eligible_exists_sql` with an `EXISTS` branch.
 4. Add a regression test in `brain/tests/test_retrieval_eligibility.py`.
 
-See also AP-6 in [`anti-patterns.md`](anti-patterns.md).
+See also AP-6 in [`anti-patterns.md`](anti-patterns.md). Agent-facing per-source semantics: [`source-trust-contracts.md`](source-trust-contracts.md).

--- a/docs/capture/source-trust-contracts.md
+++ b/docs/capture/source-trust-contracts.md
@@ -1,0 +1,242 @@
+# Source trust contracts (SNUG-122)
+
+Agent-facing semantics for every source family that retrieval and MCP tools may surface. Read this before citing Hippo evidence — it tells you **where data lives**, **which rows are synthetic**, **what timestamps mean**, **what “missing” means**, and **which fields are safe to quote**.
+
+Companion docs (do not duplicate here):
+
+| Topic | Doc |
+|---|---|
+| Eligibility filters (what retrieval excludes by default) | [`retrieval-eligibility.md`](retrieval-eligibility.md) |
+| Capture entry points and operator runbooks | [`sources.md`](sources.md), [`operator-runbook.md`](operator-runbook.md) |
+| SQLite table reference | [`../schema.md`](../schema.md) |
+| Redaction limits and config surface | [`../../config/README.md`](../../config/README.md); deeper redaction reference tracked in [#114](https://github.com/stevencarpenter/hippo/issues/114) |
+| MCP tool shapes | [`../mcp-reference.md`](../mcp-reference.md) |
+
+Machine-readable index: `brain/src/hippo_brain/_fixtures/source_trust_contracts.json`.
+
+## How to read a contract
+
+Each family below uses the same headings:
+
+| Field | Meaning |
+|---|---|
+| **Tables** | SQLite tables holding raw or enriched data |
+| **Identity** | Stable row keys agents can cite |
+| **Timestamps** | Which column is “when this happened” (all epoch **milliseconds** unless noted) |
+| **Synthetic / probe** | Rows that are canaries, not user activity |
+| **Expected absent** | Normal gaps — not evidence of failure |
+| **In-flight** | Rows that exist but are not yet eligible for retrieval |
+| **Freshness** | How to tell whether capture is current (`source_health` key) |
+| **Safe to cite** | Fields appropriate for evidence packets |
+| **Do not cite** | Operational noise or PII-adjacent columns |
+
+Retrieval applies eligibility from [`retrieval_eligibility.py`](../../brain/src/hippo_brain/retrieval_eligibility.py) by default. Operator debug: `include_excluded=true` or `HIPPO_RETRIEVAL_INCLUDE_EXCLUDED=1`.
+
+---
+
+## Shell commands
+
+**Tables:** `events` (`source_kind='shell'`), `sessions`, `knowledge_node_events` → `knowledge_nodes`.
+
+| | |
+|---|---|
+| **Identity** | `events.id` (integer); in retrieval: `linked_source_ids` entry `shell-<id>` |
+| **Timestamps** | `events.timestamp` — command start (preexec). Duration in `duration_ms`; exit in `exit_code`. |
+| **Synthetic / probe** | `events.probe_tag IS NOT NULL` — synthetic `hippo probe` commands. **Excluded** from MCP/RAG by default. |
+| **Expected absent** | No rows when terminal idle, hook not sourced, or command redacted to empty. |
+| **In-flight** | N/A — shell events are point-in-time. |
+| **Freshness** | `source_health.source = 'shell'` → `last_event_ts`, `probe_ok`, `probe_lag_ms`. Invariant **I-1**. |
+| **Safe to cite** | `command` (redacted), `cwd`, `git_repo`, `git_branch`, `exit_code`, `duration_ms`, `timestamp` |
+| **Do not cite** | Raw `stdout`/`stderr` blobs unless operator mode; `probe_tag`; `env_snapshot_id` internals |
+
+**Safe citation example**
+
+> Shell event `shell-18442`: `cargo test -p hippo-core` in `/Users/me/projects/hippo` on `main` exited 0 after 12.4s (2026-07-05T10:15:00Z).
+
+---
+
+## Claude tool events
+
+**Tables:** `events` (`source_kind='claude-tool'`, `tool_name` set), linked via `knowledge_node_events`.
+
+| | |
+|---|---|
+| **Identity** | `events.id`; `linked_source_ids`: `shell-<id>` (tool events share the events table) |
+| **Timestamps** | `events.timestamp` — when the tool call was ingested from the parent session JSONL |
+| **Synthetic / probe** | Inherits session probe tag when parent segment is synthetic; filtered via shell eligibility |
+| **Expected absent** | No tool rows when the session had no tool calls in the segment window |
+| **In-flight** | Appears while parent `agentic_sessions` segment is inside the 90s settle window |
+| **Freshness** | Indirect — `source_health.source = 'claude-tool'`; primary signal is parent `agentic-session-claude` |
+| **Safe to cite** | `tool_name`, `command` (tool input summary), `cwd`, `git_branch`, parent session `session_id` |
+| **Do not cite** | Full tool I/O if truncated; probe-tagged parent sessions |
+
+**Note:** MCP `search_events` with `source="claude"` queries `agentic_sessions`, **not** `claude-tool` rows. Tool calls appear under `source="shell"` or `source="all"`.
+
+**Safe citation example**
+
+> Claude tool event `shell-9912`: `Bash` ran `rg 'retrieval_eligibility' brain/` in hippo repo (linked to session `sess-abc`).
+
+---
+
+## Agentic sessions (Claude Code, Codex, Cursor, opencode)
+
+**Tables:** `agentic_sessions`, `knowledge_node_agentic_sessions` → `knowledge_nodes`. Legacy `claude_sessions` is frozen (v18+); retrieval reads `agentic_sessions` only.
+
+| Harness | `source_health` key | Origin path |
+|---|---|---|
+| `claude-code` | `agentic-session-claude` | `~/.claude/projects/**/*.jsonl` (FS watcher) |
+| `codex` | `agentic-session-codex` | `~/.codex/sessions/**/rollout-*.jsonl` |
+| `cursor` | `agentic-session-cursor` | `~/.cursor/projects/**/agent-transcripts/**/*.jsonl` |
+| `opencode` | `agentic-session-opencode` | opencode SQLite → poller |
+
+| | |
+|---|---|
+| **Identity** | `(session_id, harness, segment_index)` UNIQUE; row `id` for joins; retrieval: `claude-<id>`, `codex-<id>`, `cursor-<id>`, `opencode-<id>` |
+| **Timestamps** | `start_time` / `end_time` — segment bounds. Cursor segments use file mtime when JSONL has no per-line times. |
+| **Synthetic / probe** | `probe_tag IS NOT NULL` on segment row |
+| **Expected absent** | No segment until file idle past `min_idle_secs`; opencode sessions with &lt;3 messages and no diffs (enrichment skip) |
+| **In-flight** | `end_time` within **90s** of now (`IN_FLIGHT_SETTLE_MS`); workflow `journal.jsonl` under `subagents/.../workflows/`; empty stubs (`message_count=0` and blank `summary_text`) |
+| **Freshness** | Per-harness `source_health` row above; invariants **I-2**, **I-11**, **I-13**, **I-15** |
+| **Safe to cite** | `session_id`, `harness`, `segment_index`, `summary_text`, `cwd`/`project_dir`, `git_branch`, `start_time`/`end_time`, `source_file` (path only, not full transcript) |
+| **Do not cite** | Full `tool_calls_json` / `user_prompts_json` without redaction review; subagent workflow journals; probe segments |
+
+**Safe citation example**
+
+> Codex segment `codex-5021` (`session_id=rollout-7f3a`, segment 2): summarized dependency bump work in `/Users/me/projects/hippo`, ended 2026-07-04T18:22:00Z.
+
+---
+
+## Browser visits
+
+**Tables:** `browser_events`, `knowledge_node_browser_events` → `knowledge_nodes`.
+
+| | |
+|---|---|
+| **Identity** | `browser_events.id`; retrieval: `browser-<id>` |
+| **Timestamps** | `timestamp` — page departure; `dwell_ms`, `scroll_pct` describe engagement |
+| **Synthetic / probe** | `probe_tag IS NOT NULL` — probe canary page views |
+| **Expected absent** | Domains outside `[browser.allowlist]`; Firefox down; extension not loaded |
+| **In-flight** | N/A |
+| **Freshness** | `source_health.source = 'browser'`; invariant **I-4** |
+| **Safe to cite** | `domain`, `title`, `url` (query params may be redacted per config), `dwell_ms`, `timestamp` |
+| **Do not cite** | Full `content` article text in agent summaries unless user asked for page content; `probe_tag` |
+
+**Safe citation example**
+
+> Browser event `browser-3301`: read "SQLite WAL mode" on `sqlite.org` for 4m 12s (2026-07-03T14:00:00Z).
+
+---
+
+## GitHub CI (workflow runs)
+
+**Tables:** `workflow_runs`, `workflow_jobs`, `workflow_annotations`, `workflow_log_excerpts`, `knowledge_node_workflow_runs` → `knowledge_nodes`.
+
+| | |
+|---|---|
+| **Identity** | `workflow_runs.id`; GitHub `run_id`; retrieval: `workflow-<id>` |
+| **Timestamps** | `started_at` / `completed_at` on run; job-level times on `workflow_jobs` |
+| **Synthetic / probe** | No probe rows — opt-in source (`[github] enabled = true`) |
+| **Expected absent** | No rows when GitHub polling disabled, no token, or repo has no recent Actions activity |
+| **In-flight** | `status = 'in_progress'` and `conclusion IS NULL` — **excluded** from retrieval until completed |
+| **Freshness** | `source_health.source = 'workflow'`; doctor soft/hard thresholds on `MAX(started_at)` (3d / 30d) |
+| **Safe to cite** | `repo`, `head_sha`, `head_branch`, `name` (workflow), `conclusion`, `html_url`, annotation `message` excerpts |
+| **Do not cite** | Full log blobs; secrets from log excerpts (should be redacted at ingest) |
+
+**Safe citation example**
+
+> Workflow run `workflow-88` on `stevencarpenter/hippo` @ `abc1234` (`main`): CI workflow **success** (2026-07-05T09:00:00Z).
+
+---
+
+## Claude auto-memory
+
+**Tables:** `memory_documents`, `memory_revisions`, `memory_chunks`, `knowledge_node_memory_chunks` → `knowledge_nodes`.
+
+| | |
+|---|---|
+| **Identity** | `memory_documents.id`; retrieval: `memory-<chunk_id>` |
+| **Timestamps** | `memory_revisions.created_at` for revision; document `updated_at` |
+| **Synthetic / probe** | None |
+| **Expected absent** | When `[auto_memory]` disabled or no `~/.claude/...` memory files ingested |
+| **In-flight** | Queue rows in `memory_enrichment_queue` with `status != 'done'` |
+| **Freshness** | `source_health.source = 'claude-auto-memory'` |
+| **Safe to cite** | `repository`, `source_path`, chunk `heading`, `content` excerpt, active revision only (`state = 'active'`) |
+| **Do not cite** | Superseded revisions (`active_revision_id` mismatch) |
+
+---
+
+## `source_health` (capture freshness metadata)
+
+**Tables:** `source_health` only — not linked to `knowledge_nodes`. Query via `hippo doctor`, SQL, or Grafana (`hippo_daemon_source_health_*` metrics).
+
+| | |
+|---|---|
+| **Identity** | `source` (TEXT PK) — e.g. `shell`, `agentic-session-cursor`, `watchdog` |
+| **Timestamps** | `last_event_ts`, `updated_at`, `probe_last_run_ts` (all epoch ms) |
+| **Synthetic / probe** | `probe_ok`, `probe_lag_ms`, `probe_last_run_ts` describe **canary** health, not user events |
+| **Expected absent** | Row missing only on pre-v8 schema; new sources seed via migration |
+| **In-flight** | N/A |
+| **Freshness** | Self-describing — `last_event_ts` staleness vs invariant thresholds in [`architecture.md`](architecture.md) |
+| **Safe to cite** | `source`, `last_event_ts`, `consecutive_failures`, `probe_ok`, `probe_lag_ms` when explaining **coverage gaps** |
+| **Do not cite** | As user-activity evidence — health rows are operational telemetry |
+
+**Safe citation example**
+
+> `source_health` for `agentic-session-cursor`: `last_event_ts` 45m ago, `consecutive_failures=0`, `probe_ok=1` — capture healthy.
+
+---
+
+## Watchdog and probe metadata
+
+**Tables:** `source_health` (`source='watchdog'`), `capture_alarms`; probe tags on real event tables.
+
+| | |
+|---|---|
+| **Identity** | `capture_alarms.id`; invariant `I-1`…`I-16` |
+| **Timestamps** | `capture_alarms.raised_at`, `resolved_at`; watchdog bumps `source_health.updated_at` every 60s |
+| **Synthetic / probe** | Probe UUID in `probe_tag` on `events` / `browser_events` / `agentic_sessions` |
+| **Expected absent** | No alarms when capture healthy; `probe_last_run_ts` NULL until first probe cycle |
+| **In-flight** | Active unacked alarms (`acked_at IS NULL`, `resolved_at IS NULL`) |
+| **Freshness** | Watchdog **I-7**: `watchdog` row stale &gt; 180s → doctor `[!!]` |
+| **Safe to cite** | Alarm `invariant_id`, `details_json` summary, `raised_at` when warning about **stale or broken capture** |
+| **Do not cite** | Probe-tagged event rows as user evidence; unacked alarms as factual claims about user work |
+
+---
+
+## Knowledge nodes (enriched layer)
+
+All MCP retrieval tools (`ask`, `search_knowledge`, `search_hybrid`, `get_context`) return **knowledge nodes** — LLM-enriched summaries linked to source rows above.
+
+| | |
+|---|---|
+| **Identity** | `knowledge_nodes.uuid` (prefer for citations); integer `id` internal |
+| **Timestamps** | `created_at` on node; `captured_at` on `SearchResult` = best-effort max linked source time |
+| **Synthetic / probe** | Nodes linked **only** to probe-tagged sources are excluded by eligibility |
+| **Expected absent** | Enrichment backlog when brain down; ineligible sources never enqueue |
+| **Safe to cite** | `uuid`, `summary`, `outcome`, `tags`, `cwd`, `git_branch`, `linked_*_ids` / `linked_source_ids` |
+| **Do not cite** | `embed_text` as user-facing prose (identifier-dense index text); orphan nodes with no links (rare) |
+
+Cross-link: node schema and link tables in [`../schema.md`](../schema.md#top-level-table-map).
+
+---
+
+## Quick reference: MCP `source` filter vs storage
+
+| MCP `source` arg | Storage queried | Notes |
+|---|---|---|
+| `shell` | `knowledge_node_events` → `events` | Shell commands only, not `claude-tool` |
+| `claude` | `knowledge_node_agentic_sessions` → `agentic_sessions` | All harnesses |
+| `browser` | `knowledge_node_browser_events` → `browser_events` | |
+| `workflow` | `knowledge_node_workflow_runs` → `workflow_runs` | Completed runs only (retrieval) |
+| `claude-auto-memory` | `knowledge_node_memory_chunks` | Active revisions only |
+
+---
+
+## Adding a contract
+
+When a new capture source ships:
+
+1. Add a section here and an entry in `source_trust_contracts.json`.
+2. Extend [`retrieval-eligibility.md`](retrieval-eligibility.md) and `retrieval_eligibility.py`.
+3. Add a trust-eval case in `trust_eval_cases.json` if the source appears in retrieval.
+4. Update [`sources.md`](sources.md) for operator-oriented capture detail.

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -2,6 +2,8 @@
 
 Full reference for hippo's MCP server. Every tool that `hippo-mcp` exposes, with arguments, return shapes, examples, and selection guidance. The MCP server source is `brain/src/hippo_brain/mcp.py`; this doc is what to read instead.
 
+**Before citing evidence:** read [`docs/capture/source-trust-contracts.md`](capture/source-trust-contracts.md) for per-source identity, timestamp, freshness, and safe-citation semantics. Eligibility filters (what retrieval excludes by default) are in [`docs/capture/retrieval-eligibility.md`](capture/retrieval-eligibility.md).
+
 For setup (adding hippo to your MCP config), see the [README's MCP Server section](../README.md#mcp-server). For the trust-boundary discussion (what granting MCP access actually exposes), see the [README's Privacy and Security section](../README.md#privacy-and-security).
 
 ## Tool selection guide
@@ -301,6 +303,8 @@ Lessons graduate only after 2+ occurrences (single failures stay in `lesson_pend
 
 ## See also
 
+- [Source trust contracts](capture/source-trust-contracts.md) — per-source semantics for agents (SNUG-122)
+- [Retrieval eligibility](capture/retrieval-eligibility.md) — default noise-control policy (SNUG-121)
 - [README MCP Server section](../README.md#mcp-server) — setup
 - [`docs/lifecycle.md`](lifecycle.md) — what writes to the tables these tools query
 - [`docs/schema.md`](schema.md) — the SQLite tables behind each return shape


### PR DESCRIPTION
## Summary
- Add `docs/capture/source-trust-contracts.md` — agent-facing per-source semantics (tables, identity, timestamps, probe/in-flight rules, freshness, safe citations with 4+ examples)
- Add machine-readable index at `brain/src/hippo_brain/_fixtures/source_trust_contracts.json`
- Link from MCP reference, capture README, and retrieval-eligibility docs; cross-link #114 for redaction depth
- Regression tests in `test_source_trust_contracts.py` enforce required source families and doc sections

## Test plan
- [x] `pytest brain/tests/test_source_trust_contracts.py -q`
- [x] CI lint + full test suite

Closes SNUG-122 / #204