### PR TITLE
feat(brain): freshness and coverage signals on evidence (SNUG-125)

### DIFF
--- a/brain/src/hippo_brain/agent_query.py
+++ b/brain/src/hippo_brain/agent_query.py
@@ -18,7 +18,7 @@ from typing import Any, Sequence
 from hippo_brain.mcp_queries import MAX_LIMIT, parse_since
 from hippo_brain.retrieval import Filters, SearchResult, search
 from hippo_brain.retrieval_eligibility import include_excluded_from_env
-from hippo_brain.source_freshness import freshness_for_evidence_packets
+from hippo_brain.source_freshness import aggregate_freshness_from_packets
 from hippo_brain.source_filters import CLAUDE_AUTO_MEMORY_SOURCE
 
 AGENT_QUERY_MODES = frozenset({"known", "evidence", "recent", "decisions"})
@@ -181,7 +181,7 @@ def run_agent_query(
         "query": req.query,
         "answer": _compose_answer(req.mode, hits),
         "hits": hits,
-        "freshness": freshness_for_evidence_packets(conn, all_packets),
+        "freshness": aggregate_freshness_from_packets(all_packets),
         "limit": limit,
         "truncated": truncated,
     }

--- a/brain/src/hippo_brain/agent_query.py
+++ b/brain/src/hippo_brain/agent_query.py
@@ -11,7 +11,6 @@ import argparse
 import json
 import sqlite3
 import sys
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
@@ -19,7 +18,8 @@ from typing import Any, Sequence
 from hippo_brain.mcp_queries import MAX_LIMIT, parse_since
 from hippo_brain.retrieval import Filters, SearchResult, search
 from hippo_brain.retrieval_eligibility import include_excluded_from_env
-from hippo_brain.source_filters import CLAUDE_AUTO_MEMORY_SOURCE, table_exists
+from hippo_brain.source_freshness import freshness_for_evidence_packets
+from hippo_brain.source_filters import CLAUDE_AUTO_MEMORY_SOURCE
 
 AGENT_QUERY_MODES = frozenset({"known", "evidence", "recent", "decisions"})
 AGENT_QUERY_SOURCES = frozenset(
@@ -30,21 +30,6 @@ DEFAULT_LIMIT = 10
 MAX_ANSWER_CHARS = 2000
 MAX_SUMMARY_CHARS = 400
 DECISIONS_CANDIDATE_MULTIPLIER = 3
-
-# Map evidence ``source_kind`` to ``source_health.source`` keys.
-_SOURCE_KIND_HEALTH: dict[str, str] = {
-    "shell": "shell",
-    "claude-tool": "claude-tool",
-    "claude": "agentic-session-claude",
-    "codex": "agentic-session-codex",
-    "cursor": "agentic-session-cursor",
-    "opencode": "agentic-session-opencode",
-    "browser": "browser",
-    "workflow": "workflow",
-    CLAUDE_AUTO_MEMORY_SOURCE: "claude-auto-memory",
-}
-
-_STALE_MS = 24 * 3600 * 1000
 
 
 @dataclass(frozen=True)
@@ -140,50 +125,6 @@ def _compose_answer(mode: str, hits: list[dict[str, Any]]) -> str:
     return _compose_known_answer(hits)
 
 
-def freshness_for_hits(
-    conn: sqlite3.Connection,
-    hits: Sequence[dict[str, Any]],
-    *,
-    now_ms: int | None = None,
-) -> dict[str, dict[str, Any]]:
-    """Lightweight capture-health hints for sources cited in evidence packets."""
-    if not table_exists(conn, "source_health"):
-        return {}
-
-    now_ms = now_ms or int(time.time() * 1000)
-    health_keys: set[str] = set()
-    for hit in hits:
-        for pkt in hit.get("evidence") or []:
-            kind = pkt.get("source_kind")
-            if isinstance(kind, str):
-                mapped = _SOURCE_KIND_HEALTH.get(kind)
-                if mapped:
-                    health_keys.add(mapped)
-
-    freshness: dict[str, dict[str, Any]] = {}
-    for key in sorted(health_keys):
-        row = conn.execute(
-            "SELECT last_event_ts, consecutive_failures, probe_ok "
-            "FROM source_health WHERE source = ?",
-            (key,),
-        ).fetchone()
-        if row is None:
-            freshness[key] = {"source": key, "present": False}
-            continue
-        last_event_ts, consecutive_failures, probe_ok = row
-        age_ms = (now_ms - last_event_ts) if last_event_ts else None
-        freshness[key] = {
-            "source": key,
-            "present": True,
-            "last_event_ts": last_event_ts,
-            "age_ms": age_ms,
-            "stale": bool(age_ms is not None and age_ms > _STALE_MS),
-            "consecutive_failures": consecutive_failures or 0,
-            "probe_ok": probe_ok,
-        }
-    return freshness
-
-
 def run_agent_query(
     conn: sqlite3.Connection,
     req: AgentQueryRequest,
@@ -231,12 +172,16 @@ def run_agent_query(
     include_decisions = req.mode == "decisions"
     hits = [_compact_hit(r, include_decisions=include_decisions) for r in results]
 
+    all_packets: list[dict[str, Any]] = []
+    for hit in hits:
+        all_packets.extend(hit.get("evidence") or [])
+
     return {
         "mode": req.mode,
         "query": req.query,
         "answer": _compose_answer(req.mode, hits),
         "hits": hits,
-        "freshness": freshness_for_hits(conn, hits),
+        "freshness": freshness_for_evidence_packets(conn, all_packets),
         "limit": limit,
         "truncated": truncated,
     }

--- a/brain/src/hippo_brain/evidence_packets.py
+++ b/brain/src/hippo_brain/evidence_packets.py
@@ -161,6 +161,29 @@ def make_workflow_packet(
     ).to_dict()
 
 
+def make_memory_packet(
+    *,
+    chunk_id: int,
+    timestamp_ms: int,
+    heading: str | None,
+    content: str | None,
+    repository: str | None,
+    source_path: str | None,
+) -> dict[str, Any]:
+    excerpt = heading or (content or "")[:200] or source_path or ""
+    if repository and heading:
+        excerpt = f"{repository} — {heading}"
+    return EvidencePacket(
+        ref=f"memory-{chunk_id}",
+        source_kind="claude-auto-memory",
+        table="memory_chunks",
+        row_id=chunk_id,
+        timestamp_ms=timestamp_ms,
+        excerpt=_truncate(excerpt),
+        source_path=source_path or None,
+    ).to_dict()
+
+
 def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
     return {key: row[key] for key in row.keys()}
 

--- a/brain/src/hippo_brain/retrieval.py
+++ b/brain/src/hippo_brain/retrieval.py
@@ -22,6 +22,7 @@ from hippo_brain.evidence_packets import (
     attach_retrieval_scores,
     make_agentic_packet,
     make_browser_packet,
+    make_memory_packet,
     make_shell_packet,
     make_workflow_packet,
 )
@@ -33,6 +34,7 @@ from hippo_brain.retrieval_eligibility import (
     shell_event_eligible_sql,
     workflow_run_eligible_sql,
 )
+from hippo_brain.source_freshness import attach_freshness_to_results
 from hippo_brain.source_filters import (
     knowledge_memory_project_clause,
     knowledge_source_exists_clause,
@@ -212,14 +214,18 @@ def search(
     backend = backend or _default_backend()
 
     if mode == "semantic":
-        return _semantic(conn, query_vec, filters, limit, backend)
-    if mode == "lexical":
-        return _lexical(conn, query, filters, limit, backend)
-    if mode == "recent":
-        return _recent(conn, query, filters, limit, backend)
-    if mode == "hybrid":
-        return _hybrid(conn, query, query_vec, filters, limit, backend)
-    raise ValueError(f"unknown retrieval mode: {mode!r}")
+        results = _semantic(conn, query_vec, filters, limit, backend)
+    elif mode == "lexical":
+        results = _lexical(conn, query, filters, limit, backend)
+    elif mode == "recent":
+        results = _recent(conn, query, filters, limit, backend)
+    elif mode == "hybrid":
+        results = _hybrid(conn, query, query_vec, filters, limit, backend)
+    else:
+        raise ValueError(f"unknown retrieval mode: {mode!r}")
+
+    attach_freshness_to_results(conn, results)
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -698,6 +704,48 @@ def _fetch_details(
             d["git_branch"] = branch
         if start_time and start_time > d["captured_at"]:
             d["captured_at"] = start_time
+
+    if _column_exists(conn, "memory_chunks", "id"):
+        mem_rows = conn.execute(
+            f"""
+            SELECT knmc.knowledge_node_id, mc.id, mc.heading_path, mc.content,
+                   mr.created_at, md.repository, md.source_path
+            FROM knowledge_node_memory_chunks knmc
+            JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id
+            JOIN memory_revisions mr ON mr.id = mc.revision_id
+            JOIN memory_documents md ON md.id = mr.document_id
+            WHERE knmc.knowledge_node_id IN ({placeholders})
+              AND md.state = 'active'
+              AND md.active_revision_id = mr.id
+            ORDER BY mr.created_at DESC
+            """,
+            list(node_ids),
+        ).fetchall()
+        for row in mem_rows:
+            kn_id = row[0]
+            chunk_id = row[1]
+            heading = row[2]
+            content = row[3]
+            created_at = row[4]
+            repository = row[5]
+            source_path = row[6]
+            d = details.get(kn_id)
+            if d is None:
+                continue
+            ref = f"memory-{chunk_id}"
+            d["linked_source_ids"].append(ref)
+            d["evidence_packets"].append(
+                make_memory_packet(
+                    chunk_id=chunk_id,
+                    timestamp_ms=created_at or 0,
+                    heading=heading,
+                    content=content,
+                    repository=repository,
+                    source_path=source_path,
+                )
+            )
+            if created_at and created_at > d["captured_at"]:
+                d["captured_at"] = created_at
 
     # Hydrate type-bucketed entity names so the RAG renderer can surface them
     # as a structural `Entities:` line above the truncatable `Detail:` block.

--- a/brain/src/hippo_brain/source_freshness.py
+++ b/brain/src/hippo_brain/source_freshness.py
@@ -152,7 +152,7 @@ def _load_health_row(conn: sqlite3.Connection, source_key: str) -> dict[str, Any
     return dict(zip(keys, row, strict=True))
 
 
-def _active_alarms_for_source(conn: sqlite3.Connection, source_key: str) -> list[dict[str, Any]]:
+def _load_active_alarms(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     if not table_exists(conn, "capture_alarms"):
         return []
     rows = conn.execute(
@@ -164,21 +164,29 @@ def _active_alarms_for_source(conn: sqlite3.Connection, source_key: str) -> list
         LIMIT 20
         """
     ).fetchall()
-    alarms: list[dict[str, Any]] = []
-    for invariant_id, raised_at, details_json in rows:
-        mapped = _INVARIANT_SOURCES.get(str(invariant_id))
+    return [
+        {"invariant_id": invariant_id, "raised_at": raised_at, "details": details_json}
+        for invariant_id, raised_at, details_json in rows
+    ]
+
+
+def _alarms_for_source(
+    all_alarms: Sequence[dict[str, Any]], source_key: str
+) -> list[dict[str, Any]]:
+    matched: list[dict[str, Any]] = []
+    for alarm in all_alarms:
+        invariant_id = str(alarm.get("invariant_id", ""))
+        mapped = _INVARIANT_SOURCES.get(invariant_id)
         if mapped is not None and mapped != source_key:
             continue
-        if mapped is None and source_key not in str(details_json or ""):
+        if mapped is None and source_key not in str(alarm.get("details") or ""):
             continue
-        alarms.append(
-            {
-                "invariant_id": invariant_id,
-                "raised_at": raised_at,
-                "details": details_json,
-            }
-        )
-    return alarms
+        matched.append(alarm)
+    return matched
+
+
+def _active_alarms_for_source(conn: sqlite3.Connection, source_key: str) -> list[dict[str, Any]]:
+    return _alarms_for_source(_load_active_alarms(conn), source_key)
 
 
 def classify_capture_status(
@@ -241,12 +249,17 @@ def build_freshness_snapshot(
     source_key: str,
     *,
     now_ms: int | None = None,
+    active_alarms: Sequence[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build a capture-freshness dict for one ``source_health`` key."""
     now_ms = now_ms or int(time.time() * 1000)
     health = _load_health_row(conn, source_key)
     coverage = _load_coverage(conn, source_key)
-    alarms = _active_alarms_for_source(conn, source_key)
+    alarms = (
+        _alarms_for_source(active_alarms, source_key)
+        if active_alarms is not None
+        else _active_alarms_for_source(conn, source_key)
+    )
     status = classify_capture_status(
         source_key=source_key,
         health=health,
@@ -299,7 +312,11 @@ def freshness_for_source_keys(
     if not table_exists(conn, "source_health"):
         return {}
     unique = sorted({k for k in source_keys if k})
-    return {key: build_freshness_snapshot(conn, key, now_ms=now_ms) for key in unique}
+    active_alarms = _load_active_alarms(conn)
+    return {
+        key: build_freshness_snapshot(conn, key, now_ms=now_ms, active_alarms=active_alarms)
+        for key in unique
+    }
 
 
 def freshness_for_evidence_packets(
@@ -345,7 +362,24 @@ def attach_freshness_to_results(
     now_ms: int | None = None,
 ) -> None:
     """Attach inline freshness to every evidence packet on retrieval results."""
+    all_packets: list[dict[str, Any]] = []
     for result in results:
         packets = getattr(result, "evidence", None)
         if packets:
-            attach_freshness_to_packets(conn, list(packets), now_ms=now_ms)
+            all_packets.extend(packets)
+    attach_freshness_to_packets(conn, all_packets, now_ms=now_ms)
+
+
+def aggregate_freshness_from_packets(
+    packets: Sequence[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Build a source-keyed freshness map from inline packet metadata."""
+    out: dict[str, dict[str, Any]] = {}
+    for pkt in packets:
+        fresh = pkt.get("freshness")
+        if not isinstance(fresh, dict):
+            continue
+        key = fresh.get("source")
+        if isinstance(key, str) and key:
+            out[key] = fresh
+    return out

--- a/brain/src/hippo_brain/source_freshness.py
+++ b/brain/src/hippo_brain/source_freshness.py
@@ -1,0 +1,351 @@
+"""Capture freshness and coverage signals for evidence responses (SNUG-125).
+
+Reads ``source_health`` and raw-table coverage counts only — never enrichment
+queue depth — so agents can judge whether cited evidence came from healthy,
+stale, idle, or failing capture paths.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from hippo_brain.source_filters import CLAUDE_AUTO_MEMORY_SOURCE, table_exists
+
+# Evidence ``source_kind`` → ``source_health.source`` keys.
+SOURCE_KIND_HEALTH: dict[str, str] = {
+    "shell": "shell",
+    "claude-tool": "claude-tool",
+    "claude": "agentic-session-claude",
+    "codex": "agentic-session-codex",
+    "cursor": "agentic-session-cursor",
+    "opencode": "agentic-session-opencode",
+    "browser": "browser",
+    "workflow": "workflow",
+    CLAUDE_AUTO_MEMORY_SOURCE: "claude-auto-memory",
+}
+
+BURSTY_SOURCES = frozenset(
+    {
+        "agentic-session-opencode",
+        "agentic-session-codex",
+        "agentic-session-cursor",
+    }
+)
+
+POLLER_FAILURE_THRESHOLD = 3
+_HOUR_MS = 3600 * 1000
+_DAY_MS = 24 * _HOUR_MS
+
+# Soft / hard staleness thresholds (epoch ms), aligned with doctor probes.
+_THRESHOLDS_MS: dict[str, tuple[int, int]] = {
+    "shell": (24 * _HOUR_MS, 7 * _DAY_MS),
+    "claude-tool": (24 * _HOUR_MS, 7 * _DAY_MS),
+    "agentic-session-claude": (12 * _HOUR_MS, 7 * _DAY_MS),
+    "browser": (48 * _HOUR_MS, 14 * _DAY_MS),
+    "workflow": (3 * _DAY_MS, 30 * _DAY_MS),
+    "agentic-session-opencode": (3 * _DAY_MS, 30 * _DAY_MS),
+    "agentic-session-codex": (3 * _DAY_MS, 30 * _DAY_MS),
+    "agentic-session-cursor": (3 * _DAY_MS, 30 * _DAY_MS),
+    "claude-auto-memory": (7 * _DAY_MS, 30 * _DAY_MS),
+}
+
+# Raw-table coverage probes (COUNT, MAX(ts)), probe rows excluded where applicable.
+_COVERAGE_SQL: dict[str, str] = {
+    "shell": (
+        "SELECT COUNT(*), MAX(timestamp) FROM events "
+        "WHERE source_kind = 'shell' AND probe_tag IS NULL"
+    ),
+    "claude-tool": (
+        "SELECT COUNT(*), MAX(timestamp) FROM events "
+        "WHERE source_kind = 'claude-tool' AND probe_tag IS NULL"
+    ),
+    "agentic-session-claude": (
+        "SELECT COUNT(*), MAX(end_time) FROM agentic_sessions "
+        "WHERE harness = 'claude-code' AND probe_tag IS NULL"
+    ),
+    "browser": "SELECT COUNT(*), MAX(timestamp) FROM browser_events WHERE probe_tag IS NULL",
+    "workflow": "SELECT COUNT(*), MAX(started_at) FROM workflow_runs",
+    "agentic-session-opencode": (
+        "SELECT COUNT(*), MAX(end_time) FROM agentic_sessions "
+        "WHERE harness = 'opencode' AND probe_tag IS NULL"
+    ),
+    "agentic-session-codex": (
+        "SELECT COUNT(*), MAX(end_time) FROM agentic_sessions "
+        "WHERE harness = 'codex' AND probe_tag IS NULL"
+    ),
+    "agentic-session-cursor": (
+        "SELECT COUNT(*), MAX(end_time) FROM agentic_sessions "
+        "WHERE harness = 'cursor' AND probe_tag IS NULL"
+    ),
+    "claude-auto-memory": (
+        "SELECT COUNT(*), MAX(md.updated_at) FROM memory_documents md WHERE md.state = 'active'"
+    ),
+}
+
+# Map capture invariants to source_health keys for active alarm surfacing.
+_INVARIANT_SOURCES: dict[str, str] = {
+    "I-1": "shell",
+    "I-2": "agentic-session-claude",
+    "I-3": "claude-tool",
+    "I-4": "browser",
+    "I-11": "agentic-session-opencode",
+    "I-13": "agentic-session-codex",
+    "I-15": "agentic-session-cursor",
+}
+
+
+@dataclass(frozen=True)
+class CoverageSnapshot:
+    row_count: int
+    max_event_ts: int | None
+
+
+def health_key_for_source_kind(source_kind: str) -> str | None:
+    return SOURCE_KIND_HEALTH.get(source_kind)
+
+
+def _thresholds_ms(source_key: str) -> tuple[int, int]:
+    return _THRESHOLDS_MS.get(source_key, (24 * _HOUR_MS, 7 * _DAY_MS))
+
+
+def _load_coverage(conn: sqlite3.Connection, source_key: str) -> CoverageSnapshot:
+    sql = _COVERAGE_SQL.get(source_key)
+    if sql is None:
+        return CoverageSnapshot(0, None)
+    row = conn.execute(sql).fetchone()
+    if row is None:
+        return CoverageSnapshot(0, None)
+    count, max_ts = row[0], row[1]
+    return CoverageSnapshot(int(count or 0), int(max_ts) if max_ts else None)
+
+
+def _load_health_row(conn: sqlite3.Connection, source_key: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        """
+        SELECT source, last_event_ts, last_success_ts, last_error_ts, last_error_msg,
+               consecutive_failures, events_last_1h, events_last_24h,
+               probe_ok, probe_lag_ms, probe_last_run_ts, last_heartbeat_ts, updated_at
+        FROM source_health WHERE source = ?
+        """,
+        (source_key,),
+    ).fetchone()
+    if row is None:
+        return None
+    keys = (
+        "source",
+        "last_event_ts",
+        "last_success_ts",
+        "last_error_ts",
+        "last_error_msg",
+        "consecutive_failures",
+        "events_last_1h",
+        "events_last_24h",
+        "probe_ok",
+        "probe_lag_ms",
+        "probe_last_run_ts",
+        "last_heartbeat_ts",
+        "updated_at",
+    )
+    return dict(zip(keys, row, strict=True))
+
+
+def _active_alarms_for_source(conn: sqlite3.Connection, source_key: str) -> list[dict[str, Any]]:
+    if not table_exists(conn, "capture_alarms"):
+        return []
+    rows = conn.execute(
+        """
+        SELECT invariant_id, raised_at, details_json
+        FROM capture_alarms
+        WHERE acked_at IS NULL AND resolved_at IS NULL
+        ORDER BY raised_at DESC
+        LIMIT 20
+        """
+    ).fetchall()
+    alarms: list[dict[str, Any]] = []
+    for invariant_id, raised_at, details_json in rows:
+        mapped = _INVARIANT_SOURCES.get(str(invariant_id))
+        if mapped is not None and mapped != source_key:
+            continue
+        if mapped is None and source_key not in str(details_json or ""):
+            continue
+        alarms.append(
+            {
+                "invariant_id": invariant_id,
+                "raised_at": raised_at,
+                "details": details_json,
+            }
+        )
+    return alarms
+
+
+def classify_capture_status(
+    *,
+    source_key: str,
+    health: dict[str, Any] | None,
+    coverage: CoverageSnapshot,
+    alarms: Sequence[dict[str, Any]],
+    now_ms: int,
+) -> str:
+    """Return one of: fresh, stale, failing, suppressed_idle, expected_absent, unknown."""
+    if coverage.row_count == 0 and health is None:
+        return "expected_absent"
+
+    if alarms:
+        return "failing"
+
+    if health is None:
+        return "expected_absent" if coverage.row_count == 0 else "unknown"
+
+    consecutive = int(health.get("consecutive_failures") or 0)
+    probe_ok = health.get("probe_ok")
+    events_24h = int(health.get("events_last_24h") or 0)
+    last_error_ts = health.get("last_error_ts")
+
+    if source_key in BURSTY_SOURCES and consecutive > POLLER_FAILURE_THRESHOLD:
+        return "failing"
+
+    if consecutive > 0 and last_error_ts and (now_ms - int(last_error_ts)) < _DAY_MS:
+        return "failing"
+
+    if probe_ok == 0 and health.get("probe_last_run_ts"):
+        return "failing"
+
+    if coverage.row_count == 0:
+        return "expected_absent"
+
+    ref_ts = health.get("last_event_ts") or coverage.max_event_ts
+    if ref_ts is None:
+        return "unknown"
+
+    age_ms = max(0, now_ms - int(ref_ts))
+    soft_ms, hard_ms = _thresholds_ms(source_key)
+
+    if age_ms <= soft_ms:
+        return "fresh"
+
+    if events_24h == 0 and coverage.row_count > 0:
+        if source_key in BURSTY_SOURCES or source_key == "browser":
+            return "suppressed_idle"
+
+    if age_ms > hard_ms:
+        return "stale"
+
+    return "stale"
+
+
+def build_freshness_snapshot(
+    conn: sqlite3.Connection,
+    source_key: str,
+    *,
+    now_ms: int | None = None,
+) -> dict[str, Any]:
+    """Build a capture-freshness dict for one ``source_health`` key."""
+    now_ms = now_ms or int(time.time() * 1000)
+    health = _load_health_row(conn, source_key)
+    coverage = _load_coverage(conn, source_key)
+    alarms = _active_alarms_for_source(conn, source_key)
+    status = classify_capture_status(
+        source_key=source_key,
+        health=health,
+        coverage=coverage,
+        alarms=alarms,
+        now_ms=now_ms,
+    )
+
+    ref_ts = None
+    if health:
+        ref_ts = health.get("last_event_ts")
+    if ref_ts is None:
+        ref_ts = coverage.max_event_ts
+    age_ms = (now_ms - int(ref_ts)) if ref_ts else None
+
+    capture_health: dict[str, Any] | None = None
+    if health:
+        capture_health = {
+            "last_event_ts": health.get("last_event_ts"),
+            "last_heartbeat_ts": health.get("last_heartbeat_ts"),
+            "probe_last_run_ts": health.get("probe_last_run_ts"),
+            "probe_ok": health.get("probe_ok"),
+            "probe_lag_ms": health.get("probe_lag_ms"),
+            "consecutive_failures": health.get("consecutive_failures") or 0,
+            "events_last_1h": health.get("events_last_1h") or 0,
+            "events_last_24h": health.get("events_last_24h") or 0,
+        }
+
+    return {
+        "source": source_key,
+        "status": status,
+        "present": health is not None,
+        "age_ms": age_ms,
+        "stale": status in {"stale", "failing"},
+        "capture_health": capture_health,
+        "coverage": {
+            "row_count": coverage.row_count,
+            "max_event_ts": coverage.max_event_ts,
+        },
+        "active_alarms": list(alarms),
+    }
+
+
+def freshness_for_source_keys(
+    conn: sqlite3.Connection,
+    source_keys: Sequence[str],
+    *,
+    now_ms: int | None = None,
+) -> dict[str, dict[str, Any]]:
+    if not table_exists(conn, "source_health"):
+        return {}
+    unique = sorted({k for k in source_keys if k})
+    return {key: build_freshness_snapshot(conn, key, now_ms=now_ms) for key in unique}
+
+
+def freshness_for_evidence_packets(
+    conn: sqlite3.Connection,
+    packets: Sequence[dict[str, Any]],
+    *,
+    now_ms: int | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Map ``source_health`` keys to freshness snapshots cited by evidence packets."""
+    keys: list[str] = []
+    for pkt in packets:
+        kind = pkt.get("source_kind")
+        if isinstance(kind, str):
+            mapped = health_key_for_source_kind(kind)
+            if mapped:
+                keys.append(mapped)
+    return freshness_for_source_keys(conn, keys, now_ms=now_ms)
+
+
+def attach_freshness_to_packets(
+    conn: sqlite3.Connection,
+    packets: list[dict[str, Any]],
+    *,
+    now_ms: int | None = None,
+) -> None:
+    """Mutate evidence packet dicts in place with inline ``freshness`` metadata."""
+    if not packets or not table_exists(conn, "source_health"):
+        return
+    snapshots = freshness_for_evidence_packets(conn, packets, now_ms=now_ms)
+    for pkt in packets:
+        kind = pkt.get("source_kind")
+        if not isinstance(kind, str):
+            continue
+        key = health_key_for_source_kind(kind)
+        if key and key in snapshots:
+            pkt["freshness"] = snapshots[key]
+
+
+def attach_freshness_to_results(
+    conn: sqlite3.Connection,
+    results: Sequence[Any],
+    *,
+    now_ms: int | None = None,
+) -> None:
+    """Attach inline freshness to every evidence packet on retrieval results."""
+    for result in results:
+        packets = getattr(result, "evidence", None)
+        if packets:
+            attach_freshness_to_packets(conn, list(packets), now_ms=now_ms)

--- a/brain/tests/retrieval_fixtures.py
+++ b/brain/tests/retrieval_fixtures.py
@@ -88,6 +88,29 @@ CREATE TABLE knowledge_node_workflow_runs (
     run_id INTEGER NOT NULL,
     PRIMARY KEY (knowledge_node_id, run_id)
 );
+CREATE TABLE source_health (
+    source TEXT PRIMARY KEY,
+    last_event_ts INTEGER,
+    last_success_ts INTEGER,
+    last_error_ts INTEGER,
+    last_error_msg TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    events_last_1h INTEGER NOT NULL DEFAULT 0,
+    events_last_24h INTEGER NOT NULL DEFAULT 0,
+    probe_ok INTEGER,
+    probe_lag_ms INTEGER,
+    probe_last_run_ts INTEGER,
+    last_heartbeat_ts INTEGER,
+    updated_at INTEGER NOT NULL
+);
+CREATE TABLE capture_alarms (
+    id INTEGER PRIMARY KEY,
+    invariant_id TEXT NOT NULL,
+    raised_at INTEGER NOT NULL,
+    resolved_at INTEGER,
+    acked_at INTEGER,
+    details_json TEXT
+);
 """
 
 

--- a/brain/tests/retrieval_fixtures.py
+++ b/brain/tests/retrieval_fixtures.py
@@ -111,6 +111,34 @@ CREATE TABLE capture_alarms (
     acked_at INTEGER,
     details_json TEXT
 );
+CREATE TABLE memory_documents (
+    id INTEGER PRIMARY KEY,
+    uuid TEXT NOT NULL,
+    repository TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    active_revision_id INTEGER,
+    state TEXT NOT NULL DEFAULT 'active',
+    updated_at INTEGER NOT NULL
+);
+CREATE TABLE memory_revisions (
+    id INTEGER PRIMARY KEY,
+    document_id INTEGER NOT NULL,
+    revision_number INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE memory_chunks (
+    id INTEGER PRIMARY KEY,
+    revision_id INTEGER NOT NULL,
+    ordinal INTEGER NOT NULL DEFAULT 0,
+    heading_path TEXT NOT NULL DEFAULT '',
+    content TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE knowledge_node_memory_chunks (
+    knowledge_node_id INTEGER NOT NULL,
+    memory_chunk_id INTEGER NOT NULL,
+    PRIMARY KEY (knowledge_node_id, memory_chunk_id)
+);
 """
 
 

--- a/brain/tests/test_agent_query.py
+++ b/brain/tests/test_agent_query.py
@@ -99,6 +99,7 @@ def test_known_mode_includes_evidence_and_freshness(conn: sqlite3.Connection) ->
     assert "shell" in out["freshness"]
     assert out["freshness"]["shell"]["status"] == "fresh"
     assert out["freshness"]["shell"]["capture_health"]["probe_ok"] == 1
+    assert out["hits"][0]["evidence"][0]["freshness"]["status"] == "fresh"
 
 
 def test_source_filter_shell_excludes_agentic(conn: sqlite3.Connection) -> None:

--- a/brain/tests/test_agent_query.py
+++ b/brain/tests/test_agent_query.py
@@ -15,23 +15,18 @@ from tests.retrieval_fixtures import FakeBackend, TRUST_EVAL_SCHEMA
 _NOW = int(time.time() * 1000)
 _SETTLED_END = _NOW - IN_FLIGHT_SETTLE_MS - 60_000
 
-_SOURCE_HEALTH_DDL = """
-CREATE TABLE source_health (
-    source TEXT PRIMARY KEY,
-    last_event_ts INTEGER,
-    consecutive_failures INTEGER DEFAULT 0,
-    probe_ok INTEGER
-);
-INSERT INTO source_health (source, last_event_ts, consecutive_failures, probe_ok)
-VALUES ('shell', ?, 0, 1);
-"""
+_SOURCE_HEALTH_ROW = (
+    "INSERT INTO source_health "
+    "(source, last_event_ts, consecutive_failures, events_last_24h, probe_ok, updated_at) "
+    "VALUES ('shell', ?, 0, 3, 1, ?)"
+)
 
 
 @pytest.fixture
 def conn() -> sqlite3.Connection:
     c = sqlite3.connect(":memory:")
-    c.executescript(TRUST_EVAL_SCHEMA + _SOURCE_HEALTH_DDL)
-    c.execute("UPDATE source_health SET last_event_ts = ?", (_SETTLED_END,))
+    c.executescript(TRUST_EVAL_SCHEMA)
+    c.execute(_SOURCE_HEALTH_ROW, (_SETTLED_END, _NOW))
     c.commit()
     return c
 
@@ -102,7 +97,8 @@ def test_known_mode_includes_evidence_and_freshness(conn: sqlite3.Connection) ->
     assert out["hits"][0]["evidence"]
     assert out["hits"][0]["evidence"][0]["ref"] == "shell-10"
     assert "shell" in out["freshness"]
-    assert out["freshness"]["shell"]["present"] is True
+    assert out["freshness"]["shell"]["status"] == "fresh"
+    assert out["freshness"]["shell"]["capture_health"]["probe_ok"] == 1
 
 
 def test_source_filter_shell_excludes_agentic(conn: sqlite3.Connection) -> None:
@@ -179,4 +175,5 @@ def test_freshness_marks_stale_source(conn: sqlite3.Connection) -> None:
     req = AgentQueryRequest(query="cargo", mode="known", limit=5)
     out = run_agent_query(conn, req, [0.1] * 8, backend=backend)
 
+    assert out["freshness"]["shell"]["status"] == "stale"
     assert out["freshness"]["shell"]["stale"] is True

--- a/brain/tests/test_evidence_packets.py
+++ b/brain/tests/test_evidence_packets.py
@@ -189,3 +189,42 @@ def test_workflow_knowledge_includes_evidence_packet(conn: sqlite3.Connection) -
     assert pkt["ref"] == "workflow-50"
     assert pkt["source_kind"] == "workflow"
     assert "hippo" in pkt["excerpt"]
+    assert pkt["freshness"]["source"] == "workflow"
+
+
+def test_memory_knowledge_includes_evidence_packet(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 6, uuid="memory-node")
+    conn.execute(
+        "INSERT INTO memory_documents (id, uuid, repository, source_path, state, updated_at) "
+        "VALUES (1, 'doc-1', 'hippo', 'MEMORY.md', 'active', ?)",
+        (_SETTLED_END,),
+    )
+    conn.execute(
+        "INSERT INTO memory_revisions (id, document_id, revision_number, created_at) "
+        "VALUES (10, 1, 1, ?)",
+        (_SETTLED_END,),
+    )
+    conn.execute("UPDATE memory_documents SET active_revision_id = 10 WHERE id = 1")
+    conn.execute(
+        "INSERT INTO memory_chunks (id, revision_id, ordinal, heading_path, content, created_at) "
+        "VALUES (100, 10, 0, 'Vector store', 'sqlite-vec consolidation notes', ?)",
+        (_SETTLED_END,),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_memory_chunks (knowledge_node_id, memory_chunk_id) "
+        "VALUES (6, 100)"
+    )
+    conn.execute(
+        "INSERT INTO source_health "
+        "(source, last_event_ts, consecutive_failures, events_last_24h, updated_at) "
+        "VALUES ('claude-auto-memory', ?, 0, 1, ?)",
+        (_SETTLED_END, _NOW),
+    )
+    conn.commit()
+
+    backend = FakeBackend(knn=[(6, 0.87)], fts=[(6, 0.9)])
+    results = search(conn, "sqlite-vec", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    pkt = results[0].evidence[0]
+    assert pkt["ref"] == "memory-100"
+    assert pkt["source_kind"] == "claude-auto-memory"
+    assert "Vector store" in pkt["excerpt"]

--- a/brain/tests/test_evidence_packets.py
+++ b/brain/tests/test_evidence_packets.py
@@ -223,7 +223,9 @@ def test_memory_knowledge_includes_evidence_packet(conn: sqlite3.Connection) -> 
     conn.commit()
 
     backend = FakeBackend(knn=[(6, 0.87)], fts=[(6, 0.9)])
-    results = search(conn, "sqlite-vec", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    results = search(
+        conn, "sqlite-vec", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend
+    )
     pkt = results[0].evidence[0]
     assert pkt["ref"] == "memory-100"
     assert pkt["source_kind"] == "claude-auto-memory"

--- a/brain/tests/test_evidence_packets.py
+++ b/brain/tests/test_evidence_packets.py
@@ -136,3 +136,56 @@ def test_inspect_evidence_rejects_probe_without_operator_mode(conn: sqlite3.Conn
 
     payload = inspect_evidence(conn, "shell-50", include_excluded=True)
     assert payload["row"]["probe_tag"] == "tag"
+
+
+def test_browser_knowledge_includes_evidence_packet(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 4, uuid="browser-node")
+    conn.execute(
+        "INSERT INTO browser_events (id, timestamp, title, url, domain) "
+        "VALUES (40, ?, 'SQLite WAL', 'https://sqlite.org/wal', 'sqlite.org')",
+        (_SETTLED_END,),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_browser_events (knowledge_node_id, browser_event_id) "
+        "VALUES (4, 40)"
+    )
+    conn.execute(
+        "INSERT INTO source_health "
+        "(source, last_event_ts, consecutive_failures, events_last_24h, updated_at) "
+        "VALUES ('browser', ?, 0, 1, ?)",
+        (_SETTLED_END, _NOW),
+    )
+    conn.commit()
+
+    backend = FakeBackend(knn=[(4, 0.9)], fts=[(4, 0.9)])
+    results = search(conn, "sqlite", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    pkt = results[0].evidence[0]
+    assert pkt["ref"] == "browser-40"
+    assert pkt["source_kind"] == "browser"
+    assert pkt["freshness"]["source"] == "browser"
+
+
+def test_workflow_knowledge_includes_evidence_packet(conn: sqlite3.Connection) -> None:
+    _insert_node(conn, 5, uuid="workflow-node")
+    conn.execute(
+        "INSERT INTO workflow_runs (id, name, repo, conclusion, started_at) "
+        "VALUES (50, 'CI', 'stevencarpenter/hippo', 'success', ?)",
+        (_SETTLED_END,),
+    )
+    conn.execute(
+        "INSERT INTO knowledge_node_workflow_runs (knowledge_node_id, run_id) VALUES (5, 50)"
+    )
+    conn.execute(
+        "INSERT INTO source_health "
+        "(source, last_event_ts, consecutive_failures, events_last_24h, updated_at) "
+        "VALUES ('workflow', ?, 0, 1, ?)",
+        (_SETTLED_END, _NOW),
+    )
+    conn.commit()
+
+    backend = FakeBackend(knn=[(5, 0.85)], fts=[(5, 0.88)])
+    results = search(conn, "CI", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    pkt = results[0].evidence[0]
+    assert pkt["ref"] == "workflow-50"
+    assert pkt["source_kind"] == "workflow"
+    assert "hippo" in pkt["excerpt"]

--- a/brain/tests/test_source_freshness.py
+++ b/brain/tests/test_source_freshness.py
@@ -1,0 +1,143 @@
+"""Tests for capture freshness and coverage signals (SNUG-125)."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from hippo_brain.retrieval import Filters, search
+from hippo_brain.source_freshness import (
+    attach_freshness_to_packets,
+    build_freshness_snapshot,
+    classify_capture_status,
+    CoverageSnapshot,
+)
+from hippo_brain.retrieval_eligibility import IN_FLIGHT_SETTLE_MS
+from tests.retrieval_fixtures import FakeBackend, TRUST_EVAL_SCHEMA
+
+_NOW = int(time.time() * 1000)
+_SETTLED = _NOW - IN_FLIGHT_SETTLE_MS - 60_000
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.executescript(TRUST_EVAL_SCHEMA)
+    c.execute(
+        "INSERT INTO source_health "
+        "(source, last_event_ts, consecutive_failures, events_last_24h, probe_ok, updated_at) "
+        "VALUES ('shell', ?, 0, 5, 1, ?)",
+        (_SETTLED, _NOW),
+    )
+    c.commit()
+    return c
+
+
+def test_fresh_shell_source(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO events (id, timestamp, command, cwd, source_kind) "
+        "VALUES (1, ?, 'cargo test', '/p', 'shell')",
+        (_SETTLED,),
+    )
+    conn.commit()
+    snap = build_freshness_snapshot(conn, "shell", now_ms=_NOW)
+    assert snap["status"] == "fresh"
+    assert snap["coverage"]["row_count"] >= 0
+    assert snap["capture_health"]["probe_ok"] == 1
+
+
+def test_stale_shell_source(conn: sqlite3.Connection) -> None:
+    stale_ts = _NOW - (8 * 24 * 3600 * 1000)
+    conn.execute(
+        "UPDATE source_health SET last_event_ts = ?, events_last_24h = 0 WHERE source = 'shell'",
+        (stale_ts,),
+    )
+    conn.execute(
+        "INSERT INTO events (id, timestamp, command, cwd, source_kind) "
+        "VALUES (1, ?, 'old cmd', '/p', 'shell')",
+        (stale_ts,),
+    )
+    conn.commit()
+
+    snap = build_freshness_snapshot(conn, "shell", now_ms=_NOW)
+    assert snap["status"] == "stale"
+    assert snap["stale"] is True
+
+
+def test_suppressed_idle_bursty_source(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO source_health "
+        "(source, last_event_ts, consecutive_failures, events_last_24h, updated_at) "
+        "VALUES ('agentic-session-codex', ?, 0, 0, ?)",
+        (_NOW - 4 * 24 * 3600 * 1000, _NOW),
+    )
+    conn.execute(
+        "INSERT INTO agentic_sessions "
+        "(id, session_id, harness, segment_index, start_time, end_time, cwd, "
+        " summary_text, message_count, source_file) "
+        "VALUES (1, 's', 'codex', 0, ?, ?, '/p', 'old work', 3, '/f.jsonl')",
+        (_NOW - 5 * 24 * 3600 * 1000, _NOW - 4 * 24 * 3600 * 1000),
+    )
+    conn.commit()
+
+    snap = build_freshness_snapshot(conn, "agentic-session-codex", now_ms=_NOW)
+    assert snap["status"] == "suppressed_idle"
+    assert snap["coverage"]["row_count"] == 1
+
+
+def test_expected_absent_known_gap(conn: sqlite3.Connection) -> None:
+    snap = build_freshness_snapshot(conn, "workflow", now_ms=_NOW)
+    assert snap["status"] == "expected_absent"
+    assert snap["coverage"]["row_count"] == 0
+
+
+def test_failing_from_active_alarm(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO capture_alarms (id, invariant_id, raised_at, details_json) "
+        "VALUES (1, 'I-1', ?, '{\"source\":\"shell\"}')",
+        (_NOW,),
+    )
+    conn.commit()
+
+    status = classify_capture_status(
+        source_key="shell",
+        health={"consecutive_failures": 0, "events_last_24h": 1},
+        coverage=CoverageSnapshot(10, _SETTLED),
+        alarms=[{"invariant_id": "I-1"}],
+        now_ms=_NOW,
+    )
+    assert status == "failing"
+
+
+def test_evidence_packets_include_inline_freshness(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, node_type, created_at) "
+        "VALUES (1, 'n', '{\"summary\":\"x\"}', 'embed', 'observation', ?)",
+        (_SETTLED,),
+    )
+    conn.execute(
+        "INSERT INTO events (id, timestamp, command, cwd, source_kind) "
+        "VALUES (10, ?, 'cargo test', '/p', 'shell')",
+        (_SETTLED,),
+    )
+    conn.execute("INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (1, 10)")
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.9)], fts=[(1, 0.95)])
+    results = search(conn, "cargo", [0.1] * 8, Filters(), mode="hybrid", limit=5, backend=backend)
+    assert results[0].evidence[0]["freshness"]["status"] == "fresh"
+    assert results[0].evidence[0]["freshness"]["source"] == "shell"
+
+
+def test_attach_freshness_mutates_packets(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO events (id, timestamp, command, cwd, source_kind) "
+        "VALUES (1, ?, 'ls', '/p', 'shell')",
+        (_SETTLED,),
+    )
+    conn.commit()
+    packets = [{"source_kind": "shell", "ref": "shell-1"}]
+    attach_freshness_to_packets(conn, packets, now_ms=_NOW)
+    assert packets[0]["freshness"]["status"] == "fresh"

--- a/brain/tests/test_source_freshness.py
+++ b/brain/tests/test_source_freshness.py
@@ -93,7 +93,25 @@ def test_expected_absent_known_gap(conn: sqlite3.Connection) -> None:
     assert snap["coverage"]["row_count"] == 0
 
 
-def test_failing_from_active_alarm(conn: sqlite3.Connection) -> None:
+def test_failing_snapshot_from_active_alarm(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO capture_alarms (id, invariant_id, raised_at, details_json) "
+        "VALUES (1, 'I-1', ?, '{\"source\":\"shell\"}')",
+        (_NOW,),
+    )
+    conn.execute(
+        "INSERT INTO events (id, timestamp, command, cwd, source_kind) "
+        "VALUES (1, ?, 'cargo test', '/p', 'shell')",
+        (_SETTLED,),
+    )
+    conn.commit()
+
+    snap = build_freshness_snapshot(conn, "shell", now_ms=_NOW)
+    assert snap["status"] == "failing"
+    assert snap["active_alarms"]
+
+
+def test_classify_failing_from_alarm(conn: sqlite3.Connection) -> None:
     conn.execute(
         "INSERT INTO capture_alarms (id, invariant_id, raised_at, details_json) "
         "VALUES (1, 'I-1', ?, '{\"source\":\"shell\"}')",

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -10,7 +10,6 @@ For setup (adding hippo to your MCP config), see the [README's MCP Server sectio
 
 | You want… | Reach for | Why |
 |---|---|---|
-docs/mcp-reference.md
 | A synthesized prose answer with cited sources | `ask` | Performs retrieval + LLM synthesis end-to-end. Slow (~1-3 s) but most useful for "what was I working on?" / "how did I fix that?" / "why did we choose X?" |
 | A compact answer plus evidence packets in one call | `agent_query` | Modes: `known`, `evidence`, `recent`, `decisions`. Returns bounded answer, hits with `evidence` (each packet includes inline `freshness`), and aggregated `freshness` by source. |
 | A list of relevant knowledge nodes (no synthesis) | `search_knowledge` or `search_hybrid` | Retrieval only. Fastest path. Use `search_hybrid` when you want score-fused vec0 + FTS5 results; `search_knowledge` for the simpler "semantic with lexical fallback" path. Each hit's `evidence` packets include inline capture `freshness` (SNUG-125). |

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -10,9 +10,10 @@ For setup (adding hippo to your MCP config), see the [README's MCP Server sectio
 
 | You want… | Reach for | Why |
 |---|---|---|
-| A compact answer plus evidence packets in one call | `agent_query` | Modes: `known`, `evidence`, `recent`, `decisions`. Returns bounded answer, hits with `evidence`, and `freshness` hints. |
+docs/mcp-reference.md
 | A synthesized prose answer with cited sources | `ask` | Performs retrieval + LLM synthesis end-to-end. Slow (~1-3 s) but most useful for "what was I working on?" / "how did I fix that?" / "why did we choose X?" |
-| A list of relevant knowledge nodes (no synthesis) | `search_knowledge` or `search_hybrid` | Retrieval only. Fastest path. Use `search_hybrid` when you want score-fused vec0 + FTS5 results; `search_knowledge` for the simpler "semantic with lexical fallback" path. |
+| A compact answer plus evidence packets in one call | `agent_query` | Modes: `known`, `evidence`, `recent`, `decisions`. Returns bounded answer, hits with `evidence` (each packet includes inline `freshness`), and aggregated `freshness` by source. |
+| A list of relevant knowledge nodes (no synthesis) | `search_knowledge` or `search_hybrid` | Retrieval only. Fastest path. Use `search_hybrid` when you want score-fused vec0 + FTS5 results; `search_knowledge` for the simpler "semantic with lexical fallback" path. Each hit's `evidence` packets include inline capture `freshness` (SNUG-125). |
 | A Markdown context block ready to paste into another agent's prompt | `get_context` | Same retrieval as `search_hybrid`, rendered as a prompt-shaped block (numbered list + per-hit summary/outcome/cwd/uuid). |
 | Raw shell commands / Claude tool calls / browser visits — not enriched summaries | `search_events` | Operates on the events tables, not knowledge nodes. Use for "what command did I run?" / "what URL was I on?" |
 | The list of projects in the corpus | `list_projects` | Use for discovery before filtering other tools by `project`. |


### PR DESCRIPTION
## Summary
- Add `source_freshness` module: capture-health snapshots with status (`fresh`, `stale`, `failing`, `suppressed_idle`, `expected_absent`), coverage counts, probe/heartbeat metadata, active alarms
- Inline `freshness` on evidence packets in retrieval (MCP `search_hybrid` / `search_knowledge` hits)
- Upgrade `agent_query` aggregated freshness to full snapshots
- Hydrate memory evidence packets in retrieval; browser/workflow evidence tests

## Test plan
- [x] `pytest brain/tests/test_source_freshness.py -q`
- [x] `pytest brain/tests/test_evidence_packets.py brain/tests/test_agent_query.py -q`
- [x] CI

Closes SNUG-125 / #206