### PR TITLE
feat(brain): auto-memory revision lifecycle (SNUG-133)

### DIFF
--- a/brain/src/hippo_brain/auto_memory.py
+++ b/brain/src/hippo_brain/auto_memory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import hashlib
 import json
 import sqlite3
@@ -25,6 +26,10 @@ SOURCE_KIND = "claude-auto-memory"
 CHUNKER_NAME = "markdown-headings"
 CHUNKER_VERSION = 1
 _IDENTITY_NAMESPACE = uuid.UUID("0fc25921-9c30-4c16-85da-b489ea81f087")
+DEFAULT_MAX_REVISION_COUNT = 20
+DEFAULT_MAX_REVISION_AGE_DAYS = 90
+DEFAULT_ABSENCE_CONFIRM_POLLS = 2
+_MAX_DIFF_CHARS = 16_384
 
 MEMORY_ENRICHMENT_SYSTEM_PROMPT = """\
 You enrich Claude Code auto-memory Markdown into structured knowledge for a local \
@@ -52,6 +57,13 @@ class IngestResult:
     revision_number: int
     changed: bool
     chunk_count: int
+
+
+@dataclass(frozen=True)
+class RevisionRetention:
+    max_count: int = DEFAULT_MAX_REVISION_COUNT
+    max_age_ms: int = DEFAULT_MAX_REVISION_AGE_DAYS * 86_400_000
+    absence_confirm_polls: int = DEFAULT_ABSENCE_CONFIRM_POLLS
 
 
 @dataclass(frozen=True)
@@ -116,6 +128,355 @@ def _chunks(markdown: str) -> list[MarkdownChunk]:
     return markdown_heading_chunks(markdown)
 
 
+def revision_retention_from_config(auto_memory: dict[str, Any]) -> RevisionRetention:
+    """Parse revision retention settings from a config ``[auto_memory]`` table."""
+    max_count = int(auto_memory.get("max_revision_count", DEFAULT_MAX_REVISION_COUNT))
+    max_age_days = int(auto_memory.get("max_revision_age_days", DEFAULT_MAX_REVISION_AGE_DAYS))
+    absence_polls = int(
+        auto_memory.get("absence_confirm_polls", DEFAULT_ABSENCE_CONFIRM_POLLS)
+    )
+    return RevisionRetention(
+        max_count=max(max_count, 1),
+        max_age_ms=max(max_age_days, 1) * 86_400_000,
+        absence_confirm_polls=max(absence_polls, 1),
+    )
+
+
+def _summarize_diff(old_redacted: str, new_redacted: str) -> tuple[str, str]:
+    """Build a bounded summary and unified diff from redacted content only."""
+    old_lines = old_redacted.splitlines(keepends=True)
+    new_lines = new_redacted.splitlines(keepends=True)
+    diff_lines = list(
+        difflib.unified_diff(
+            old_lines,
+            new_lines,
+            fromfile="previous",
+            tofile="current",
+            lineterm="",
+        )
+    )
+    diff_text = "".join(diff_lines)
+    if len(diff_text) > _MAX_DIFF_CHARS:
+        diff_text = diff_text[:_MAX_DIFF_CHARS] + "\n… (diff truncated)\n"
+    added = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
+    removed = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+    summary = f"{added} line(s) added, {removed} line(s) removed"
+    return summary, diff_text
+
+
+def _finalize_superseded_revision(
+    conn: sqlite3.Connection,
+    revision_id: int,
+    *,
+    old_redacted: str,
+    new_redacted: str,
+) -> None:
+    """Move superseded revision content into bounded summary/diff metadata."""
+    summary, diff_text = _summarize_diff(old_redacted, new_redacted)
+    conn.execute(
+        "UPDATE memory_revisions SET summary = ?, diff_text = ?, redacted_content = NULL "
+        "WHERE id = ?",
+        (summary, diff_text, revision_id),
+    )
+
+
+def _try_resolve_rename(
+    conn: sqlite3.Connection,
+    *,
+    repository: str,
+    logical_path: str,
+    content_hash: str,
+    source_path: str,
+    observed_at: int,
+) -> int | None:
+    """Return an existing document id when an unambiguous rename is detected."""
+    rows = conn.execute(
+        "SELECT d.id, d.logical_path, d.source_path "
+        "FROM memory_documents d "
+        "JOIN memory_revisions r ON r.id = d.current_revision_id "
+        "WHERE d.repository = ? AND d.logical_path != ? AND r.content_hash = ? "
+        "AND d.state IN ('active', 'unavailable')",
+        (repository, logical_path, content_hash),
+    ).fetchall()
+    if len(rows) != 1:
+        return None
+    document_id, old_logical_path, old_source_path = int(rows[0][0]), rows[0][1], rows[0][2]
+    if Path(old_source_path).is_file():
+        return None
+    with conn:
+        conn.execute(
+            "UPDATE memory_documents SET logical_path = ?, source_path = ?, state = 'active', "
+            "observed_at = ?, updated_at = ?, tombstoned_at = NULL WHERE id = ?",
+            (logical_path, source_path, observed_at, observed_at, document_id),
+        )
+        revision_number = int(
+            conn.execute(
+                "SELECT COALESCE(MAX(revision_number), 0) + 1 FROM memory_revisions "
+                "WHERE document_id = ?",
+                (document_id,),
+            ).fetchone()[0]
+        )
+        conn.execute(
+            "INSERT INTO memory_revisions "
+            "(document_id, revision_number, content_hash, source_hash, redacted_content, "
+            " source_mtime_ms, source_size, change_kind, summary, chunker_name, "
+            " chunker_version, chunker_config_json, enrichment_version, created_at) "
+            "VALUES (?, ?, ?, ?, NULL, ?, ?, 'rename', ?, ?, ?, ?, 1, ?)",
+            (
+                document_id,
+                revision_number,
+                content_hash,
+                content_hash,
+                observed_at,
+                0,
+                f"Renamed from {old_logical_path!r} to {logical_path!r}",
+                CHUNKER_NAME,
+                CHUNKER_VERSION,
+                json.dumps({"boundary": "heading", "retain_heading": True}, sort_keys=True),
+                observed_at,
+            ),
+        )
+    return document_id
+
+
+def prune_document_revisions(
+    conn: sqlite3.Connection,
+    document_id: int,
+    retention: RevisionRetention,
+    *,
+    now_ms: int,
+) -> int:
+    """Delete bounded historical revisions without touching current/active rows."""
+    row = conn.execute(
+        "SELECT current_revision_id, active_revision_id FROM memory_documents WHERE id = ?",
+        (document_id,),
+    ).fetchone()
+    if row is None:
+        return 0
+    protected = {int(row[0]) if row[0] is not None else None, int(row[1]) if row[1] is not None else None}
+    protected.discard(None)
+    revisions = conn.execute(
+        "SELECT id, revision_number, created_at FROM memory_revisions "
+        "WHERE document_id = ? ORDER BY revision_number ASC",
+        (document_id,),
+    ).fetchall()
+    cutoff = now_ms - retention.max_age_ms
+    deletable: list[int] = []
+    for rev_id, _revision_number, created_at in revisions:
+        if rev_id in protected:
+            continue
+        if created_at < cutoff:
+            deletable.append(int(rev_id))
+    surviving = [
+        int(rev_id)
+        for rev_id, _revision_number, _created_at in revisions
+        if int(rev_id) not in deletable and int(rev_id) not in protected
+    ]
+    while len(revisions) - len(deletable) > retention.max_count and surviving:
+        deletable.append(surviving.pop(0))
+    if not deletable:
+        return 0
+    with conn:
+        conn.executemany(
+            "DELETE FROM memory_revisions WHERE id = ?",
+            [(rev_id,) for rev_id in deletable],
+        )
+    return len(deletable)
+
+
+def query_memory_history(
+    conn: sqlite3.Connection,
+    *,
+    repository: str | None = None,
+    logical_path: str | None = None,
+    document_uuid: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Return bounded revision metadata for explicit history queries."""
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+    if not document_uuid and not (repository and logical_path):
+        raise ValueError("document_uuid or repository+logical_path is required")
+    clauses: list[str] = []
+    params: list[Any] = []
+    if document_uuid:
+        clauses.append("d.uuid = ?")
+        params.append(document_uuid)
+    if repository:
+        clauses.append("d.repository = ?")
+        params.append(repository)
+    if logical_path:
+        clauses.append("d.logical_path = ?")
+        params.append(logical_path)
+    where = " AND ".join(clauses)
+    rows = conn.execute(
+        f"SELECT d.uuid, d.repository, d.logical_path, d.source_path, d.state, "
+        f"r.revision_number, r.content_hash, r.change_kind, r.summary, r.diff_text, "
+        f"r.source_mtime_ms, r.created_at, r.enriched_at "
+        f"FROM memory_revisions r "
+        f"JOIN memory_documents d ON d.id = r.document_id "
+        f"WHERE {where} "
+        f"ORDER BY r.revision_number DESC LIMIT ?",
+        (*params, limit),
+    ).fetchall()
+    return [
+        {
+            "document_uuid": row[0],
+            "repository": row[1],
+            "logical_path": row[2],
+            "source_path": row[3],
+            "document_state": row[4],
+            "revision_number": row[5],
+            "content_hash": row[6],
+            "change_kind": row[7],
+            "summary": row[8],
+            "diff_text": row[9],
+            "source_mtime_ms": row[10],
+            "created_at": row[11],
+            "enriched_at": row[12],
+        }
+        for row in rows
+    ]
+
+
+def _delete_projection_for_revision(conn: sqlite3.Connection, revision_id: int) -> None:
+    old_node_id = conn.execute(
+        "SELECT knmc.knowledge_node_id FROM knowledge_node_memory_chunks knmc "
+        "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "
+        "WHERE mc.revision_id = ? LIMIT 1",
+        (revision_id,),
+    ).fetchone()
+    if old_node_id is None:
+        return
+    node_id = int(old_node_id[0])
+    if vec_table_available(conn):
+        conn.execute("DELETE FROM knowledge_vectors WHERE knowledge_node_id = ?", (node_id,))
+    conn.execute("DELETE FROM knowledge_node_memory_chunks WHERE knowledge_node_id = ?", (node_id,))
+    conn.execute("DELETE FROM knowledge_nodes WHERE id = ?", (node_id,))
+
+
+def tombstone_document(
+    conn: sqlite3.Connection,
+    document_id: int,
+    *,
+    now_ms: int,
+) -> None:
+    """Tombstone a confirmed-missing document while retaining bounded history."""
+    row = conn.execute(
+        "SELECT active_revision_id, current_revision_id, repository, logical_path, state "
+        "FROM memory_documents WHERE id = ?",
+        (document_id,),
+    ).fetchone()
+    if row is None or row[4] == "tombstoned":
+        return
+    active_revision_id, current_revision_id, repository, logical_path, _state = row
+    with conn:
+        if active_revision_id is not None:
+            _delete_projection_for_revision(conn, int(active_revision_id))
+        revision_number = int(
+            conn.execute(
+                "SELECT COALESCE(MAX(revision_number), 0) + 1 FROM memory_revisions "
+                "WHERE document_id = ?",
+                (document_id,),
+            ).fetchone()[0]
+        )
+        cursor = conn.execute(
+            "INSERT INTO memory_revisions "
+            "(document_id, revision_number, content_hash, source_hash, redacted_content, "
+            " source_mtime_ms, source_size, change_kind, summary, chunker_name, "
+            " chunker_version, chunker_config_json, enrichment_version, created_at) "
+            "VALUES (?, ?, ?, ?, NULL, ?, ?, 'delete', ?, ?, ?, ?, 1, ?)",
+            (
+                document_id,
+                revision_number,
+                "",
+                "",
+                now_ms,
+                0,
+                f"Document {logical_path!r} removed from {repository!r}",
+                CHUNKER_NAME,
+                CHUNKER_VERSION,
+                json.dumps({"boundary": "heading", "retain_heading": True}, sort_keys=True),
+                now_ms,
+            ),
+        )
+        delete_revision_id = int(cursor.lastrowid)
+        conn.execute(
+            "UPDATE memory_documents SET state = 'tombstoned', tombstoned_at = ?, "
+            "active_revision_id = NULL, projection_status = 'stale', observed_at = ?, "
+            "updated_at = ?, current_revision_id = ? WHERE id = ?",
+            (now_ms, now_ms, now_ms, delete_revision_id, document_id),
+        )
+
+
+def reconcile_missing_source(
+    conn: sqlite3.Connection,
+    document_id: int,
+    *,
+    now_ms: int,
+    absence_confirm_polls: int,
+) -> bool:
+    """Advance absence handling; tombstone after configured confirmation polls."""
+    row = conn.execute(
+        "SELECT state FROM memory_documents WHERE id = ?", (document_id,)
+    ).fetchone()
+    if row is None:
+        return False
+    state = row[0]
+    if state == "tombstoned":
+        return True
+    if state == "active":
+        conn.execute(
+            "UPDATE memory_documents SET state = 'unavailable', observed_at = ?, updated_at = ? "
+            "WHERE id = ?",
+            (now_ms, now_ms, document_id),
+        )
+        if absence_confirm_polls <= 1:
+            tombstone_document(conn, document_id, now_ms=now_ms)
+            return True
+        return False
+    if state == "unavailable":
+        tombstone_document(conn, document_id, now_ms=now_ms)
+        return True
+    return False
+
+
+def reconcile_configured_sources(
+    conn: sqlite3.Connection,
+    sources: list[dict[str, Any]],
+    *,
+    retention: RevisionRetention,
+    now_ms: int | None = None,
+) -> int:
+    """Mark configured-but-missing files unavailable, then tombstone after confirmation."""
+    observed_at = now_ms if now_ms is not None else int(time.time() * 1000)
+    tombstoned = 0
+    configured_paths = {
+        str(Path(source["path"]).expanduser().resolve())
+        for source in sources
+        if source.get("path")
+    }
+    for source_path in sorted(configured_paths):
+        if Path(source_path).is_file():
+            continue
+        rows = conn.execute(
+            "SELECT id FROM memory_documents WHERE source_path = ? AND state != 'tombstoned'",
+            (source_path,),
+        ).fetchall()
+        for (document_id,) in rows:
+            if reconcile_missing_source(
+                conn,
+                int(document_id),
+                now_ms=observed_at,
+                absence_confirm_polls=retention.absence_confirm_polls,
+            ):
+                prune_document_revisions(
+                    conn, int(document_id), retention, now_ms=observed_at
+                )
+                tombstoned += 1
+    return tombstoned
+
+
 def ingest_memory_file(
     conn: sqlite3.Connection,
     source_path: Path | str,
@@ -123,6 +484,7 @@ def ingest_memory_file(
     repository: str | None = None,
     logical_path: str | None = None,
     now_ms: int | None = None,
+    retention: RevisionRetention | None = None,
 ) -> IngestResult:
     """Read, redact, version, chunk, and enqueue one explicit memory file.
 
@@ -154,7 +516,7 @@ def ingest_memory_file(
     # so the path-keyed match is already unambiguous.
     explicit_repo = repository.strip() if repository and repository.strip() else None
     unchanged = conn.execute(
-        "SELECT d.id, d.uuid, r.id, r.revision_number "
+        "SELECT d.id, d.uuid, r.id, r.revision_number, r.source_hash "
         "FROM memory_documents d JOIN memory_revisions r ON r.id = d.current_revision_id "
         "WHERE d.source_kind = ? AND d.source_path = ? AND d.logical_path = ? "
         "AND (? IS NULL OR d.repository = ?) "
@@ -170,13 +532,15 @@ def ingest_memory_file(
         ),
     ).fetchone()
     if unchanged is not None:
-        doc_id, doc_uuid, rev_id, rev_num = unchanged
-        chunk_count = conn.execute(
-            "SELECT COUNT(*) FROM memory_chunks WHERE revision_id = ?", (rev_id,)
-        ).fetchone()[0]
-        return IngestResult(
-            int(doc_id), doc_uuid, int(rev_id), int(rev_num), False, int(chunk_count)
-        )
+        doc_id, doc_uuid, rev_id, rev_num, stored_source_hash = unchanged
+        source_text = path.read_text(encoding="utf-8")
+        if _sha256(source_text) == stored_source_hash:
+            chunk_count = conn.execute(
+                "SELECT COUNT(*) FROM memory_chunks WHERE revision_id = ?", (rev_id,)
+            ).fetchone()[0]
+            return IngestResult(
+                int(doc_id), doc_uuid, int(rev_id), int(rev_num), False, int(chunk_count)
+            )
 
     repository_identity = derive_repository_identity(path, repository)
 
@@ -188,6 +552,38 @@ def ingest_memory_file(
     document_uuid = str(
         uuid.uuid5(_IDENTITY_NAMESPACE, f"{SOURCE_KIND}\0{repository_identity}\0{identity_path}")
     )
+    retention_policy = retention or RevisionRetention()
+
+    renamed_document_id = _try_resolve_rename(
+        conn,
+        repository=repository_identity,
+        logical_path=identity_path,
+        content_hash=content_hash,
+        source_path=resolved,
+        observed_at=observed_at,
+    )
+    if renamed_document_id is not None:
+        row = conn.execute(
+            "SELECT d.uuid, d.current_revision_id, r.revision_number FROM memory_documents d "
+            "JOIN memory_revisions r ON r.id = d.current_revision_id WHERE d.id = ?",
+            (renamed_document_id,),
+        ).fetchone()
+        if row is not None:
+            doc_uuid, revision_id, revision_number = row[0], int(row[1]), int(row[2])
+            chunk_count = conn.execute(
+                "SELECT COUNT(*) FROM memory_chunks WHERE revision_id = ?", (revision_id,)
+            ).fetchone()[0]
+            prune_document_revisions(
+                conn, renamed_document_id, retention_policy, now_ms=observed_at
+            )
+            return IngestResult(
+                renamed_document_id,
+                doc_uuid,
+                revision_id,
+                revision_number,
+                False,
+                int(chunk_count),
+            )
 
     with conn:
         row = conn.execute(
@@ -224,7 +620,8 @@ def ingest_memory_file(
 
         if current_revision_id is not None:
             current = conn.execute(
-                "SELECT id, revision_number, content_hash FROM memory_revisions WHERE id = ?",
+                "SELECT id, revision_number, content_hash, redacted_content FROM memory_revisions "
+                "WHERE id = ?",
                 (current_revision_id,),
             ).fetchone()
             if current is not None and current[2] == content_hash:
@@ -239,6 +636,15 @@ def ingest_memory_file(
                     False,
                     int(chunk_count),
                 )
+
+        previous_redacted: str | None = None
+        if current_revision_id is not None:
+            previous = conn.execute(
+                "SELECT redacted_content FROM memory_revisions WHERE id = ?",
+                (current_revision_id,),
+            ).fetchone()
+            if previous is not None and previous[0]:
+                previous_redacted = previous[0]
 
         revision_number = int(
             conn.execute(
@@ -306,6 +712,15 @@ def ingest_memory_file(
             "consecutive_failures = 0, updated_at = ? WHERE source = ?",
             (observed_at, observed_at, observed_at, SOURCE_KIND),
         )
+        if previous_redacted is not None and current_revision_id is not None:
+            _finalize_superseded_revision(
+                conn,
+                int(current_revision_id),
+                old_redacted=previous_redacted,
+                new_redacted=redacted,
+            )
+
+    prune_document_revisions(conn, document_id, retention_policy, now_ms=observed_at)
 
     return IngestResult(
         document_id,
@@ -654,21 +1069,30 @@ def _schema_version(conn: sqlite3.Connection) -> int:
 def poll_sources(
     conn: sqlite3.Connection,
     sources: list[dict[str, Any]],
+    *,
+    retention: RevisionRetention | None = None,
 ) -> int:
     """Ingest every configured auto-memory source. Returns count of changed revisions."""
+    retention_policy = retention or RevisionRetention()
     changed = 0
     for source in sources:
         path = source.get("path")
         if not path:
+            continue
+        if not Path(path).is_file():
             continue
         result = ingest_memory_file(
             conn,
             path,
             repository=source.get("repository"),
             logical_path=source.get("logical_path"),
+            retention=retention_policy,
         )
         if result.changed:
             changed += 1
+    reconcile_configured_sources(
+        conn, sources, retention=retention_policy
+    )
     return changed
 
 
@@ -709,7 +1133,11 @@ def poll_from_config(config_path: Path | None = None) -> int:
                 f"found {version}; the daemon migrates hippo.db on startup. "
                 "Run `hippo doctor` to check daemon/brain version alignment."
             )
-        return poll_sources(conn, sources)
+        return poll_sources(
+            conn,
+            sources,
+            retention=revision_retention_from_config(auto_memory),
+        )
     finally:
         conn.close()
 
@@ -732,7 +1160,7 @@ def poll_main(argv: list[str] | None = None) -> int:
 def main(argv: list[str] | None = None) -> int:
     """Ingest one explicitly configured Claude auto-memory file."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--file", type=Path, required=True, help="Memory Markdown file")
+    parser.add_argument("--file", type=Path, help="Memory Markdown file")
     parser.add_argument(
         "--repository",
         help="Stable repository identity; defaults to sanitized Git origin or local path",
@@ -748,6 +1176,11 @@ def main(argv: list[str] | None = None) -> int:
         default=Path.home() / ".local" / "share" / "hippo" / "hippo.db",
         help="Hippo SQLite database",
     )
+    parser.add_argument(
+        "--history",
+        action="store_true",
+        help="Print bounded revision history instead of ingesting",
+    )
     args = parser.parse_args(argv)
     conn = _open_db(args.db)
     try:
@@ -756,6 +1189,19 @@ def main(argv: list[str] | None = None) -> int:
             parser.error(
                 f"database schema version must be {EXPECTED_SCHEMA_VERSION}, found {version}"
             )
+        if args.history:
+            if not args.repository or not args.logical_path:
+                parser.error("--history requires --repository and --logical-path")
+            history = query_memory_history(
+                conn,
+                repository=args.repository,
+                logical_path=args.logical_path,
+                limit=50,
+            )
+            print(json.dumps(history, sort_keys=True))
+            return 0
+        if args.file is None:
+            parser.error("--file is required unless --history is set")
         result = ingest_memory_file(
             conn,
             args.file,

--- a/brain/src/hippo_brain/auto_memory.py
+++ b/brain/src/hippo_brain/auto_memory.py
@@ -132,9 +132,7 @@ def revision_retention_from_config(auto_memory: dict[str, Any]) -> RevisionReten
     """Parse revision retention settings from a config ``[auto_memory]`` table."""
     max_count = int(auto_memory.get("max_revision_count", DEFAULT_MAX_REVISION_COUNT))
     max_age_days = int(auto_memory.get("max_revision_age_days", DEFAULT_MAX_REVISION_AGE_DAYS))
-    absence_polls = int(
-        auto_memory.get("absence_confirm_polls", DEFAULT_ABSENCE_CONFIRM_POLLS)
-    )
+    absence_polls = int(auto_memory.get("absence_confirm_polls", DEFAULT_ABSENCE_CONFIRM_POLLS))
     return RevisionRetention(
         max_count=max(max_count, 1),
         max_age_ms=max(max_age_days, 1) * 86_400_000,
@@ -253,7 +251,10 @@ def prune_document_revisions(
     ).fetchone()
     if row is None:
         return 0
-    protected = {int(row[0]) if row[0] is not None else None, int(row[1]) if row[1] is not None else None}
+    protected = {
+        int(row[0]) if row[0] is not None else None,
+        int(row[1]) if row[1] is not None else None,
+    }
     protected.discard(None)
     revisions = conn.execute(
         "SELECT id, revision_number, created_at FROM memory_revisions "
@@ -417,9 +418,7 @@ def reconcile_missing_source(
     absence_confirm_polls: int,
 ) -> bool:
     """Advance absence handling; tombstone after configured confirmation polls."""
-    row = conn.execute(
-        "SELECT state FROM memory_documents WHERE id = ?", (document_id,)
-    ).fetchone()
+    row = conn.execute("SELECT state FROM memory_documents WHERE id = ?", (document_id,)).fetchone()
     if row is None:
         return False
     state = row[0]
@@ -452,9 +451,7 @@ def reconcile_configured_sources(
     observed_at = now_ms if now_ms is not None else int(time.time() * 1000)
     tombstoned = 0
     configured_paths = {
-        str(Path(source["path"]).expanduser().resolve())
-        for source in sources
-        if source.get("path")
+        str(Path(source["path"]).expanduser().resolve()) for source in sources if source.get("path")
     }
     for source_path in sorted(configured_paths):
         if Path(source_path).is_file():
@@ -470,9 +467,7 @@ def reconcile_configured_sources(
                 now_ms=observed_at,
                 absence_confirm_polls=retention.absence_confirm_polls,
             ):
-                prune_document_revisions(
-                    conn, int(document_id), retention, now_ms=observed_at
-                )
+                prune_document_revisions(conn, int(document_id), retention, now_ms=observed_at)
                 tombstoned += 1
     return tombstoned
 
@@ -1090,9 +1085,7 @@ def poll_sources(
         )
         if result.changed:
             changed += 1
-    reconcile_configured_sources(
-        conn, sources, retention=retention_policy
-    )
+    reconcile_configured_sources(conn, sources, retention=retention_policy)
     return changed
 
 

--- a/brain/tests/test_auto_memory.py
+++ b/brain/tests/test_auto_memory.py
@@ -523,11 +523,12 @@ def test_supersede_deletes_old_node_vector(tmp_db, tmp_path: Path) -> None:
 def test_unchanged_file_skips_read_redact_and_git_identity(
     conn: sqlite3.Connection, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A poll of an unchanged file must short-circuit before the expensive work.
+    """A poll of an unchanged file must short-circuit before redact and Git identity.
 
-    The current revision stores mtime+size; when both still match the file on
-    disk, ingest must skip Git identity derivation, the full read, and the regex
-    redact — proven here by sabotaging those and requiring they are never called.
+    The current revision stores mtime+size+source_hash; when all still match the file
+    on disk, ingest reads once for a source-hash check but skips Git derivation and
+    regex redaction — proven here by sabotaging those and requiring they are never
+    called.
     """
     import hippo_brain.auto_memory as am
 

--- a/brain/tests/test_auto_memory_lifecycle.py
+++ b/brain/tests/test_auto_memory_lifecycle.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hippo_brain.auto_memory import (
+    RevisionRetention,
+    ingest_memory_file,
+    query_memory_history,
+    reconcile_configured_sources,
+    write_memory_knowledge_node,
+)
+from hippo_brain.models import EnrichmentResult
+from hippo_brain.mcp_queries import search_knowledge_lexical
+
+
+@pytest.fixture
+def conn(tmp_db):
+    connection, _path = tmp_db
+    yield connection
+
+
+def _publish(conn: sqlite3.Connection, revision_id: int, summary: str) -> int:
+    result = EnrichmentResult(
+        summary=summary,
+        intent="memory",
+        outcome="success",
+        tags=["memory"],
+        embed_text=summary,
+    )
+    node_id = write_memory_knowledge_node(
+        conn, result, revision_id, "mock-model", now_ms=revision_id * 1000
+    )
+    assert node_id is not None
+    return node_id
+
+
+def test_update_clears_superseded_redacted_content_and_stores_diff(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    source = tmp_path / "MEMORY.md"
+    source.write_text("# One\n\nFirst body.\n")
+    first = ingest_memory_file(conn, source, repository="hippo", now_ms=1000)
+
+    source.write_text("# One\n\nSecond body with more detail.\n")
+    second = ingest_memory_file(conn, source, repository="hippo", now_ms=2000)
+
+    assert second.revision_number == 2
+    old = conn.execute(
+        "SELECT redacted_content, summary, diff_text FROM memory_revisions WHERE id = ?",
+        (first.revision_id,),
+    ).fetchone()
+    assert old[0] is None
+    assert "added" in old[1]
+    assert "Second body" in old[2]
+    current = conn.execute(
+        "SELECT redacted_content FROM memory_revisions WHERE id = ?",
+        (second.revision_id,),
+    ).fetchone()[0]
+    assert "Second body" in current
+
+
+def test_history_query_returns_revision_metadata(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    source = tmp_path / "MEMORY.md"
+    source.write_text("# Alpha\n\none\n")
+    ingest_memory_file(conn, source, repository="hippo", now_ms=1000)
+    source.write_text("# Alpha\n\ntwo\n")
+    ingest_memory_file(conn, source, repository="hippo", now_ms=2000)
+
+    history = query_memory_history(
+        conn, repository="hippo", logical_path="MEMORY.md", limit=10
+    )
+    assert len(history) == 2
+    assert history[0]["revision_number"] == 2
+    assert history[0]["change_kind"] == "update"
+    assert history[1]["change_kind"] == "create"
+    assert "one" in (history[1]["diff_text"] or "")
+
+
+def test_unambiguous_rename_preserves_document_identity(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    old_path = tmp_path / "notes.md"
+    old_path.write_text("# Stable\n\nunchanged\n")
+    first = ingest_memory_file(
+        conn, old_path, repository="hippo", logical_path="notes.md", now_ms=1000
+    )
+
+    old_path.unlink()
+    new_path = tmp_path / "reference.md"
+    new_path.write_text("# Stable\n\nunchanged\n")
+    second = ingest_memory_file(
+        conn, new_path, repository="hippo", logical_path="reference.md", now_ms=2000
+    )
+
+    assert second.document_uuid == first.document_uuid
+    assert second.changed is False
+    rename = conn.execute(
+        "SELECT change_kind FROM memory_revisions WHERE document_id = ? "
+        "ORDER BY revision_number DESC LIMIT 1",
+        (first.document_id,),
+    ).fetchone()[0]
+    assert rename == "rename"
+
+
+def test_ambiguous_same_content_creates_distinct_documents(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    left = tmp_path / "a.md"
+    right = tmp_path / "b.md"
+    body = "# Shared\n\nsame text\n"
+    left.write_text(body)
+    right.write_text(body)
+
+    first = ingest_memory_file(conn, left, repository="hippo", logical_path="a.md")
+    second = ingest_memory_file(conn, right, repository="hippo", logical_path="b.md")
+
+    assert first.document_uuid != second.document_uuid
+    assert conn.execute("SELECT COUNT(*) FROM memory_documents").fetchone()[0] == 2
+
+
+def test_missing_source_becomes_unavailable_then_tombstoned(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    source = tmp_path / "MEMORY.md"
+    source.write_text("# Gone\n\nsoon\n")
+    ingested = ingest_memory_file(conn, source, repository="hippo", now_ms=1000)
+    _publish(conn, ingested.revision_id, "gone soon")
+    source.unlink()
+
+    retention = RevisionRetention(absence_confirm_polls=2)
+    sources = [{"path": str(source), "repository": "hippo", "logical_path": "MEMORY.md"}]
+
+    reconcile_configured_sources(conn, sources, retention=retention, now_ms=2000)
+    state = conn.execute(
+        "SELECT state FROM memory_documents WHERE id = ?", (ingested.document_id,)
+    ).fetchone()[0]
+    assert state == "unavailable"
+    assert (
+        search_knowledge_lexical(
+            conn, "gone", source="claude-auto-memory", project="hippo"
+        )
+        == []
+    )
+
+    reconcile_configured_sources(conn, sources, retention=retention, now_ms=3000)
+    state = conn.execute(
+        "SELECT state FROM memory_documents WHERE id = ?", (ingested.document_id,)
+    ).fetchone()[0]
+    assert state == "tombstoned"
+    history = query_memory_history(
+        conn, repository="hippo", logical_path="MEMORY.md", limit=5
+    )
+    assert history[0]["change_kind"] == "delete"
+
+
+def test_revision_pruning_respects_count(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    source = tmp_path / "MEMORY.md"
+    retention = RevisionRetention(max_count=2, max_age_ms=10_000_000)
+    for index in range(3):
+        source.write_text(f"# Rev {index}\n\nbody {index}\n")
+        ingest_memory_file(
+            conn, source, repository="hippo", now_ms=1000 + index, retention=retention
+        )
+
+    count = conn.execute(
+        "SELECT COUNT(*) FROM memory_revisions WHERE document_id = ?",
+        (
+            conn.execute("SELECT id FROM memory_documents").fetchone()[0],
+        ),
+    ).fetchone()[0]
+    assert count == 2
+
+
+def test_full_lifecycle_add_update_history_rename_delete(
+    tmp_db, tmp_path: Path
+) -> None:
+    from hippo_brain import vector_store
+
+    _seeded, db_path = tmp_db
+    conn = vector_store.open_conn(db_path)
+    path = tmp_path / "MEMORY.md"
+    path.write_text("# Start\n\nv1\n")
+    first = ingest_memory_file(conn, path, repository="hippo", now_ms=1000)
+    _publish(conn, first.revision_id, "start v1")
+
+    path.write_text("# Start\n\nv2\n")
+    second = ingest_memory_file(conn, path, repository="hippo", now_ms=2000)
+    _publish(conn, second.revision_id, "start v2")
+    assert len(query_memory_history(conn, repository="hippo", logical_path="MEMORY.md")) >= 2
+
+    path.unlink()
+    renamed = tmp_path / "ARCHIVE.md"
+    renamed.write_text("# Start\n\nv2\n")
+    third = ingest_memory_file(
+        conn, renamed, repository="hippo", logical_path="ARCHIVE.md", now_ms=3000
+    )
+    assert third.document_uuid == first.document_uuid
+
+    sources = [{"path": str(renamed), "repository": "hippo", "logical_path": "ARCHIVE.md"}]
+    renamed.unlink()
+    reconcile_configured_sources(
+        conn, sources, retention=RevisionRetention(absence_confirm_polls=1), now_ms=4000
+    )
+    assert (
+        conn.execute(
+            "SELECT state FROM memory_documents WHERE id = ?", (first.document_id,)
+        ).fetchone()[0]
+        == "tombstoned"
+    )
+    assert (
+        search_knowledge_lexical(
+            conn, "start", source="claude-auto-memory", project="hippo"
+        )
+        == []
+    )

--- a/brain/tests/test_auto_memory_lifecycle.py
+++ b/brain/tests/test_auto_memory_lifecycle.py
@@ -69,9 +69,7 @@ def test_history_query_returns_revision_metadata(conn: sqlite3.Connection, tmp_p
     source.write_text("# Alpha\n\ntwo\n")
     ingest_memory_file(conn, source, repository="hippo", now_ms=2000)
 
-    history = query_memory_history(
-        conn, repository="hippo", logical_path="MEMORY.md", limit=10
-    )
+    history = query_memory_history(conn, repository="hippo", logical_path="MEMORY.md", limit=10)
     assert len(history) == 2
     assert history[0]["revision_number"] == 2
     assert history[0]["change_kind"] == "update"
@@ -139,10 +137,7 @@ def test_missing_source_becomes_unavailable_then_tombstoned(
     ).fetchone()[0]
     assert state == "unavailable"
     assert (
-        search_knowledge_lexical(
-            conn, "gone", source="claude-auto-memory", project="hippo"
-        )
-        == []
+        search_knowledge_lexical(conn, "gone", source="claude-auto-memory", project="hippo") == []
     )
 
     reconcile_configured_sources(conn, sources, retention=retention, now_ms=3000)
@@ -150,9 +145,7 @@ def test_missing_source_becomes_unavailable_then_tombstoned(
         "SELECT state FROM memory_documents WHERE id = ?", (ingested.document_id,)
     ).fetchone()[0]
     assert state == "tombstoned"
-    history = query_memory_history(
-        conn, repository="hippo", logical_path="MEMORY.md", limit=5
-    )
+    history = query_memory_history(conn, repository="hippo", logical_path="MEMORY.md", limit=5)
     assert history[0]["change_kind"] == "delete"
 
 
@@ -167,16 +160,12 @@ def test_revision_pruning_respects_count(conn: sqlite3.Connection, tmp_path: Pat
 
     count = conn.execute(
         "SELECT COUNT(*) FROM memory_revisions WHERE document_id = ?",
-        (
-            conn.execute("SELECT id FROM memory_documents").fetchone()[0],
-        ),
+        (conn.execute("SELECT id FROM memory_documents").fetchone()[0],),
     ).fetchone()[0]
     assert count == 2
 
 
-def test_full_lifecycle_add_update_history_rename_delete(
-    tmp_db, tmp_path: Path
-) -> None:
+def test_full_lifecycle_add_update_history_rename_delete(tmp_db, tmp_path: Path) -> None:
     from hippo_brain import vector_store
 
     _seeded, db_path = tmp_db
@@ -211,8 +200,5 @@ def test_full_lifecycle_add_update_history_rename_delete(
         == "tombstoned"
     )
     assert (
-        search_knowledge_lexical(
-            conn, "start", source="claude-auto-memory", project="hippo"
-        )
-        == []
+        search_knowledge_lexical(conn, "start", source="claude-auto-memory", project="hippo") == []
     )

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -249,7 +249,9 @@ enabled = true
 # its privacy boundaries are configured.
 [auto_memory]
 enabled = false
-# poll_interval_secs = 60  # com.hippo.auto-memory LaunchAgent cadence
+# max_revision_count: keep at most this many revisions per document (default 20)
+# max_revision_age_days: drop older revision metadata after this many days (default 90)
+# absence_confirm_polls: missing-file polls before tombstone (default 2)
 
 # [[auto_memory.sources]]
 # path = "/absolute/path/to/.claude/memory/MEMORY.md"

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -41,6 +41,25 @@ search_knowledge(query="busy timeout", mode="lexical", source="claude-auto-memor
 
 Results include `source`, `source_path`, `repository`, `logical_path`, `content_hash`, and capture time. Only the active revision is ever queryable: superseding a revision replaces its knowledge node (and vector), and a revision superseded before its enrichment finishes is discarded rather than published, so stale memory content never appears in answers.
 
+## Revision history
+
+Each content update stores bounded summary/diff metadata on superseded revisions and clears their redacted bodies. Historical revisions never appear in normal `search_knowledge` results; use explicit history instead:
+
+```sh
+mise run ingest:auto-memory -- \
+  --history \
+  --repository owner/repository \
+  --logical-path MEMORY.md
+```
+
+Retention defaults (override in `[auto_memory]`):
+
+- `max_revision_count = 20`
+- `max_revision_age_days = 90`
+- `absence_confirm_polls = 2` (configured file missing on consecutive polls before tombstone)
+
+Renames are detected when exactly one prior document shares the same redacted hash, the old path is gone, and the new path is ingested. Deleted files move to `unavailable` on the first missing poll, then `tombstoned` after confirmation; tombstoned documents drop out of retrieval but keep bounded history.
+
 ## Storage and rollback
 
 Schema v19 adds only additive tables: `memory_documents`, `memory_revisions`, `memory_chunks`, `memory_enrichment_queue`, and `knowledge_node_memory_chunks`. Existing source and knowledge tables are unchanged.


### PR DESCRIPTION
## Summary
- Superseded revisions keep bounded summary/diff metadata; redacted bodies cleared from history
- `query_memory_history` + `--history` CLI; rename detection; tombstone after confirmed absence
- Configurable `max_revision_count`, `max_revision_age_days`, `absence_confirm_polls`
- Fix ingest fast-path: verify `source_hash` when mtime+size match (same-size edits)

## Test plan
- [x] `pytest brain/tests/test_auto_memory_lifecycle.py brain/tests/test_auto_memory.py -q`
- [x] CI

Closes SNUG-133