### PR TITLE
feat(auto-memory): categorize and link memory knowledge (SNUG-136)

### DIFF
--- a/brain/src/hippo_brain/auto_memory.py
+++ b/brain/src/hippo_brain/auto_memory.py
@@ -16,6 +16,7 @@ from hippo_brain.auto_memory_constants import (
     SOURCE_KIND,
     _IDENTITY_NAMESPACE,
 )
+from hippo_brain.auto_memory_categories import replace_model_categories
 from hippo_brain.auto_memory_lifecycle import (
     RevisionRetention,
     query_memory_history,
@@ -56,6 +57,7 @@ The input is already redacted. Produce a JSON object with:
 - outcome: one of success, failure, partial, unknown
 - entities: object with keys projects, tools, files, services, errors (each a list of strings)
 - tags: short topical tags
+- memory_categories: zero or more of user, feedback, project, reference inferred from content (never index)
 - key_decisions: list of notable decisions or conventions captured
 - problems_encountered: list of problems or pitfalls documented
 - design_decisions: list of objects with decision, rationale, alternatives (may be empty)
@@ -367,6 +369,13 @@ def write_memory_knowledge_node(
             "UPDATE memory_documents SET active_revision_id = ?, projection_status = 'ready', "
             "last_error = NULL, updated_at = ? WHERE id = ?",
             (revision_id, completed_at, document_id),
+        )
+        replace_model_categories(
+            conn,
+            document_id,
+            result.memory_categories,
+            model_name=model_name,
+            now_ms=completed_at,
         )
         conn.commit()
     except Exception:

--- a/brain/src/hippo_brain/auto_memory_categories.py
+++ b/brain/src/hippo_brain/auto_memory_categories.py
@@ -1,0 +1,371 @@
+"""Deterministic and model-derived categories plus MEMORY.md index links."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+INDEX_LOGICAL_PATH = "MEMORY.md"
+KNOWN_CATEGORIES = frozenset({"user", "feedback", "project", "reference", "index"})
+FILENAME_PREFIX_CATEGORIES = (
+    ("feedback_", "feedback"),
+    ("project_", "project"),
+    ("reference_", "reference"),
+    ("user_", "user"),
+)
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+
+
+@dataclass(frozen=True)
+class MarkdownLink:
+    anchor_text: str
+    href: str
+
+
+@dataclass(frozen=True)
+class CategoryRecord:
+    category: str
+    source: str
+    confidence: float | None
+    model: str | None
+    enrichment_version: int | None
+    created_at: int
+    updated_at: int
+
+
+def category_from_filename(logical_path: str) -> str | None:
+    """Return a deterministic category from the memory filename, if any."""
+    name = PurePosixPath(logical_path).name
+    if name == INDEX_LOGICAL_PATH:
+        return "index"
+    stem = PurePosixPath(name).stem.lower()
+    if stem == "user":
+        return "user"
+    lowered = name.lower()
+    for prefix, category in FILENAME_PREFIX_CATEGORIES:
+        if lowered.startswith(prefix):
+            return category
+    return None
+
+
+def extract_markdown_links(markdown: str) -> list[MarkdownLink]:
+    """Extract inline Markdown links from redacted content."""
+    links: list[MarkdownLink] = []
+    for match in _MARKDOWN_LINK_RE.finditer(markdown):
+        href = match.group(2).strip()
+        if href:
+            links.append(MarkdownLink(anchor_text=match.group(1).strip(), href=href))
+    return links
+
+
+def _memory_directory(source_path: Path) -> Path:
+    return source_path.expanduser().resolve().parent
+
+
+def _normalize_href(href: str) -> str:
+    return href.strip().split("#", 1)[0].strip()
+
+
+def classify_link_resolution(
+    href: str,
+    *,
+    memory_dir: Path,
+    source_document_id: int,
+    repository: str,
+    conn: sqlite3.Connection,
+) -> tuple[str, str, int | None]:
+    """Return (target_logical_path, resolution, target_document_id)."""
+    normalized = _normalize_href(href)
+    if not normalized or normalized.startswith("#"):
+        return normalized or href, "external", None
+    lowered = normalized.lower()
+    if lowered.startswith(("http://", "https://", "mailto:")):
+        return normalized, "external", None
+
+    target_path = (memory_dir / normalized).resolve()
+    try:
+        target_path.relative_to(memory_dir.resolve())
+    except ValueError:
+        return PurePosixPath(normalized).name or normalized, "external", None
+
+    logical_path = PurePosixPath(normalized).name
+    if not logical_path:
+        return normalized, "external", None
+
+    rows = conn.execute(
+        "SELECT id FROM memory_documents WHERE repository = ? AND logical_path = ? "
+        "AND state = 'active'",
+        (repository, logical_path),
+    ).fetchall()
+    if len(rows) > 1:
+        return logical_path, "ambiguous", None
+    if len(rows) == 1:
+        target_id = int(rows[0][0])
+        if target_id == source_document_id:
+            return logical_path, "circular", None
+        if _would_create_cycle(conn, source_document_id, target_id):
+            return logical_path, "circular", target_id
+        return logical_path, "resolved", target_id
+    if target_path.is_file():
+        return logical_path, "unresolved", None
+    return logical_path, "unresolved", None
+
+
+def _would_create_cycle(
+    conn: sqlite3.Connection, source_document_id: int, target_document_id: int
+) -> bool:
+    """True when following resolved links from target reaches source."""
+    seen = {source_document_id}
+    frontier = [target_document_id]
+    while frontier:
+        current = frontier.pop()
+        if current in seen:
+            return True
+        seen.add(current)
+        next_ids = [
+            int(row[0])
+            for row in conn.execute(
+                "SELECT DISTINCT target_document_id FROM memory_document_links "
+                "WHERE source_document_id = ? AND resolution = 'resolved' "
+                "AND target_document_id IS NOT NULL",
+                (current,),
+            ).fetchall()
+        ]
+        frontier.extend(next_ids)
+    return False
+
+
+def upsert_filename_category(
+    conn: sqlite3.Connection,
+    document_id: int,
+    logical_path: str,
+    *,
+    now_ms: int,
+) -> str | None:
+    """Upsert the deterministic filename category; returns category or None."""
+    category = category_from_filename(logical_path)
+    if category is None:
+        conn.execute(
+            "DELETE FROM memory_document_categories WHERE document_id = ? AND source = 'filename'",
+            (document_id,),
+        )
+        return None
+    conn.execute(
+        "INSERT INTO memory_document_categories "
+        "(document_id, category, source, confidence, model, enrichment_version, "
+        " created_at, updated_at) VALUES (?, ?, 'filename', 1.0, NULL, NULL, ?, ?) "
+        "ON CONFLICT(document_id, category, source) DO UPDATE SET "
+        "updated_at = excluded.updated_at",
+        (document_id, category, now_ms, now_ms),
+    )
+    return category
+
+
+def replace_model_categories(
+    conn: sqlite3.Connection,
+    document_id: int,
+    categories: list[str],
+    *,
+    model_name: str,
+    enrichment_version: int = 1,
+    now_ms: int,
+    default_confidence: float = 0.8,
+) -> None:
+    """Replace model-derived categories for a document."""
+    conn.execute(
+        "DELETE FROM memory_document_categories WHERE document_id = ? AND source = 'model'",
+        (document_id,),
+    )
+    for raw in categories:
+        category = raw.strip().lower()
+        if not category or category not in KNOWN_CATEGORIES or category == "index":
+            continue
+        conn.execute(
+            "INSERT INTO memory_document_categories "
+            "(document_id, category, source, confidence, model, enrichment_version, "
+            " created_at, updated_at) VALUES (?, ?, 'model', ?, ?, ?, ?, ?) "
+            "ON CONFLICT(document_id, category, source) DO UPDATE SET "
+            "confidence = excluded.confidence, model = excluded.model, "
+            "enrichment_version = excluded.enrichment_version, updated_at = excluded.updated_at",
+            (
+                document_id,
+                category,
+                default_confidence,
+                model_name,
+                enrichment_version,
+                now_ms,
+                now_ms,
+            ),
+        )
+
+
+def reconcile_index_links(
+    conn: sqlite3.Connection,
+    *,
+    document_id: int,
+    revision_id: int,
+    logical_path: str,
+    repository: str,
+    source_path: Path,
+    redacted_content: str,
+    now_ms: int,
+) -> int:
+    """Rebuild MEMORY.md index links for one revision. Returns link count."""
+    if logical_path != INDEX_LOGICAL_PATH:
+        return 0
+    memory_dir = _memory_directory(source_path)
+    conn.execute(
+        "DELETE FROM memory_document_links WHERE source_document_id = ?",
+        (document_id,),
+    )
+    inserted = 0
+    for link in extract_markdown_links(redacted_content):
+        target_logical_path, resolution, target_document_id = classify_link_resolution(
+            link.href,
+            memory_dir=memory_dir,
+            source_document_id=document_id,
+            repository=repository,
+            conn=conn,
+        )
+        conn.execute(
+            "INSERT INTO memory_document_links "
+            "(source_document_id, source_revision_id, target_document_id, "
+            " target_logical_path, anchor_text, resolution, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                document_id,
+                revision_id,
+                target_document_id,
+                target_logical_path,
+                link.anchor_text,
+                resolution,
+                now_ms,
+                now_ms,
+            ),
+        )
+        inserted += 1
+    return inserted
+
+
+def retry_unresolved_links(
+    conn: sqlite3.Connection,
+    *,
+    repository: str,
+    memory_dir: Path,
+    now_ms: int,
+) -> int:
+    """Re-resolve pending index links after a new topic file lands."""
+    rows = conn.execute(
+        "SELECT mdl.id, mdl.source_document_id, mdl.target_logical_path "
+        "FROM memory_document_links mdl "
+        "JOIN memory_documents md ON md.id = mdl.source_document_id "
+        "WHERE md.repository = ? AND mdl.resolution = 'unresolved'",
+        (repository,),
+    ).fetchall()
+    updated = 0
+    for link_id, source_document_id, target_logical_path in rows:
+        target_path = memory_dir / target_logical_path
+        if not target_path.is_file():
+            continue
+        target_rows = conn.execute(
+            "SELECT id FROM memory_documents WHERE repository = ? AND logical_path = ? "
+            "AND state = 'active'",
+            (repository, target_logical_path),
+        ).fetchall()
+        if len(target_rows) != 1:
+            resolution = "ambiguous" if len(target_rows) > 1 else "unresolved"
+            conn.execute(
+                "UPDATE memory_document_links SET resolution = ?, updated_at = ? WHERE id = ?",
+                (resolution, now_ms, link_id),
+            )
+            continue
+        target_document_id = int(target_rows[0][0])
+        resolution = "circular"
+        if target_document_id != source_document_id and not _would_create_cycle(
+            conn, source_document_id, target_document_id
+        ):
+            resolution = "resolved"
+        conn.execute(
+            "UPDATE memory_document_links SET target_document_id = ?, resolution = ?, "
+            "updated_at = ? WHERE id = ?",
+            (target_document_id, resolution, now_ms, link_id),
+        )
+        updated += 1
+    return updated
+
+
+def reconcile_document_taxonomy(
+    conn: sqlite3.Connection,
+    *,
+    document_id: int,
+    revision_id: int,
+    repository: str,
+    logical_path: str,
+    source_path: Path,
+    redacted_content: str,
+    now_ms: int,
+    content_changed: bool,
+) -> None:
+    """Refresh filename categories and index links after ingest."""
+    upsert_filename_category(conn, document_id, logical_path, now_ms=now_ms)
+    if content_changed:
+        reconcile_index_links(
+            conn,
+            document_id=document_id,
+            revision_id=revision_id,
+            logical_path=logical_path,
+            repository=repository,
+            source_path=source_path,
+            redacted_content=redacted_content,
+            now_ms=now_ms,
+        )
+        retry_unresolved_links(
+            conn,
+            repository=repository,
+            memory_dir=_memory_directory(source_path),
+            now_ms=now_ms,
+        )
+
+
+def list_document_categories(conn: sqlite3.Connection, document_id: int) -> list[CategoryRecord]:
+    rows = conn.execute(
+        "SELECT category, source, confidence, model, enrichment_version, created_at, updated_at "
+        "FROM memory_document_categories WHERE document_id = ? ORDER BY category, source",
+        (document_id,),
+    ).fetchall()
+    return [
+        CategoryRecord(
+            category=row[0],
+            source=row[1],
+            confidence=row[2],
+            model=row[3],
+            enrichment_version=row[4],
+            created_at=int(row[5]),
+            updated_at=int(row[6]),
+        )
+        for row in rows
+    ]
+
+
+def list_document_links(conn: sqlite3.Connection, document_id: int) -> list[dict[str, object]]:
+    rows = conn.execute(
+        "SELECT target_logical_path, anchor_text, resolution, target_document_id, "
+        "source_revision_id, created_at, updated_at "
+        "FROM memory_document_links WHERE source_document_id = ? "
+        "ORDER BY target_logical_path",
+        (document_id,),
+    ).fetchall()
+    return [
+        {
+            "target_logical_path": row[0],
+            "anchor_text": row[1],
+            "resolution": row[2],
+            "target_document_id": row[3],
+            "source_revision_id": row[4],
+            "created_at": row[5],
+            "updated_at": row[6],
+        }
+        for row in rows
+    ]

--- a/brain/src/hippo_brain/auto_memory_categories.py
+++ b/brain/src/hippo_brain/auto_memory_categories.py
@@ -50,6 +50,12 @@ def category_from_filename(logical_path: str) -> str | None:
     return None
 
 
+def validate_memory_category_filter(category: str) -> None:
+    """Reject unknown memory category filters (mirrors source filter validation)."""
+    if category not in KNOWN_CATEGORIES:
+        raise ValueError(f"unknown memory category filter: {category!r}")
+
+
 def extract_markdown_links(markdown: str) -> list[MarkdownLink]:
     """Extract inline Markdown links from redacted content."""
     links: list[MarkdownLink] = []
@@ -310,7 +316,24 @@ def reconcile_document_taxonomy(
 ) -> None:
     """Refresh filename categories and index links after ingest."""
     upsert_filename_category(conn, document_id, logical_path, now_ms=now_ms)
-    if content_changed:
+    missing_index_links = False
+    if logical_path == INDEX_LOGICAL_PATH:
+        missing_index_links = (
+            conn.execute(
+                "SELECT COUNT(*) FROM memory_document_links WHERE source_document_id = ?",
+                (document_id,),
+            ).fetchone()[0]
+            == 0
+        )
+    should_reconcile_links = content_changed or missing_index_links
+    if should_reconcile_links:
+        body = redacted_content
+        if not body:
+            row = conn.execute(
+                "SELECT redacted_content FROM memory_revisions WHERE id = ?",
+                (revision_id,),
+            ).fetchone()
+            body = row[0] if row is not None and row[0] else ""
         reconcile_index_links(
             conn,
             document_id=document_id,
@@ -318,9 +341,10 @@ def reconcile_document_taxonomy(
             logical_path=logical_path,
             repository=repository,
             source_path=source_path,
-            redacted_content=redacted_content,
+            redacted_content=body,
             now_ms=now_ms,
         )
+    if content_changed or missing_index_links:
         retry_unresolved_links(
             conn,
             repository=repository,

--- a/brain/src/hippo_brain/auto_memory_ingest.py
+++ b/brain/src/hippo_brain/auto_memory_ingest.py
@@ -24,6 +24,7 @@ from hippo_brain.auto_memory_lifecycle import (
     prune_document_revisions,
     try_resolve_rename,
 )
+from hippo_brain.auto_memory_categories import reconcile_document_taxonomy
 from hippo_brain.markdown_chunking import MarkdownChunk, markdown_heading_chunks
 from hippo_brain.redaction import redact
 
@@ -86,6 +87,31 @@ def _chunks(markdown: str) -> list[MarkdownChunk]:
     return markdown_heading_chunks(markdown)
 
 
+def _apply_taxonomy(
+    conn: sqlite3.Connection,
+    *,
+    document_id: int,
+    revision_id: int,
+    repository: str,
+    logical_path: str,
+    path: Path,
+    redacted: str | None,
+    changed: bool,
+    now_ms: int,
+) -> None:
+    reconcile_document_taxonomy(
+        conn,
+        document_id=document_id,
+        revision_id=revision_id,
+        repository=repository,
+        logical_path=logical_path,
+        source_path=path,
+        redacted_content=redacted or "",
+        now_ms=now_ms,
+        content_changed=changed,
+    )
+
+
 def ingest_memory_file(
     conn: sqlite3.Connection,
     source_path: Path | str,
@@ -125,7 +151,7 @@ def ingest_memory_file(
     # so the path-keyed match is already unambiguous.
     explicit_repo = repository.strip() if repository and repository.strip() else None
     unchanged = conn.execute(
-        "SELECT d.id, d.uuid, r.id, r.revision_number, r.source_hash "
+        "SELECT d.id, d.uuid, r.id, r.revision_number, r.source_hash, d.repository "
         "FROM memory_documents d JOIN memory_revisions r ON r.id = d.current_revision_id "
         "WHERE d.source_kind = ? AND d.source_path = ? AND d.logical_path = ? "
         "AND (? IS NULL OR d.repository = ?) "
@@ -141,12 +167,24 @@ def ingest_memory_file(
         ),
     ).fetchone()
     if unchanged is not None:
-        doc_id, doc_uuid, rev_id, rev_num, stored_source_hash = unchanged
+        doc_id, doc_uuid, rev_id, rev_num, stored_source_hash, stored_repository = unchanged
         source_text = path.read_text(encoding="utf-8")
         if _sha256(source_text) == stored_source_hash:
             chunk_count = conn.execute(
                 "SELECT COUNT(*) FROM memory_chunks WHERE revision_id = ?", (rev_id,)
             ).fetchone()[0]
+            _apply_taxonomy(
+                conn,
+                document_id=int(doc_id),
+                revision_id=int(rev_id),
+                repository=stored_repository,
+                logical_path=identity_path,
+                path=path,
+                redacted=None,
+                changed=False,
+                now_ms=now_ms if now_ms is not None else int(time.time() * 1000),
+            )
+            conn.commit()
             return IngestResult(
                 int(doc_id), doc_uuid, int(rev_id), int(rev_num), False, int(chunk_count)
             )
@@ -185,6 +223,18 @@ def ingest_memory_file(
             prune_document_revisions(
                 conn, renamed_document_id, retention_policy, now_ms=observed_at
             )
+            _apply_taxonomy(
+                conn,
+                document_id=renamed_document_id,
+                revision_id=revision_id,
+                repository=repository_identity,
+                logical_path=identity_path,
+                path=path,
+                redacted=None,
+                changed=False,
+                now_ms=observed_at,
+            )
+            conn.commit()
             return IngestResult(
                 renamed_document_id,
                 doc_uuid,
@@ -237,6 +287,17 @@ def ingest_memory_file(
                 chunk_count = conn.execute(
                     "SELECT COUNT(*) FROM memory_chunks WHERE revision_id = ?", (current[0],)
                 ).fetchone()[0]
+                _apply_taxonomy(
+                    conn,
+                    document_id=document_id,
+                    revision_id=int(current[0]),
+                    repository=repository_identity,
+                    logical_path=identity_path,
+                    path=path,
+                    redacted=current[3],
+                    changed=False,
+                    now_ms=observed_at,
+                )
                 return IngestResult(
                     document_id,
                     document_uuid,
@@ -328,8 +389,20 @@ def ingest_memory_file(
                 old_redacted=previous_redacted,
                 new_redacted=redacted,
             )
+        _apply_taxonomy(
+            conn,
+            document_id=document_id,
+            revision_id=revision_id,
+            repository=repository_identity,
+            logical_path=identity_path,
+            path=path,
+            redacted=redacted,
+            changed=True,
+            now_ms=observed_at,
+        )
 
     prune_document_revisions(conn, document_id, retention_policy, now_ms=observed_at)
+    conn.commit()
 
     return IngestResult(
         document_id,

--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -189,6 +189,7 @@ async def search_knowledge(
     since: str = "",
     source: str = "",
     branch: str = "",
+    category: str = "",
     include_excluded: bool = False,
 ) -> list[dict]:
     """Search the Hippo knowledge base for enriched knowledge nodes.
@@ -204,6 +205,7 @@ async def search_knowledge(
                 "claude", "browser", "workflow", or "claude-auto-memory".
                 Empty means all sources; an unrecognized source raises.
         branch: Exact match on git_branch of linked events/sessions.
+        category: Auto-memory category filter (feedback, project, reference, user, index).
         include_excluded: Operator mode — include probe/diagnostic rows (default false).
     """
     include_excluded = include_excluded or include_excluded_from_env()
@@ -212,7 +214,7 @@ async def search_knowledge(
     t0 = time.monotonic()
     logger.info(
         "search_knowledge called: query=%r mode=%s limit=%d project=%r since=%r "
-        "source=%r branch=%r",
+        "source=%r branch=%r category=%r",
         query,
         mode,
         limit,
@@ -220,6 +222,7 @@ async def search_knowledge(
         since,
         source,
         branch,
+        category,
     )
 
     tracer = _get_tracer()
@@ -243,6 +246,7 @@ async def search_knowledge(
                         since=since,
                         source=source,
                         branch=branch,
+                        category=category,
                         include_excluded=include_excluded,
                     )
                     elapsed = time.monotonic() - t0
@@ -267,6 +271,7 @@ async def search_knowledge(
                     since=since,
                     source=source,
                     branch=branch,
+                    category=category,
                     include_excluded=include_excluded,
                 )
             finally:
@@ -618,6 +623,7 @@ async def _retrieve_filtered(
     since: str,
     source: str,
     branch: str,
+    category: str = "",
     entity: str = "",
     include_excluded: bool = False,
 ) -> list[dict]:
@@ -636,6 +642,7 @@ async def _retrieve_filtered(
         source=source or None,
         branch=branch or None,
         entity=entity or None,
+        memory_category=category or None,
         include_excluded=include_excluded or include_excluded_from_env(),
     )
 
@@ -662,6 +669,7 @@ async def _retrieve_filtered(
                 since=since,
                 source=source,
                 branch=branch,
+                category=category,
                 include_excluded=filters.include_excluded,
             )
     finally:

--- a/brain/src/hippo_brain/mcp_queries.py
+++ b/brain/src/hippo_brain/mcp_queries.py
@@ -10,12 +10,17 @@ import sqlite3
 import time
 from datetime import datetime, timezone
 
+from hippo_brain.auto_memory_categories import (
+    list_document_categories,
+    list_document_links,
+)
 from hippo_brain.models import CIAnnotation, CIJob, CIStatus, Lesson
 from hippo_brain.retrieval_eligibility import (
     agentic_session_eligible_sql,
     knowledge_node_eligible_exists_sql,
 )
 from hippo_brain.source_filters import (
+    knowledge_memory_category_clause,
     knowledge_memory_project_clause,
     knowledge_source_exists_clause,
     table_exists as _table_exists,
@@ -155,12 +160,44 @@ def parse_since(since: str) -> int:
     return now_ms - (value * unit_ms)
 
 
+def _memory_provenance(
+    conn: sqlite3.Connection, node_id: int
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    row = conn.execute(
+        "SELECT md.id FROM knowledge_node_memory_chunks knmc "
+        "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "
+        "JOIN memory_revisions mr ON mr.id = mc.revision_id "
+        "JOIN memory_documents md ON md.id = mr.document_id "
+        "WHERE knmc.knowledge_node_id = ? AND md.active_revision_id = mr.id "
+        "AND md.state = 'active' LIMIT 1",
+        (node_id,),
+    ).fetchone()
+    if row is None:
+        return [], []
+    document_id = int(row[0])
+    categories = [
+        {
+            "category": item.category,
+            "source": item.source,
+            "confidence": item.confidence,
+            "model": item.model,
+            "enrichment_version": item.enrichment_version,
+            "created_at": item.created_at,
+            "updated_at": item.updated_at,
+        }
+        for item in list_document_categories(conn, document_id)
+    ]
+    links = list_document_links(conn, document_id)
+    return categories, links
+
+
 def _build_knowledge_filter_clause(
     conn: sqlite3.Connection,
     project: str,
     since_ms: int,
     source: str,
     branch: str,
+    category: str = "",
     *,
     include_excluded: bool = False,
 ) -> tuple[str, list]:
@@ -244,6 +281,13 @@ def _build_knowledge_filter_clause(
             raise ValueError(f"unknown source filter: {source!r}")
         clauses.append(source_clause)
 
+    if category:
+        category_clause = knowledge_memory_category_clause(conn)
+        if category_clause is None:
+            raise ValueError("memory category filter requires schema v20+")
+        clauses.append(category_clause)
+        params.append(category)
+
     where = (" AND " + " AND ".join(clauses)) if clauses else ""
     return where, params
 
@@ -256,6 +300,7 @@ def search_knowledge_lexical(
     since: str = "",
     source: str = "",
     branch: str = "",
+    category: str = "",
     *,
     include_excluded: bool = False,
 ) -> list[dict]:
@@ -267,6 +312,7 @@ def search_knowledge_lexical(
         since_ms=since_ms,
         source=source,
         branch=branch,
+        category=category,
         include_excluded=include_excluded,
     )
 
@@ -301,6 +347,7 @@ def search_knowledge_lexical(
         source_meta = content.get("source", {}) if isinstance(content, dict) else {}
         tags = _safe_json_loads(tags_str, []) if tags_str else []
         event_ids, claude_ids, browser_ids = _knowledge_node_links(conn, node_id)
+        memory_categories, memory_links = _memory_provenance(conn, node_id)
 
         results.append(
             {
@@ -319,6 +366,8 @@ def search_knowledge_lexical(
                 "repository": source_meta.get("repository", ""),
                 "logical_path": source_meta.get("logical_path", ""),
                 "content_hash": source_meta.get("content_hash", ""),
+                "memory_categories": memory_categories,
+                "memory_links": memory_links,
                 "linked_event_ids": event_ids,
                 "linked_claude_session_ids": claude_ids,
                 "linked_browser_event_ids": browser_ids,

--- a/brain/src/hippo_brain/mcp_queries.py
+++ b/brain/src/hippo_brain/mcp_queries.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from hippo_brain.auto_memory_categories import (
     list_document_categories,
     list_document_links,
+    validate_memory_category_filter,
 )
 from hippo_brain.models import CIAnnotation, CIJob, CIStatus, Lesson
 from hippo_brain.retrieval_eligibility import (
@@ -282,6 +283,7 @@ def _build_knowledge_filter_clause(
         clauses.append(source_clause)
 
     if category:
+        validate_memory_category_filter(category)
         category_clause = knowledge_memory_category_clause(conn)
         if category_clause is None:
             raise ValueError("memory category filter requires schema v20+")

--- a/brain/src/hippo_brain/mcp_queries.py
+++ b/brain/src/hippo_brain/mcp_queries.py
@@ -164,6 +164,8 @@ def parse_since(since: str) -> int:
 def _memory_provenance(
     conn: sqlite3.Connection, node_id: int
 ) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    if not _table_exists(conn, "knowledge_node_memory_chunks"):
+        return [], []
     row = conn.execute(
         "SELECT md.id FROM knowledge_node_memory_chunks knmc "
         "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "

--- a/brain/src/hippo_brain/models.py
+++ b/brain/src/hippo_brain/models.py
@@ -19,6 +19,7 @@ class EnrichmentResult:
         }
     )
     tags: list = field(default_factory=list)
+    memory_categories: list = field(default_factory=list)
     embed_text: str = ""
     key_decisions: list = field(default_factory=list)
     problems_encountered: list = field(default_factory=list)
@@ -231,12 +232,18 @@ def validate_enrichment_data(data: dict) -> EnrichmentResult:
         raw_tags = []
     tags = [t for t in raw_tags if isinstance(t, str)]
 
+    raw_memory_categories = data.get("memory_categories", [])
+    if not isinstance(raw_memory_categories, list):
+        raw_memory_categories = []
+    memory_categories = [c for c in raw_memory_categories if isinstance(c, str)]
+
     return EnrichmentResult(
         summary=data["summary"],
         intent=data["intent"],
         outcome=outcome,
         entities=entities,
         tags=tags,
+        memory_categories=memory_categories,
         embed_text=data["embed_text"],
         key_decisions=key_decisions,
         problems_encountered=problems_encountered,

--- a/brain/src/hippo_brain/retrieval.py
+++ b/brain/src/hippo_brain/retrieval.py
@@ -26,6 +26,7 @@ from hippo_brain.evidence_packets import (
     make_shell_packet,
     make_workflow_packet,
 )
+from hippo_brain.auto_memory_categories import validate_memory_category_filter
 from hippo_brain.retrieval_eligibility import (
     agentic_session_eligible_sql,
     browser_event_eligible_sql,
@@ -425,6 +426,7 @@ def _apply_filters(
         clauses.append(source_clause)
 
     if filters.memory_category:
+        validate_memory_category_filter(filters.memory_category)
         category_clause = knowledge_memory_category_clause(conn)
         if category_clause is None:
             raise ValueError("memory category filter requires schema v20+")

--- a/brain/src/hippo_brain/retrieval.py
+++ b/brain/src/hippo_brain/retrieval.py
@@ -37,6 +37,7 @@ from hippo_brain.retrieval_eligibility import (
 from hippo_brain.confidence_scoring import attach_confidence_to_results
 from hippo_brain.source_freshness import attach_freshness_to_results
 from hippo_brain.source_filters import (
+    knowledge_memory_category_clause,
     knowledge_memory_project_clause,
     knowledge_source_exists_clause,
 )
@@ -60,6 +61,7 @@ class Filters:
     project: str | None = None
     since_ms: int | None = None
     source: str | None = None  # "shell" | "claude" | "browser" | "workflow"
+    memory_category: str | None = None
     branch: str | None = None
     entity: str | None = None
     include_excluded: bool = False
@@ -422,6 +424,13 @@ def _apply_filters(
             raise ValueError(f"unknown source filter: {filters.source!r}")
         clauses.append(source_clause)
 
+    if filters.memory_category:
+        category_clause = knowledge_memory_category_clause(conn)
+        if category_clause is None:
+            raise ValueError("memory category filter requires schema v20+")
+        clauses.append(category_clause)
+        params.append(filters.memory_category)
+
     sql = f"""
         SELECT DISTINCT kn.id
         FROM knowledge_nodes kn
@@ -473,6 +482,7 @@ def _is_empty_filter(f: Filters) -> bool:
         f.project is None
         and f.since_ms is None
         and f.source is None
+        and f.memory_category is None
         and f.branch is None
         and f.entity is None
     )

--- a/brain/src/hippo_brain/schema_version.py
+++ b/brain/src/hippo_brain/schema_version.py
@@ -46,13 +46,14 @@ the `agentic_*` tables (harness derived from `source_file`). The legacy
 longer written, dropped in a later unification step.
 v18→v19 adds the read-only Claude auto-memory tables: document,
 revision, chunk, enrichment queue, and knowledge-node link.
+v19→v20 adds auto-memory category provenance and MEMORY.md index links.
 """
 
 from __future__ import annotations
 
 import sqlite3
 
-EXPECTED_SCHEMA_VERSION: int = 19
+EXPECTED_SCHEMA_VERSION: int = 20
 
 # Versions brain can read without erroring.
 #

--- a/brain/src/hippo_brain/source_filters.py
+++ b/brain/src/hippo_brain/source_filters.py
@@ -53,6 +53,17 @@ _MEMORY_PROJECT_EXISTS = (
     "AND (md.repository LIKE ? OR md.source_path LIKE ?))"
 )
 
+_MEMORY_CATEGORY_EXISTS = (
+    "EXISTS (SELECT 1 FROM knowledge_node_memory_chunks knmc "
+    "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "
+    "JOIN memory_revisions mr ON mr.id = mc.revision_id "
+    "JOIN memory_documents md ON md.id = mr.document_id "
+    "JOIN memory_document_categories mdc ON mdc.document_id = md.id "
+    "WHERE knmc.knowledge_node_id = kn.id "
+    "AND md.active_revision_id = mr.id AND md.state = 'active' "
+    "AND mdc.category = ?)"
+)
+
 
 def table_exists(conn: sqlite3.Connection, table: str) -> bool:
     row = conn.execute(
@@ -73,6 +84,13 @@ def knowledge_memory_project_clause(conn: sqlite3.Connection | None = None) -> s
     if conn is not None and not table_exists(conn, "knowledge_node_memory_chunks"):
         return None
     return _MEMORY_PROJECT_EXISTS
+
+
+def knowledge_memory_category_clause(conn: sqlite3.Connection | None = None) -> str | None:
+    """EXISTS fragment matching auto-memory nodes by document category."""
+    if conn is not None and not table_exists(conn, "memory_document_categories"):
+        return None
+    return _MEMORY_CATEGORY_EXISTS
 
 
 def knowledge_source_exists_clause(

--- a/brain/tests/conftest.py
+++ b/brain/tests/conftest.py
@@ -13,12 +13,26 @@ AUTO_MEMORY_SCHEMA_PATH = (
     / "schema"
     / "auto_memory.sql"
 )
+AUTO_MEMORY_TAXONOMY_SCHEMA_PATH = (
+    Path(__file__).parent.parent.parent
+    / "crates"
+    / "hippo-core"
+    / "src"
+    / "schema"
+    / "auto_memory_taxonomy.sql"
+)
 
 
 @pytest.fixture
 def tmp_db():
     """Create a temporary SQLite database with the hippo schema."""
-    schema = SCHEMA_PATH.read_text() + "\n" + AUTO_MEMORY_SCHEMA_PATH.read_text()
+    schema = (
+        SCHEMA_PATH.read_text()
+        + "\n"
+        + AUTO_MEMORY_SCHEMA_PATH.read_text()
+        + "\n"
+        + AUTO_MEMORY_TAXONOMY_SCHEMA_PATH.read_text()
+    )
     tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
     tmp.close()
     db_path = Path(tmp.name)

--- a/brain/tests/test_auto_memory_categories.py
+++ b/brain/tests/test_auto_memory_categories.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hippo_brain.auto_memory import ingest_memory_file, write_memory_knowledge_node
+from hippo_brain.auto_memory_categories import (
+    category_from_filename,
+    list_document_categories,
+    list_document_links,
+    replace_model_categories,
+)
+from hippo_brain.models import EnrichmentResult
+from hippo_brain.mcp_queries import search_knowledge_lexical
+from hippo_brain.retrieval import Filters, _apply_filters
+
+
+@pytest.fixture
+def conn(tmp_db):
+    connection, _path = tmp_db
+    yield connection
+
+
+def test_category_from_filename_handles_prefixes_and_index() -> None:
+    assert category_from_filename("MEMORY.md") == "index"
+    assert category_from_filename("feedback_candor.md") == "feedback"
+    assert category_from_filename("project_architecture.md") == "project"
+    assert category_from_filename("reference_api.md") == "reference"
+    assert category_from_filename("user_role.md") == "user"
+    assert category_from_filename("debugging.md") is None
+
+
+def test_ingest_assigns_filename_category_and_resolves_index_links(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    fixture_dir = (
+        Path(__file__).parent.parent
+        / "src"
+        / "hippo_brain"
+        / "_fixtures"
+        / "auto_memory_spike"
+        / "source"
+    )
+    for name in (
+        "MEMORY.md",
+        "project_architecture.md",
+        "debugging.md",
+        "workflow.md",
+        "feedback_candor.md",
+    ):
+        target = tmp_path / name
+        target.write_text((fixture_dir / name).read_text(encoding="utf-8"))
+
+    for name in (
+        "MEMORY.md",
+        "project_architecture.md",
+        "debugging.md",
+        "workflow.md",
+        "feedback_candor.md",
+    ):
+        ingest_memory_file(conn, tmp_path / name, repository="hippo", now_ms=1000)
+
+    index_id = conn.execute(
+        "SELECT id FROM memory_documents WHERE logical_path = 'MEMORY.md'"
+    ).fetchone()[0]
+    categories = list_document_categories(conn, int(index_id))
+    assert any(c.category == "index" and c.source == "filename" for c in categories)
+
+    links = list_document_links(conn, int(index_id))
+    resolved = [link for link in links if link["resolution"] == "resolved"]
+    assert {link["target_logical_path"] for link in resolved} == {
+        "project_architecture.md",
+        "debugging.md",
+        "workflow.md",
+        "feedback_candor.md",
+    }
+
+
+def test_unresolved_link_resolves_when_target_file_is_ingested_later(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    index = tmp_path / "MEMORY.md"
+    index.write_text("- [Debug](debugging.md)\n")
+    ingest_memory_file(conn, index, repository="hippo", now_ms=1000)
+    index_id = conn.execute(
+        "SELECT id FROM memory_documents WHERE logical_path = 'MEMORY.md'"
+    ).fetchone()[0]
+    assert list_document_links(conn, int(index_id))[0]["resolution"] == "unresolved"
+
+    (tmp_path / "debugging.md").write_text("# Debug\n\nnotes\n")
+    ingest_memory_file(conn, tmp_path / "debugging.md", repository="hippo", now_ms=2000)
+
+    links = list_document_links(conn, int(index_id))
+    assert links[0]["resolution"] == "resolved"
+
+
+def test_model_categories_replace_on_enrichment_but_filename_persists(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    source = tmp_path / "feedback_style.md"
+    source.write_text("# Feedback\n\nPrefer integration tests.\n")
+    ingested = ingest_memory_file(conn, source, repository="hippo", now_ms=1000)
+    replace_model_categories(
+        conn,
+        ingested.document_id,
+        ["project"],
+        model_name="mock-model",
+        now_ms=2000,
+    )
+    categories = list_document_categories(conn, ingested.document_id)
+    assert {c.category for c in categories} == {"feedback", "project"}
+    assert sum(1 for c in categories if c.source == "filename") == 1
+    assert sum(1 for c in categories if c.source == "model") == 1
+
+    replace_model_categories(
+        conn, ingested.document_id, ["reference"], model_name="mock-model", now_ms=3000
+    )
+    categories = list_document_categories(conn, ingested.document_id)
+    model_categories = [c.category for c in categories if c.source == "model"]
+    assert model_categories == ["reference"]
+    assert any(c.category == "feedback" and c.source == "filename" for c in categories)
+
+
+def test_category_filter_returns_matching_memory_nodes(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    feedback = tmp_path / "feedback_style.md"
+    feedback.write_text("# Style\n\nBe direct.\n")
+    project = tmp_path / "project_notes.md"
+    project.write_text("# Notes\n\nUse cargo.\n")
+
+    feedback_ingest = ingest_memory_file(conn, feedback, repository="hippo", now_ms=1000)
+    project_ingest = ingest_memory_file(conn, project, repository="hippo", now_ms=1000)
+
+    result = EnrichmentResult(
+        summary="Style guidance.",
+        intent="feedback",
+        outcome="success",
+        tags=["style"],
+        embed_text="feedback style guidance",
+    )
+    feedback_node = write_memory_knowledge_node(
+        conn, result, feedback_ingest.revision_id, "mock-model", now_ms=2000
+    )
+    project_result = EnrichmentResult(
+        summary="Build notes.",
+        intent="project",
+        outcome="success",
+        tags=["build"],
+        embed_text="cargo build notes",
+    )
+    project_node = write_memory_knowledge_node(
+        conn, project_result, project_ingest.revision_id, "mock-model", now_ms=2000
+    )
+    assert feedback_node is not None and project_node is not None
+
+    kept = _apply_filters(conn, [feedback_node, project_node], Filters(memory_category="feedback"))
+    assert kept == {feedback_node}
+
+    lexical = search_knowledge_lexical(
+        conn,
+        "style",
+        source="claude-auto-memory",
+        project="hippo",
+        category="feedback",
+    )
+    assert len(lexical) == 1
+    assert lexical[0]["memory_categories"]
+    assert lexical[0]["memory_categories"][0]["source"] == "filename"
+
+
+def test_external_link_is_not_invented(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    index = tmp_path / "MEMORY.md"
+    index.write_text("- [Docs](https://example.com/docs)\n")
+    ingest_memory_file(conn, index, repository="hippo", now_ms=1000)
+    index_id = conn.execute(
+        "SELECT id FROM memory_documents WHERE logical_path = 'MEMORY.md'"
+    ).fetchone()[0]
+    links = list_document_links(conn, int(index_id))
+    assert len(links) == 1
+    assert links[0]["resolution"] == "external"
+    assert links[0]["target_document_id"] is None
+
+
+def test_self_link_in_index_is_marked_circular(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    index = tmp_path / "MEMORY.md"
+    index.write_text("- [Self](MEMORY.md)\n")
+    ingest_memory_file(conn, index, repository="hippo", now_ms=1000)
+    index_id = conn.execute(
+        "SELECT id FROM memory_documents WHERE logical_path = 'MEMORY.md'"
+    ).fetchone()[0]
+    links = list_document_links(conn, int(index_id))
+    assert len(links) == 1
+    assert links[0]["resolution"] == "circular"

--- a/brain/tests/test_auto_memory_categories.py
+++ b/brain/tests/test_auto_memory_categories.py
@@ -194,3 +194,29 @@ def test_self_link_in_index_is_marked_circular(conn: sqlite3.Connection, tmp_pat
     links = list_document_links(conn, int(index_id))
     assert len(links) == 1
     assert links[0]["resolution"] == "circular"
+
+
+def test_missing_index_links_backfill_on_unchanged_poll(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    index = tmp_path / "MEMORY.md"
+    index.write_text("- [Debug](debugging.md)\n")
+    (tmp_path / "debugging.md").write_text("# Debug\n\nnotes\n")
+    first = ingest_memory_file(conn, index, repository="hippo", now_ms=1000)
+    ingest_memory_file(conn, tmp_path / "debugging.md", repository="hippo", now_ms=1000)
+    index_id = int(first.document_id)
+    assert len(list_document_links(conn, index_id)) == 1
+
+    conn.execute("DELETE FROM memory_document_links WHERE source_document_id = ?", (index_id,))
+    conn.commit()
+
+    second = ingest_memory_file(conn, index, repository="hippo", now_ms=2000)
+    assert second.changed is False
+    links = list_document_links(conn, index_id)
+    assert len(links) == 1
+    assert links[0]["resolution"] == "resolved"
+
+
+def test_unknown_memory_category_filter_raises(conn: sqlite3.Connection) -> None:
+    with pytest.raises(ValueError, match="unknown memory category filter"):
+        search_knowledge_lexical(conn, "test", category="not-a-category")

--- a/crates/hippo-core/src/schema.sql
+++ b/crates/hippo-core/src/schema.sql
@@ -657,4 +657,4 @@ INSERT OR IGNORE INTO source_health (source, last_event_ts, updated_at) VALUES
 -- The `claude_session_offsets` table (deprecated since T-5) is preserved
 -- to avoid breaking existing CREATE SCHEMA users.
 
-PRAGMA user_version = 19;
+PRAGMA user_version = 20;

--- a/crates/hippo-core/src/schema/auto_memory_taxonomy.sql
+++ b/crates/hippo-core/src/schema/auto_memory_taxonomy.sql
@@ -1,0 +1,38 @@
+-- Claude auto-memory taxonomy (schema v20): deterministic categories, model
+-- categories, and index-to-topic links. Concatenated at migrate/install time.
+
+CREATE TABLE IF NOT EXISTS memory_document_categories (
+    id INTEGER PRIMARY KEY,
+    document_id INTEGER NOT NULL REFERENCES memory_documents(id) ON DELETE CASCADE,
+    category TEXT NOT NULL,
+    source TEXT NOT NULL CHECK (source IN ('filename', 'model')),
+    confidence REAL,
+    model TEXT,
+    enrichment_version INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    UNIQUE (document_id, category, source)
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_memory_document_categories_category
+    ON memory_document_categories(category);
+CREATE INDEX IF NOT EXISTS idx_memory_document_categories_document
+    ON memory_document_categories(document_id);
+
+CREATE TABLE IF NOT EXISTS memory_document_links (
+    id INTEGER PRIMARY KEY,
+    source_document_id INTEGER NOT NULL REFERENCES memory_documents(id) ON DELETE CASCADE,
+    source_revision_id INTEGER NOT NULL REFERENCES memory_revisions(id) ON DELETE CASCADE,
+    target_document_id INTEGER REFERENCES memory_documents(id) ON DELETE SET NULL,
+    target_logical_path TEXT NOT NULL,
+    anchor_text TEXT NOT NULL DEFAULT '',
+    resolution TEXT NOT NULL CHECK (
+        resolution IN ('resolved', 'unresolved', 'external', 'ambiguous', 'circular')
+    ),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    UNIQUE (source_document_id, source_revision_id, target_logical_path)
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_memory_document_links_target
+    ON memory_document_links(target_logical_path, resolution);
+CREATE INDEX IF NOT EXISTS idx_memory_document_links_source
+    ON memory_document_links(source_document_id);

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -10,17 +10,22 @@ use crate::events::{BrowserEvent, ShellEvent};
 const SCHEMA: &str = concat!(
     include_str!("schema.sql"),
     "\n",
-    include_str!("schema/auto_memory.sql")
+    include_str!("schema/auto_memory.sql"),
+    "\n",
+    include_str!("schema/auto_memory_taxonomy.sql")
 );
 
 /// Schema version the daemon expects a healthy DB to be at. Exposed so
 /// startup code (e.g. the brain handshake) can cross-check without
 /// re-declaring the value. Keep in sync with
 /// `brain/src/hippo_brain/schema_version.py::EXPECTED_SCHEMA_VERSION`.
-pub const EXPECTED_VERSION: i64 = 19;
+pub const EXPECTED_VERSION: i64 = 20;
 
 /// Idempotent v18→v19 auto-memory DDL (same file as fresh-install assembly).
 const AUTO_MEMORY_SCHEMA: &str = include_str!("schema/auto_memory.sql");
+
+/// Idempotent v19→v20 auto-memory taxonomy DDL.
+const AUTO_MEMORY_TAXONOMY_SCHEMA: &str = include_str!("schema/auto_memory_taxonomy.sql");
 
 /// Idempotent `ALTER TABLE … ADD COLUMN`. Pre-checks `PRAGMA table_info`
 /// for the column name; if absent, runs the supplied DDL. Used by
@@ -1433,6 +1438,12 @@ pub fn open_db(path: &Path) -> Result<Connection> {
             )?;
         }
         conn.execute_batch("PRAGMA user_version = 19;")?;
+    }
+
+    // v19→v20: auto-memory category and index-link tables.
+    if (1..20).contains(&version) {
+        conn.execute_batch(AUTO_MEMORY_TAXONOMY_SCHEMA)?;
+        conn.execute_batch("PRAGMA user_version = 20;")?;
     } else if version != 0 && version != EXPECTED_VERSION {
         anyhow::bail!(
             "DB schema version mismatch: expected {}, found {}. \
@@ -3908,6 +3919,48 @@ mod tests {
             )
             .unwrap();
         assert!(queue_exists);
+    }
+
+    #[test]
+    fn test_migrate_v19_to_v20_adds_auto_memory_taxonomy_without_touching_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("auto-memory-v19.db");
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sentinel (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO sentinel(value) VALUES ('preserved');
+             PRAGMA user_version = 19;",
+        )
+        .unwrap();
+        drop(conn);
+
+        let conn = open_db(&db).unwrap();
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, EXPECTED_VERSION);
+        assert_eq!(
+            conn.query_row("SELECT value FROM sentinel", [], |row| row
+                .get::<_, String>(0))
+                .unwrap(),
+            "preserved"
+        );
+        let categories_exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_document_categories')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(categories_exists);
+        let links_exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_document_links')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(links_exists);
     }
 
     /// REGRESSION (BT-29 schema gap, 2026-05-04): the bench's corpus init

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -60,6 +60,24 @@ Retention defaults (override in `[auto_memory]`):
 
 Renames are detected when exactly one prior document shares the same redacted hash, the old path is gone, and the new path is ingested. Deleted files move to `unavailable` on the first missing poll, then `tombstoned` after confirmation; tombstoned documents drop out of retrieval but keep bounded history.
 
+## Categories and links
+
+Claude's four-category filename convention is detected deterministically when present:
+
+| Signal | Examples |
+|--------|----------|
+| `index` | `MEMORY.md` |
+| `user` | `user.md`, `user_role.md` |
+| `feedback` | `feedback_testing.md` |
+| `project` | `project_auth.md` |
+| `reference` | `reference_api.md` |
+
+Files without a recognized prefix (for example `debugging.md`) remain uncategorized until the enrichment model adds optional `memory_categories` in its JSON output. Filename-derived categories are kept across content updates; model-derived categories are replaced on each successful enrichment.
+
+`MEMORY.md` index Markdown links are reconciled to other files in the same memory directory. Unresolved, external, ambiguous, and circular links are stored with their resolution status but never invented.
+
+Filter retrieval with `memory_category` (RAG `Filters.memory_category` or `search_knowledge(..., category="feedback")`). Results include `memory_categories` and `memory_links` provenance when the knowledge node projects an auto-memory document.
+
 ## Continuous reconciliation
 
 When `auto_memory.enabled = true`, `hippo daemon install` writes two LaunchAgents:


### PR DESCRIPTION
## Summary
- Add schema v20 `memory_document_categories` and `memory_document_links` tables with v19→v20 migration
- Deterministic filename categories plus model-inferred categories from enrichment JSON with provenance
- Reconcile `MEMORY.md` index Markdown links within the same memory directory; retry unresolved links on ingest
- Expose `memory_category` filter in retrieval, MCP `search_knowledge`, and include category/link provenance in results

## Test plan
- [x] `uv run --project brain pytest brain/tests/test_auto_memory*.py`
- [x] `cargo test -p hippo-core --lib test_migrate_v19_to_v20`
- [ ] CI green

Closes SNUG-136