### PR TITLE
feat(brain): conflict and staleness surfacing (SNUG-127)

### DIFF
--- a/brain/src/hippo_brain/agent_query.py
+++ b/brain/src/hippo_brain/agent_query.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
 
+from hippo_brain.conflict_detection import analyze_conflicts, apply_conflict_confidence_caps
 from hippo_brain.mcp_queries import MAX_LIMIT, parse_since
 from hippo_brain.retrieval import Filters, SearchResult, search
 from hippo_brain.retrieval_eligibility import include_excluded_from_env
@@ -173,16 +174,27 @@ def run_agent_query(
     include_decisions = req.mode == "decisions"
     hits = [_compact_hit(r, include_decisions=include_decisions) for r in results]
 
+    conflict_report = analyze_conflicts(hits)
+    apply_conflict_confidence_caps(hits, conflict_report)
+
     all_packets: list[dict[str, Any]] = []
     for hit in hits:
         all_packets.extend(hit.get("evidence") or [])
 
+    answer = _compose_answer(req.mode, hits)
+    if conflict_report.get("summary"):
+        answer = _truncate(
+            f"{answer}\n\nConflict/staleness: {conflict_report['summary']}",
+            MAX_ANSWER_CHARS,
+        )
+
     return {
         "mode": req.mode,
         "query": req.query,
-        "answer": _compose_answer(req.mode, hits),
+        "answer": answer,
         "hits": hits,
         "freshness": aggregate_freshness_from_packets(all_packets),
+        "conflicts": conflict_report,
         "limit": limit,
         "truncated": truncated,
     }

--- a/brain/src/hippo_brain/agent_query.py
+++ b/brain/src/hippo_brain/agent_query.py
@@ -148,6 +148,12 @@ def run_agent_query(
             "answer": "limit must be greater than 0",
             "hits": [],
             "freshness": {},
+            "conflicts": {
+                "staleness": None,
+                "conflicts": [],
+                "has_unresolved_conflicts": False,
+                "summary": "",
+            },
             "limit": 0,
             "truncated": False,
         }

--- a/brain/src/hippo_brain/conflict_detection.py
+++ b/brain/src/hippo_brain/conflict_detection.py
@@ -1,0 +1,151 @@
+"""Conflict and staleness analysis for evidence-backed responses (SNUG-127).
+
+Surfaces competing evidence and stale-only result sets so agents do not treat
+older or contradictory knowledge as current fact.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Sequence
+
+_STALE_STATUSES = frozenset({"stale", "suppressed_idle", "expected_absent", "unknown", "failing"})
+
+
+def _evidence_packets(hits: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    packets: list[dict[str, Any]] = []
+    for hit in hits:
+        packets.extend(hit.get("evidence") or [])
+    return packets
+
+
+def _staleness_warning(hits: Sequence[dict[str, Any]]) -> dict[str, Any] | None:
+    packets = _evidence_packets(hits)
+    if not packets:
+        return None
+    statuses = [
+        pkt.get("freshness", {}).get("status")
+        for pkt in packets
+        if isinstance(pkt.get("freshness"), dict)
+    ]
+    if not statuses:
+        return None
+    if all(s in _STALE_STATUSES for s in statuses if isinstance(s, str)):
+        return {
+            "kind": "stale_evidence",
+            "message": "All cited evidence is stale, idle, or from absent capture sources.",
+            "evidence_refs": [p.get("ref") for p in packets if p.get("ref")],
+        }
+    return None
+
+
+def _outcome_conflict(hits: Sequence[dict[str, Any]]) -> dict[str, Any] | None:
+    sides: list[dict[str, Any]] = []
+    for hit in hits:
+        outcome = hit.get("outcome")
+        if outcome not in {"success", "failure"}:
+            continue
+        sides.append(
+            {
+                "outcome": outcome,
+                "uuid": hit.get("uuid"),
+                "captured_at": hit.get("captured_at"),
+                "summary": hit.get("summary", ""),
+                "evidence_refs": [
+                    p.get("ref") for p in (hit.get("evidence") or []) if p.get("ref")
+                ],
+            }
+        )
+    outcomes = {s["outcome"] for s in sides}
+    if "success" not in outcomes or "failure" not in outcomes:
+        return None
+    return {
+        "kind": "outcome_disagreement",
+        "message": "Knowledge nodes disagree on whether the work succeeded or failed.",
+        "sides": sorted(sides, key=lambda s: s.get("captured_at") or 0),
+    }
+
+
+def _decision_conflict(hits: Sequence[dict[str, Any]]) -> dict[str, Any] | None:
+    entries: list[dict[str, Any]] = []
+    for hit in hits:
+        for dd in hit.get("design_decisions") or []:
+            chosen = dd.get("chosen") if isinstance(dd, dict) else None
+            if not chosen:
+                continue
+            entries.append(
+                {
+                    "chosen": str(chosen),
+                    "considered": dd.get("considered") if isinstance(dd, dict) else None,
+                    "reason": dd.get("reason") if isinstance(dd, dict) else None,
+                    "uuid": hit.get("uuid"),
+                    "captured_at": hit.get("captured_at"),
+                    "evidence_refs": [
+                        p.get("ref") for p in (hit.get("evidence") or []) if p.get("ref")
+                    ],
+                }
+            )
+    chosen_values = {e["chosen"] for e in entries}
+    if len(chosen_values) < 2:
+        return None
+    ordered = sorted(entries, key=lambda e: e.get("captured_at") or 0)
+    older = ordered[0]
+    newer = ordered[-1]
+    if older["chosen"] == newer["chosen"]:
+        return None
+    return {
+        "kind": "decision_contradiction",
+        "message": (
+            f"Newer evidence ({newer['chosen']!r} @ {newer.get('captured_at')}) "
+            f"contradicts an older decision ({older['chosen']!r} @ {older.get('captured_at')})."
+        ),
+        "sides": [older, newer],
+    }
+
+
+def analyze_conflicts(hits: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Return conflict/staleness report for a bounded hit list."""
+    conflicts: list[dict[str, Any]] = []
+    staleness = _staleness_warning(hits)
+    for detector in (_outcome_conflict, _decision_conflict):
+        found = detector(hits)
+        if found:
+            conflicts.append(found)
+
+    has_unresolved = bool(conflicts)
+    summary_parts: list[str] = []
+    if staleness:
+        summary_parts.append(staleness["message"])
+    for conflict in conflicts:
+        summary_parts.append(conflict["message"])
+
+    return {
+        "staleness": staleness,
+        "conflicts": conflicts,
+        "has_unresolved_conflicts": has_unresolved,
+        "summary": " ".join(summary_parts) if summary_parts else "",
+    }
+
+
+def apply_conflict_confidence_caps(hits: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    """Lower per-hit confidence when unresolved conflicts or stale-only evidence exist."""
+    if not report.get("has_unresolved_conflicts") and not report.get("staleness"):
+        return
+    for hit in hits:
+        conf = hit.get("confidence")
+        if not isinstance(conf, dict) or not conf:
+            continue
+        level = conf.get("level")
+        if report.get("has_unresolved_conflicts"):
+            if level == "high":
+                conf["level"] = "medium"
+            elif level == "medium":
+                conf["level"] = "low"
+            conf["explanation"] = (
+                conf.get("explanation", "") + " Capped due to unresolved evidence conflict."
+            ).strip()
+        elif report.get("staleness") and level == "high":
+            conf["level"] = "medium"
+            conf["explanation"] = (
+                conf.get("explanation", "") + " Capped: all evidence is stale or idle."
+            ).strip()

--- a/brain/src/hippo_brain/conflict_detection.py
+++ b/brain/src/hippo_brain/conflict_detection.py
@@ -6,7 +6,6 @@ older or contradictory knowledge as current fact.
 
 from __future__ import annotations
 
-import time
 from typing import Any, Sequence
 
 _STALE_STATUSES = frozenset({"stale", "suppressed_idle", "expected_absent", "unknown", "failing"})

--- a/brain/tests/test_conflict_detection.py
+++ b/brain/tests/test_conflict_detection.py
@@ -1,0 +1,144 @@
+"""Tests for conflict and staleness surfacing (SNUG-127)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from hippo_brain.agent_query import AgentQueryRequest, run_agent_query
+from hippo_brain.conflict_detection import analyze_conflicts, apply_conflict_confidence_caps
+from hippo_brain.retrieval_eligibility import IN_FLIGHT_SETTLE_MS
+from tests.retrieval_fixtures import FakeBackend, TRUST_EVAL_SCHEMA
+
+_NOW = int(time.time() * 1000)
+_SETTLED = _NOW - IN_FLIGHT_SETTLE_MS - 60_000
+
+
+def test_no_conflicts_clean_report() -> None:
+    hits = [
+        {
+            "uuid": "a",
+            "outcome": "success",
+            "captured_at": _SETTLED,
+            "summary": "ok",
+            "evidence": [{"ref": "shell-1", "freshness": {"status": "fresh"}}],
+            "confidence": {"level": "medium", "explanation": "ok"},
+        }
+    ]
+    report = analyze_conflicts(hits)
+    assert report["has_unresolved_conflicts"] is False
+    assert report["conflicts"] == []
+    assert report["staleness"] is None
+
+
+def test_stale_only_evidence_warning() -> None:
+    hits = [
+        {
+            "uuid": "a",
+            "evidence": [
+                {"ref": "shell-1", "freshness": {"status": "stale"}},
+                {"ref": "shell-2", "freshness": {"status": "suppressed_idle"}},
+            ],
+            "confidence": {"level": "high", "explanation": "x"},
+        }
+    ]
+    report = analyze_conflicts(hits)
+    assert report["staleness"]["kind"] == "stale_evidence"
+    apply_conflict_confidence_caps(hits, report)
+    assert hits[0]["confidence"]["level"] == "medium"
+
+
+def test_outcome_disagreement_conflict() -> None:
+    hits = [
+        {
+            "uuid": "old",
+            "outcome": "failure",
+            "captured_at": _SETTLED - 100_000,
+            "summary": "build failed",
+            "evidence": [{"ref": "shell-1"}],
+        },
+        {
+            "uuid": "new",
+            "outcome": "success",
+            "captured_at": _SETTLED,
+            "summary": "build fixed",
+            "evidence": [{"ref": "shell-2"}],
+        },
+    ]
+    report = analyze_conflicts(hits)
+    assert report["has_unresolved_conflicts"] is True
+    assert report["conflicts"][0]["kind"] == "outcome_disagreement"
+    assert len(report["conflicts"][0]["sides"]) == 2
+
+
+def test_decision_contradiction_newer_vs_older() -> None:
+    hits = [
+        {
+            "uuid": "old",
+            "captured_at": _SETTLED - 50_000,
+            "design_decisions": [{"chosen": "LanceDB", "considered": "sqlite-vec"}],
+            "evidence": [{"ref": "claude-1"}],
+        },
+        {
+            "uuid": "new",
+            "captured_at": _SETTLED,
+            "design_decisions": [{"chosen": "sqlite-vec", "considered": "LanceDB"}],
+            "evidence": [{"ref": "claude-2"}],
+        },
+    ]
+    report = analyze_conflicts(hits)
+    assert report["has_unresolved_conflicts"] is True
+    assert report["conflicts"][0]["kind"] == "decision_contradiction"
+    sides = report["conflicts"][0]["sides"]
+    assert sides[0]["chosen"] == "LanceDB"
+    assert sides[1]["chosen"] == "sqlite-vec"
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.executescript(TRUST_EVAL_SCHEMA)
+    c.execute(
+        "INSERT INTO source_health "
+        "(source, last_event_ts, consecutive_failures, events_last_24h, updated_at) "
+        "VALUES ('shell', ?, 0, 1, ?), ('agentic-session-claude', ?, 0, 1, ?)",
+        (_SETTLED, _NOW, _SETTLED, _NOW),
+    )
+    c.commit()
+    return c
+
+
+def test_agent_query_surfaces_conflicts(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO knowledge_nodes (id, uuid, content, embed_text, outcome, node_type, created_at) "
+        "VALUES (1, 'fail-node', ?, 'fail embed', 'failure', 'observation', ?), "
+        "       (2, 'ok-node', ?, 'ok embed', 'success', 'observation', ?)",
+        (
+            json.dumps({"summary": "Tests failed"}),
+            _SETTLED - 10_000,
+            json.dumps({"summary": "Tests passed"}),
+            _SETTLED,
+        ),
+    )
+    for node_id, event_id in ((1, 10), (2, 11)):
+        conn.execute(
+            "INSERT INTO events (id, timestamp, command, cwd, source_kind) "
+            "VALUES (?, ?, 'cargo test', '/p', 'shell')",
+            (event_id, _SETTLED - (20_000 if node_id == 1 else 0)),
+        )
+        conn.execute(
+            "INSERT INTO knowledge_node_events (knowledge_node_id, event_id) VALUES (?, ?)",
+            (node_id, event_id),
+        )
+    conn.commit()
+
+    backend = FakeBackend(knn=[(1, 0.8), (2, 0.85)], fts=[(2, 0.9), (1, 0.7)])
+    req = AgentQueryRequest(query="cargo test", mode="known", limit=5)
+    out = run_agent_query(conn, req, [0.1] * 8, backend=backend)
+
+    assert out["conflicts"]["has_unresolved_conflicts"] is True
+    assert "Conflict/staleness" in out["answer"]
+    assert any(h["confidence"]["level"] != "high" for h in out["hits"])

--- a/docs/capture/confidence-scoring.md
+++ b/docs/capture/confidence-scoring.md
@@ -30,7 +30,7 @@ Each hit carries a `confidence` object:
 - **No evidence → `insufficient`.** Hits without inspectable evidence packets are never rated high confidence, regardless of retrieval score.
 - **Stale/failing capture → capped.** `stale`, `failing`, `expected_absent`, or `unknown` freshness on cited sources prevents `high` and often yields `low`.
 - **Single weak packet → capped at medium.** One evidence packet needs very strong match + health to reach `high`.
-- **No conflict detection yet.** This module does not detect contradictory newer evidence (see SNUG-127); do not treat `high` as contradiction-free.
+- **Conflict caps (SNUG-127).** `conflict_detection.analyze_conflicts` surfaces outcome disagreements, decision contradictions, and stale-only evidence; `apply_conflict_confidence_caps` lowers per-hit confidence when conflicts are unresolved. Do not treat `high` as contradiction-free until conflicts are reviewed.
 - **Enrichment health excluded.** Queue depth and LLM enrichment status are intentionally omitted — capture health only.
 
 ## Surfaces

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -11,7 +11,7 @@ For setup (adding hippo to your MCP config), see the [README's MCP Server sectio
 | You want… | Reach for | Why |
 |---|---|---|
 | A synthesized prose answer with cited sources | `ask` | Performs retrieval + LLM synthesis end-to-end. Slow (~1-3 s) but most useful for "what was I working on?" / "how did I fix that?" / "why did we choose X?" |
-| A compact answer plus evidence packets in one call | `agent_query` | Modes: `known`, `evidence`, `recent`, `decisions`. Returns bounded answer, hits with `evidence` (each packet includes inline `freshness`), and aggregated `freshness` by source. |
+| A compact answer plus evidence packets in one call | `agent_query` | Modes: `known`, `evidence`, `recent`, `decisions`. Returns bounded answer, hits with `evidence` (inline `freshness` + `confidence`), aggregated `freshness`, and `conflicts` when stale or contradictory evidence is detected. |
 | A list of relevant knowledge nodes (no synthesis) | `search_knowledge` or `search_hybrid` | Retrieval only. Fastest path. Use `search_hybrid` when you want score-fused vec0 + FTS5 results; `search_knowledge` for the simpler "semantic with lexical fallback" path. Each hit's `evidence` packets include inline capture `freshness` (SNUG-125) and an explainable `confidence` rating (SNUG-126). |
 | A Markdown context block ready to paste into another agent's prompt | `get_context` | Same retrieval as `search_hybrid`, rendered as a prompt-shaped block (numbered list + per-hit summary/outcome/cwd/uuid). |
 | Raw shell commands / Claude tool calls / browser visits — not enriched summaries | `search_events` | Operates on the events tables, not knowledge nodes. Use for "what command did I run?" / "what URL was I on?" |


### PR DESCRIPTION
## Summary
- Add `conflict_detection` for stale-only warnings, outcome disagreements, and decision contradictions
- `agent_query` returns `conflicts` report, surfaces summary in answer, caps confidence on conflicts
- Preserves both sides with uuid, timestamps, and evidence refs

## Test plan
- [x] `pytest brain/tests/test_conflict_detection.py -q`
- [x] CI

Closes SNUG-127 / #209