### PR TITLE
feat(auto-memory): fleet discovery for Claude memory dirs (SNUG-135)

### DIFF
--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -37,6 +37,7 @@ hippo-brain-openapi = "hippo_brain.openapi:main"
 hippo-auto-memory = "hippo_brain.auto_memory:main"
 hippo-auto-memory-poll = "hippo_brain.auto_memory:poll_main"
 hippo-auto-memory-reconcile = "hippo_brain.auto_memory:reconcile_file_main"
+hippo-auto-memory-inventory = "hippo_brain.auto_memory:inventory_main"
 
 [build-system]
 requires = ["hatchling"]

--- a/brain/src/hippo_brain/auto_memory.py
+++ b/brain/src/hippo_brain/auto_memory.py
@@ -544,8 +544,24 @@ def reconcile_file_main(argv: list[str] | None = None) -> int:
     resolved = str(args.file.expanduser().resolve())
     source = next(
         (s for s in sources if str(Path(s["path"]).expanduser().resolve()) == resolved),
-        {"path": resolved, "repository": None, "logical_path": args.file.name},
+        None,
     )
+    if source is None:
+        print(
+            json.dumps(
+                {
+                    "path": resolved,
+                    "outcome": "skipped",
+                    "changed": False,
+                    "revision_id": None,
+                    "projection_status": None,
+                    "pending_enrichment": 0,
+                    "failed_enrichment": 0,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
     storage = config.get("storage", {})
     data_dir = Path(
         storage.get("data_dir", Path.home() / ".local" / "share" / "hippo")

--- a/brain/src/hippo_brain/auto_memory.py
+++ b/brain/src/hippo_brain/auto_memory.py
@@ -31,6 +31,7 @@ from hippo_brain.auto_memory_ingest import (
 from hippo_brain.auto_memory_reconcile import (
     ReconcileConfig,
     document_absence_outcome,
+    inventory_from_config,
     reconcile_config_from_dict,
     reconcile_source,
     reconcile_sources,
@@ -476,6 +477,7 @@ def reconcile_from_config(
             retention=revision_retention_from_config(auto_memory),
             reconcile=reconcile_config_from_dict(auto_memory),
             require_stable=require_stable,
+            auto_memory=auto_memory,
         )
     finally:
         conn.close()
@@ -498,6 +500,28 @@ def poll_main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     summary = reconcile_from_config(args.config, require_stable=True)
     print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+def inventory_main(argv: list[str] | None = None) -> int:
+    """Dry-run fleet inventory of discovered Claude auto-memory directories."""
+    parser = argparse.ArgumentParser(
+        description="List discovered Claude auto-memory directories and files."
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Hippo config.toml (defaults to ~/.config/hippo/config.toml)",
+    )
+    args = parser.parse_args(argv)
+    config_path = args.config or Path.home() / ".config" / "hippo" / "config.toml"
+    if not config_path.is_file():
+        print(json.dumps({"roots": [], "file_sources": 0}, sort_keys=True))
+        return 0
+    with config_path.open("rb") as handle:
+        config = tomllib.load(handle)
+    print(json.dumps(inventory_from_config(config), sort_keys=True))
     return 0
 
 

--- a/brain/src/hippo_brain/auto_memory_discovery.py
+++ b/brain/src/hippo_brain/auto_memory_discovery.py
@@ -125,7 +125,7 @@ def decode_claude_project_slug(slug: str) -> str | None:
 def _read_settings_json(path: Path) -> dict[str, Any] | None:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+    except OSError, json.JSONDecodeError, UnicodeDecodeError:
         return None
     return payload if isinstance(payload, dict) else None
 
@@ -224,9 +224,7 @@ def discover_settings_memory_roots(home: Path) -> list[MemoryRoot]:
                 settings_path = project_dir / name
                 if not settings_path.is_file():
                     continue
-                custom = _auto_memory_directory_from_settings(
-                    settings_path, base_dir=project_dir
-                )
+                custom = _auto_memory_directory_from_settings(settings_path, base_dir=project_dir)
                 if custom is None:
                     continue
                 roots.append(

--- a/brain/src/hippo_brain/auto_memory_discovery.py
+++ b/brain/src/hippo_brain/auto_memory_discovery.py
@@ -224,7 +224,9 @@ def discover_settings_memory_roots(home: Path) -> list[MemoryRoot]:
                 settings_path = project_dir / name
                 if not settings_path.is_file():
                     continue
-                custom = _auto_memory_directory_from_settings(settings_path)
+                custom = _auto_memory_directory_from_settings(
+                    settings_path, base_dir=project_dir
+                )
                 if custom is None:
                     continue
                 roots.append(

--- a/brain/src/hippo_brain/auto_memory_discovery.py
+++ b/brain/src/hippo_brain/auto_memory_discovery.py
@@ -1,0 +1,397 @@
+"""Discover Claude Code auto-memory directories across projects and worktrees."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hippo_brain.auto_memory_constants import SOURCE_KIND
+from hippo_brain.auto_memory_ingest import derive_repository_identity
+
+CLAUDE_PROJECTS_DIR = Path(".claude") / "projects"
+MEMORY_DIR_NAME = "memory"
+TRUSTED_SETTINGS_FILES = (
+    "settings.json",
+    "settings.local.json",
+)
+
+
+@dataclass(frozen=True)
+class DiscoveryConfig:
+    """Fleet discovery knobs under ``[auto_memory.discovery]``."""
+
+    enabled: bool = True
+    claude_projects: bool = True
+    include_patterns: tuple[str, ...] = ()
+    exclude_patterns: tuple[str, ...] = ()
+    read_claude_settings: bool = True
+
+
+@dataclass(frozen=True)
+class MemoryRoot:
+    """One logical auto-memory directory (deduplicated by resolved path)."""
+
+    memory_dir: Path
+    origin: str
+    claude_project_slug: str | None = None
+    encoded_path_hint: str | None = None
+    settings_path: str | None = None
+    accessible: bool = True
+    error: str | None = None
+
+    @property
+    def inventory_key(self) -> str:
+        return str(self.memory_dir.resolve())
+
+
+@dataclass
+class InventoryEntry:
+    memory_dir: str
+    origin: str
+    claude_project_slug: str | None
+    encoded_path_hint: str | None
+    repository: str | None
+    file_count: int
+    accessible: bool
+    error: str | None = None
+    last_success_ts: int | None = None
+    last_error_ts: int | None = None
+    last_error_msg: str | None = None
+    reconciled_files: int = 0
+    changed_files: int = 0
+
+
+@dataclass
+class DiscoveryInventory:
+    discovered_at_ms: int
+    roots: list[InventoryEntry] = field(default_factory=list)
+    file_sources: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "discovered_at_ms": self.discovered_at_ms,
+            "file_sources": self.file_sources,
+            "roots": [
+                {
+                    "memory_dir": entry.memory_dir,
+                    "origin": entry.origin,
+                    "claude_project_slug": entry.claude_project_slug,
+                    "encoded_path_hint": entry.encoded_path_hint,
+                    "repository": entry.repository,
+                    "file_count": entry.file_count,
+                    "accessible": entry.accessible,
+                    "error": entry.error,
+                    "last_success_ts": entry.last_success_ts,
+                    "last_error_ts": entry.last_error_ts,
+                    "last_error_msg": entry.last_error_msg,
+                    "reconciled_files": entry.reconciled_files,
+                    "changed_files": entry.changed_files,
+                }
+                for entry in self.roots
+            ],
+        }
+
+
+def discovery_config_from_dict(auto_memory: dict[str, Any]) -> DiscoveryConfig:
+    raw = auto_memory.get("discovery", {})
+    if not isinstance(raw, dict):
+        raw = {}
+    include = raw.get("include_patterns", raw.get("include", []))
+    exclude = raw.get("exclude_patterns", raw.get("exclude", []))
+    return DiscoveryConfig(
+        enabled=bool(raw.get("enabled", True)),
+        claude_projects=bool(raw.get("claude_projects", True)),
+        include_patterns=tuple(str(item) for item in include) if include else (),
+        exclude_patterns=tuple(str(item) for item in exclude) if exclude else (),
+        read_claude_settings=bool(raw.get("read_claude_settings", True)),
+    )
+
+
+def decode_claude_project_slug(slug: str) -> str | None:
+    """Best-effort decode of Claude's encoded project directory name."""
+    if not slug or slug in {".", ".."}:
+        return None
+    if slug.startswith("-"):
+        decoded = "/" + slug[1:].replace("-", "/")
+        return decoded if decoded != "/" else None
+    return None
+
+
+def _read_settings_json(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _expand_memory_directory(value: str, *, base_dir: Path | None = None) -> Path | None:
+    text = value.strip()
+    if not text:
+        return None
+    path = Path(text).expanduser()
+    if not path.is_absolute() and base_dir is not None:
+        path = (base_dir / path).resolve()
+    else:
+        path = path.resolve()
+    return path
+
+
+def _auto_memory_directory_from_settings(
+    settings_path: Path, *, base_dir: Path | None = None
+) -> Path | None:
+    payload = _read_settings_json(settings_path)
+    if payload is None:
+        return None
+    raw = payload.get("autoMemoryDirectory")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return _expand_memory_directory(raw, base_dir=base_dir)
+
+
+def _root_passes_filters(root: MemoryRoot, config: DiscoveryConfig) -> bool:
+    candidates = [
+        root.claude_project_slug or "",
+        root.encoded_path_hint or "",
+        str(root.memory_dir),
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if config.exclude_patterns and any(
+            fnmatch.fnmatchcase(candidate, pattern) for pattern in config.exclude_patterns
+        ):
+            return False
+    if not config.include_patterns:
+        return True
+    return any(
+        fnmatch.fnmatchcase(candidate, pattern)
+        for candidate in candidates
+        if candidate
+        for pattern in config.include_patterns
+    )
+
+
+def discover_default_claude_project_roots(home: Path) -> list[MemoryRoot]:
+    """Discover ``~/.claude/projects/<slug>/memory`` directories."""
+    projects_root = home / CLAUDE_PROJECTS_DIR
+    if not projects_root.is_dir():
+        return []
+    roots: list[MemoryRoot] = []
+    for project_dir in sorted(projects_root.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        slug = project_dir.name
+        memory_dir = project_dir / MEMORY_DIR_NAME
+        if not memory_dir.is_dir():
+            continue
+        roots.append(
+            MemoryRoot(
+                memory_dir=memory_dir.resolve(),
+                origin="claude-default",
+                claude_project_slug=slug,
+                encoded_path_hint=decode_claude_project_slug(slug),
+            )
+        )
+    return roots
+
+
+def discover_settings_memory_roots(home: Path) -> list[MemoryRoot]:
+    """Read trusted Claude settings scopes for ``autoMemoryDirectory`` overrides."""
+    roots: list[MemoryRoot] = []
+    user_settings = home / ".claude" / "settings.json"
+    custom = _auto_memory_directory_from_settings(user_settings)
+    if custom is not None:
+        roots.append(
+            MemoryRoot(
+                memory_dir=custom,
+                origin="claude-settings-user",
+                settings_path=str(user_settings),
+            )
+        )
+
+    projects_root = home / CLAUDE_PROJECTS_DIR
+    if projects_root.is_dir():
+        for project_dir in sorted(projects_root.iterdir()):
+            if not project_dir.is_dir():
+                continue
+            for name in TRUSTED_SETTINGS_FILES:
+                settings_path = project_dir / name
+                if not settings_path.is_file():
+                    continue
+                custom = _auto_memory_directory_from_settings(settings_path)
+                if custom is None:
+                    continue
+                roots.append(
+                    MemoryRoot(
+                        memory_dir=custom,
+                        origin="claude-settings-project",
+                        claude_project_slug=project_dir.name,
+                        encoded_path_hint=decode_claude_project_slug(project_dir.name),
+                        settings_path=str(settings_path),
+                    )
+                )
+    return roots
+
+
+def deduplicate_memory_roots(roots: list[MemoryRoot]) -> list[MemoryRoot]:
+    """Keep one root per resolved memory directory (first wins)."""
+    seen: dict[str, MemoryRoot] = {}
+    for root in roots:
+        key = root.inventory_key
+        if key not in seen:
+            seen[key] = root
+    return list(seen.values())
+
+
+def discover_memory_roots(
+    config: DiscoveryConfig,
+    *,
+    home: Path | None = None,
+) -> list[MemoryRoot]:
+    """Return deduplicated memory roots from Claude defaults and settings."""
+    if not config.enabled:
+        return []
+    home_dir = (home or Path.home()).expanduser()
+    discovered: list[MemoryRoot] = []
+    if config.claude_projects:
+        discovered.extend(discover_default_claude_project_roots(home_dir))
+    if config.read_claude_settings:
+        discovered.extend(discover_settings_memory_roots(home_dir))
+    deduped = deduplicate_memory_roots(discovered)
+    return [root for root in deduped if _root_passes_filters(root, config)]
+
+
+def list_memory_markdown_files(memory_dir: Path) -> list[Path]:
+    """List Markdown files directly inside a memory directory."""
+    if not memory_dir.is_dir():
+        return []
+    files = [path.resolve() for path in sorted(memory_dir.glob("*.md")) if path.is_file()]
+    return files
+
+
+def repository_for_memory_root(root: MemoryRoot) -> str:
+    """Derive repository identity from MEMORY.md or the memory directory."""
+    memory_md = root.memory_dir / "MEMORY.md"
+    if memory_md.is_file():
+        return derive_repository_identity(memory_md)
+    return derive_repository_identity(root.memory_dir)
+
+
+def memory_roots_to_file_sources(roots: list[MemoryRoot]) -> list[dict[str, Any]]:
+    """Expand memory roots into per-file ingest sources."""
+    sources: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    for root in roots:
+        if not root.accessible:
+            continue
+        try:
+            repository = repository_for_memory_root(root)
+            for path in list_memory_markdown_files(root.memory_dir):
+                resolved = str(path)
+                if resolved in seen_paths:
+                    continue
+                seen_paths.add(resolved)
+                sources.append(
+                    {
+                        "path": resolved,
+                        "repository": repository,
+                        "logical_path": path.name,
+                        "memory_dir": str(root.memory_dir),
+                        "origin": root.origin,
+                        "claude_project_slug": root.claude_project_slug,
+                    }
+                )
+        except OSError:
+            continue
+    return sources
+
+
+def merge_configured_sources(
+    explicit: list[dict[str, Any]],
+    discovered: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge explicit operator sources with discovered file sources (explicit wins)."""
+    merged: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for source in explicit + discovered:
+        path = str(Path(source["path"]).expanduser().resolve())
+        if path in seen:
+            continue
+        seen.add(path)
+        item = dict(source)
+        item["path"] = path
+        merged.append(item)
+    return merged
+
+
+def build_discovery_inventory(
+    roots: list[MemoryRoot],
+    *,
+    file_sources: list[dict[str, Any]],
+    conn: sqlite3.Connection | None = None,
+    now_ms: int | None = None,
+) -> DiscoveryInventory:
+    """Compose a dry-run or post-reconcile inventory snapshot."""
+    observed_at = now_ms if now_ms is not None else int(time.time() * 1000)
+    entries: list[InventoryEntry] = []
+    files_by_root: dict[str, list[dict[str, Any]]] = {}
+    for source in file_sources:
+        memory_dir = source.get("memory_dir")
+        if memory_dir:
+            files_by_root.setdefault(str(Path(memory_dir).resolve()), []).append(source)
+
+    health_by_repo: dict[str, tuple[int | None, int | None, str | None]] = {}
+    if conn is not None:
+        for row in conn.execute(
+            "SELECT repository, MAX(observed_at), MAX(updated_at) "
+            "FROM memory_documents WHERE source_kind = ? AND state != 'tombstoned' "
+            "GROUP BY repository",
+            (SOURCE_KIND,),
+        ).fetchall():
+            health_by_repo[str(row[0])] = (int(row[1]), None, None)
+
+    for root in roots:
+        memory_dir = str(root.memory_dir)
+        repository: str | None = None
+        file_count = 0
+        error = root.error
+        accessible = root.accessible
+        if accessible:
+            try:
+                files = list_memory_markdown_files(root.memory_dir)
+                file_count = len(files)
+                if files:
+                    repository = repository_for_memory_root(root)
+            except OSError as exc:
+                accessible = False
+                error = str(exc)
+        last_success_ts, last_error_ts, last_error_msg = (None, None, None)
+        if repository and repository in health_by_repo:
+            last_success_ts = health_by_repo[repository][0]
+        entries.append(
+            InventoryEntry(
+                memory_dir=memory_dir,
+                origin=root.origin,
+                claude_project_slug=root.claude_project_slug,
+                encoded_path_hint=root.encoded_path_hint,
+                repository=repository,
+                file_count=file_count,
+                accessible=accessible,
+                error=error,
+                last_success_ts=last_success_ts,
+                last_error_ts=last_error_ts,
+                last_error_msg=last_error_msg,
+                reconciled_files=len(files_by_root.get(root.inventory_key, [])),
+            )
+        )
+    return DiscoveryInventory(
+        discovered_at_ms=observed_at,
+        roots=entries,
+        file_sources=len(file_sources),
+    )

--- a/brain/src/hippo_brain/auto_memory_reconcile.py
+++ b/brain/src/hippo_brain/auto_memory_reconcile.py
@@ -220,14 +220,29 @@ def reconcile_sources(
     for source in sources:
         if not source.get("path"):
             continue
-        item = reconcile_source(
-            conn,
-            source,
-            retention=retention_policy,
-            reconcile=reconcile_policy,
-            now_ms=observed_at,
-            require_stable=require_stable,
-        )
+        try:
+            item = reconcile_source(
+                conn,
+                source,
+                retention=retention_policy,
+                reconcile=reconcile_policy,
+                now_ms=observed_at,
+                require_stable=require_stable,
+            )
+        except (OSError, ValueError, sqlite3.Error) as exc:
+            results.append(
+                {
+                    "path": str(Path(source["path"]).expanduser().resolve()),
+                    "outcome": "error",
+                    "changed": False,
+                    "revision_id": None,
+                    "projection_status": None,
+                    "pending_enrichment": 0,
+                    "failed_enrichment": 0,
+                    "error": str(exc),
+                }
+            )
+            continue
         if item.changed:
             changed += 1
         results.append(
@@ -265,8 +280,7 @@ def reconcile_sources(
     return summary
 
 
-def load_sources_from_config(config: dict[str, Any]) -> list[dict[str, Any]]:
-    auto_memory = config.get("auto_memory", {})
+def _explicit_sources_from_config(auto_memory: dict[str, Any]) -> list[dict[str, Any]]:
     explicit: list[dict[str, Any]] = []
     for source in auto_memory.get("sources", []):
         if not isinstance(source, dict):
@@ -282,6 +296,12 @@ def load_sources_from_config(config: dict[str, Any]) -> list[dict[str, Any]]:
                 "origin": "explicit",
             }
         )
+    return explicit
+
+
+def load_sources_from_config(config: dict[str, Any]) -> list[dict[str, Any]]:
+    auto_memory = config.get("auto_memory", {})
+    explicit = _explicit_sources_from_config(auto_memory)
     discovery = discovery_config_from_dict(auto_memory)
     if not auto_memory.get("enabled", False) or not discovery.enabled:
         return explicit
@@ -300,18 +320,7 @@ def inventory_from_config(
     auto_memory = config.get("auto_memory", {})
     discovery = discovery_config_from_dict(auto_memory)
     roots = discover_memory_roots(discovery)
-    explicit: list[dict[str, Any]] = []
-    for source in auto_memory.get("sources", []):
-        if not isinstance(source, dict) or not source.get("path"):
-            continue
-        explicit.append(
-            {
-                "path": str(Path(source["path"]).expanduser()),
-                "repository": source.get("repository"),
-                "logical_path": source.get("logical_path"),
-                "origin": "explicit",
-            }
-        )
+    explicit = _explicit_sources_from_config(auto_memory)
     discovered = memory_roots_to_file_sources(roots)
     merged = merge_configured_sources(explicit, discovered)
     inventory = build_discovery_inventory(

--- a/brain/src/hippo_brain/auto_memory_reconcile.py
+++ b/brain/src/hippo_brain/auto_memory_reconcile.py
@@ -16,6 +16,13 @@ from hippo_brain.auto_memory_constants import (
     DEFAULT_STABLE_TIMEOUT_MS,
     SOURCE_KIND,
 )
+from hippo_brain.auto_memory_discovery import (
+    build_discovery_inventory,
+    discover_memory_roots,
+    discovery_config_from_dict,
+    memory_roots_to_file_sources,
+    merge_configured_sources,
+)
 from hippo_brain.auto_memory_ingest import ingest_memory_file
 from hippo_brain.auto_memory_lifecycle import (
     RevisionRetention,
@@ -202,6 +209,7 @@ def reconcile_sources(
     reconcile: ReconcileConfig | None = None,
     now_ms: int | None = None,
     require_stable: bool = True,
+    auto_memory: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Reconcile every configured source; returns summary JSON for operators."""
     retention_policy = retention or RevisionRetention()
@@ -239,25 +247,77 @@ def reconcile_sources(
             entry["outcome"] = document_absence_outcome(conn, entry["path"])
     pending_total = sum(r["pending_enrichment"] for r in results)
     failed_total = sum(r["failed_enrichment"] for r in results)
-    return {
+    summary: dict[str, Any] = {
         "changed": changed,
         "pending_enrichment": pending_total,
         "failed_enrichment": failed_total,
         "sources": results,
     }
+    discovery = discovery_config_from_dict(auto_memory or {})
+    if auto_memory is not None and discovery.enabled:
+        roots = discover_memory_roots(discovery)
+        summary["inventory"] = build_discovery_inventory(
+            roots,
+            file_sources=sources,
+            conn=conn,
+            now_ms=observed_at,
+        ).to_dict()
+    return summary
 
 
 def load_sources_from_config(config: dict[str, Any]) -> list[dict[str, Any]]:
     auto_memory = config.get("auto_memory", {})
-    sources: list[dict[str, Any]] = []
+    explicit: list[dict[str, Any]] = []
     for source in auto_memory.get("sources", []):
         if not isinstance(source, dict):
             continue
-        sources.append(
+        path = source.get("path", "")
+        if not path:
+            continue
+        explicit.append(
             {
-                "path": str(Path(source.get("path", "")).expanduser()),
+                "path": str(Path(path).expanduser()),
                 "repository": source.get("repository"),
                 "logical_path": source.get("logical_path"),
+                "origin": "explicit",
             }
         )
-    return sources
+    discovery = discovery_config_from_dict(auto_memory)
+    if not auto_memory.get("enabled", False) or not discovery.enabled:
+        return explicit
+    roots = discover_memory_roots(discovery)
+    discovered = memory_roots_to_file_sources(roots)
+    return merge_configured_sources(explicit, discovered)
+
+
+def inventory_from_config(
+    config: dict[str, Any],
+    *,
+    conn: sqlite3.Connection | None = None,
+    now_ms: int | None = None,
+) -> dict[str, Any]:
+    """Return a dry-run fleet inventory without ingesting."""
+    auto_memory = config.get("auto_memory", {})
+    discovery = discovery_config_from_dict(auto_memory)
+    roots = discover_memory_roots(discovery)
+    explicit: list[dict[str, Any]] = []
+    for source in auto_memory.get("sources", []):
+        if not isinstance(source, dict) or not source.get("path"):
+            continue
+        explicit.append(
+            {
+                "path": str(Path(source["path"]).expanduser()),
+                "repository": source.get("repository"),
+                "logical_path": source.get("logical_path"),
+                "origin": "explicit",
+            }
+        )
+    discovered = memory_roots_to_file_sources(roots)
+    merged = merge_configured_sources(explicit, discovered)
+    inventory = build_discovery_inventory(
+        roots,
+        file_sources=merged,
+        conn=conn,
+        now_ms=now_ms,
+    )
+    return inventory.to_dict()

--- a/brain/tests/test_auto_memory_discovery.py
+++ b/brain/tests/test_auto_memory_discovery.py
@@ -17,7 +17,11 @@ from hippo_brain.auto_memory_discovery import (
     memory_roots_to_file_sources,
     merge_configured_sources,
 )
-from hippo_brain.auto_memory_reconcile import inventory_from_config, load_sources_from_config
+from hippo_brain.auto_memory_reconcile import (
+    inventory_from_config,
+    load_sources_from_config,
+    reconcile_sources,
+)
 
 
 @pytest.fixture
@@ -127,6 +131,54 @@ def test_load_sources_from_config_merges_explicit_and_discovered(
     paths = {source["path"] for source in sources}
     assert str(explicit_file.resolve()) in paths
     assert str((discovered / "MEMORY.md").resolve()) in paths
+
+
+def test_explicit_source_wins_over_discovered_path_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    memory = home / ".claude/projects/-repo-a/memory"
+    memory.mkdir(parents=True)
+    shared = memory / "MEMORY.md"
+    shared.write_text("# Discovered\n")
+    monkeypatch.setenv("HOME", str(home))
+
+    config = {
+        "auto_memory": {
+            "enabled": True,
+            "sources": [
+                {
+                    "path": str(shared),
+                    "repository": "example/explicit",
+                    "logical_path": "MEMORY.md",
+                }
+            ],
+            "discovery": {"enabled": True},
+        }
+    }
+    sources = load_sources_from_config(config)
+    match = next(s for s in sources if s["path"] == str(shared.resolve()))
+    assert match["repository"] == "example/explicit"
+    assert match["origin"] == "explicit"
+
+
+def test_reconcile_sources_isolates_errors_between_files(
+    conn: sqlite3.Connection, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    good = tmp_path / "good.md"
+    bad = tmp_path / "missing.md"
+    good.write_text("# Good\n")
+    summary = reconcile_sources(
+        conn,
+        [
+            {"path": str(bad), "repository": "example/bad", "logical_path": "missing.md"},
+            {"path": str(good), "repository": "example/good", "logical_path": "good.md"},
+        ],
+        require_stable=False,
+    )
+    outcomes = {entry["path"]: entry["outcome"] for entry in summary["sources"]}
+    assert outcomes[str(bad.resolve())] in {"missing", "error"}
+    assert outcomes[str(good.resolve())] in {"changed", "unchanged"}
 
 
 def test_inventory_dry_run_reports_roots_without_ingest(tmp_path: Path, monkeypatch) -> None:

--- a/brain/tests/test_auto_memory_discovery.py
+++ b/brain/tests/test_auto_memory_discovery.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hippo_brain.auto_memory import ingest_memory_file
+from hippo_brain.auto_memory_discovery import (
+    decode_claude_project_slug,
+    deduplicate_memory_roots,
+    discover_default_claude_project_roots,
+    discover_memory_roots,
+    discover_settings_memory_roots,
+    discovery_config_from_dict,
+    memory_roots_to_file_sources,
+    merge_configured_sources,
+)
+from hippo_brain.auto_memory_reconcile import inventory_from_config, load_sources_from_config
+
+
+@pytest.fixture
+def conn(tmp_db):
+    connection, _path = tmp_db
+    yield connection
+
+
+def test_decode_claude_project_slug_reverses_encoded_paths() -> None:
+    assert decode_claude_project_slug("-Users-carpenter-projects-hippo") == (
+        "/Users/carpenter/projects/hippo"
+    )
+
+
+def test_discover_default_claude_project_memory_dirs(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    memory_a = home / ".claude/projects/-repo-a/memory"
+    memory_b = home / ".claude/projects/-repo-b/memory"
+    memory_a.mkdir(parents=True)
+    memory_b.mkdir(parents=True)
+    (memory_a / "MEMORY.md").write_text("# A\n")
+    (memory_b / "project_notes.md").write_text("# Notes\n")
+
+    roots = discover_default_claude_project_roots(home)
+    assert {root.memory_dir for root in roots} == {memory_a.resolve(), memory_b.resolve()}
+
+
+def test_custom_auto_memory_directory_from_user_settings(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    custom = home / "shared-memory"
+    custom.mkdir(parents=True)
+    settings = home / ".claude/settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({"autoMemoryDirectory": str(custom)}))
+
+    roots = discover_settings_memory_roots(home)
+    assert len(roots) == 1
+    assert roots[0].memory_dir == custom.resolve()
+    assert roots[0].origin == "claude-settings-user"
+
+
+def test_deduplicate_shared_memory_directory_across_slugs(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    shared = home / "shared-memory"
+    shared.mkdir(parents=True)
+    settings_a = home / ".claude/projects/-repo-a/settings.local.json"
+    settings_b = home / ".claude/projects/-repo-b/settings.local.json"
+    settings_a.parent.mkdir(parents=True)
+    settings_b.parent.mkdir(parents=True)
+    payload = json.dumps({"autoMemoryDirectory": str(shared)})
+    settings_a.write_text(payload)
+    settings_b.write_text(payload)
+
+    roots = deduplicate_memory_roots(discover_settings_memory_roots(home))
+    assert len(roots) == 1
+    assert roots[0].memory_dir == shared.resolve()
+
+
+def test_include_and_exclude_patterns_filter_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    keep = home / ".claude/projects/-Users-me-hippo/memory"
+    skip = home / ".claude/projects/-Users-me-archive/memory"
+    keep.mkdir(parents=True)
+    skip.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    config = discovery_config_from_dict(
+        {
+            "discovery": {
+                "include_patterns": ["*hippo*"],
+                "exclude_patterns": ["*archive*"],
+            }
+        }
+    )
+    roots = discover_memory_roots(config, home=home)
+    assert {root.memory_dir for root in roots} == {keep.resolve()}
+
+
+def test_load_sources_from_config_merges_explicit_and_discovered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    discovered = home / ".claude/projects/-repo-a/memory"
+    discovered.mkdir(parents=True)
+    (discovered / "MEMORY.md").write_text("# Memory\n")
+    monkeypatch.setenv("HOME", str(home))
+
+    explicit_file = tmp_path / "explicit.md"
+    explicit_file.write_text("# Explicit\n")
+
+    config = {
+        "auto_memory": {
+            "enabled": True,
+            "sources": [
+                {
+                    "path": str(explicit_file),
+                    "repository": "example/explicit",
+                    "logical_path": "explicit.md",
+                }
+            ],
+            "discovery": {"enabled": True},
+        }
+    }
+    sources = load_sources_from_config(config)
+    paths = {source["path"] for source in sources}
+    assert str(explicit_file.resolve()) in paths
+    assert str((discovered / "MEMORY.md").resolve()) in paths
+
+
+def test_inventory_dry_run_reports_roots_without_ingest(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    memory = home / ".claude/projects/-repo-a/memory"
+    memory.mkdir(parents=True)
+    (memory / "MEMORY.md").write_text("# Memory\n")
+    monkeypatch.setenv("HOME", str(home))
+
+    inventory = inventory_from_config(
+        {
+            "auto_memory": {
+                "enabled": True,
+                "discovery": {"enabled": True},
+            }
+        }
+    )
+    assert inventory["file_sources"] >= 1
+    assert inventory["roots"][0]["memory_dir"] == str(memory.resolve())
+
+
+def test_fleet_discovery_ingests_without_duplicate_documents(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    repo_a = tmp_path / "repos" / "alpha"
+    repo_b = tmp_path / "repos" / "beta"
+    shared = tmp_path / "shared-memory"
+    shared.mkdir(parents=True)
+    repo_a.mkdir(parents=True)
+    repo_b.mkdir(parents=True)
+
+    (shared / "MEMORY.md").write_text("# Shared index\n")
+    (shared / "project_notes.md").write_text("# Notes\nUse cargo.\n")
+
+    ingest_memory_file(conn, shared / "MEMORY.md", repository="example/alpha", now_ms=1000)
+    ingest_memory_file(conn, shared / "project_notes.md", repository="example/alpha", now_ms=1000)
+    ingest_memory_file(conn, shared / "MEMORY.md", repository="example/beta", now_ms=2000)
+
+    doc_count = conn.execute("SELECT COUNT(*) FROM memory_documents").fetchone()[0]
+    assert doc_count == 3
+
+    explicit = memory_roots_to_file_sources(
+        deduplicate_memory_roots(
+            [
+                *discover_default_claude_project_roots(tmp_path),
+            ]
+        )
+    )
+    merged = merge_configured_sources([], explicit)
+    assert len({source["path"] for source in merged}) == len(merged)

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -259,6 +259,16 @@ enabled = false
 # max_revision_age_days: drop older revision metadata after this many days (default 90)
 # absence_confirm_polls: missing-file polls before tombstone (default 2)
 
+# Fleet discovery (SNUG-135): when enabled, ingest every local Claude Code
+# auto-memory directory under ~/.claude/projects/*/memory/ plus trusted
+# autoMemoryDirectory overrides from Claude settings (read-only).
+# [auto_memory.discovery]
+# enabled = true
+# claude_projects = true
+# read_claude_settings = true
+# include_patterns = ["*hippo*"]
+# exclude_patterns = ["*-archived-*"]
+
 # [[auto_memory.sources]]
 # path = "/absolute/path/to/.claude/memory/MEMORY.md"
 # repository = "owner/repository"

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -37,6 +37,30 @@ pub struct HippoConfig {
 /// Explicit read-only Claude Code auto-memory sources. Fleet discovery is a
 /// later layer; this list is the deterministic single-file operator contract.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutoMemoryDiscoveryConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_true")]
+    pub claude_projects: bool,
+    #[serde(default = "default_true")]
+    pub read_claude_settings: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for AutoMemoryDiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            claude_projects: true,
+            read_claude_settings: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AutoMemoryConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -48,6 +72,8 @@ pub struct AutoMemoryConfig {
     /// In-process periodic full reconcile while the watcher is running.
     #[serde(default = "default_auto_memory_reconcile_fallback_secs")]
     pub reconcile_fallback_secs: u64,
+    #[serde(default)]
+    pub discovery: AutoMemoryDiscoveryConfig,
     #[serde(default)]
     pub sources: Vec<AutoMemorySourceConfig>,
 }
@@ -71,6 +97,7 @@ impl Default for AutoMemoryConfig {
             poll_interval_secs: default_auto_memory_poll_interval_secs(),
             debounce_ms: default_auto_memory_debounce_ms(),
             reconcile_fallback_secs: default_auto_memory_reconcile_fallback_secs(),
+            discovery: AutoMemoryDiscoveryConfig::default(),
             sources: Vec::new(),
         }
     }

--- a/crates/hippo-core/src/config.rs
+++ b/crates/hippo-core/src/config.rs
@@ -60,6 +60,18 @@ impl Default for AutoMemoryDiscoveryConfig {
     }
 }
 
+impl AutoMemoryDiscoveryConfig {
+    /// Whether Python discovery can produce ingest sources (matches `discover_memory_roots`).
+    pub fn produces_sources(&self) -> bool {
+        self.enabled && (self.claude_projects || self.read_claude_settings)
+    }
+
+    /// Whether the daemon should attach FSEvents to `~/.claude/projects` (default layout only).
+    pub fn watches_claude_projects_fleet(&self) -> bool {
+        self.enabled && self.claude_projects
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AutoMemoryConfig {
     #[serde(default)]
@@ -1452,5 +1464,28 @@ strip_params = ["secret", "nonce"]
         );
         assert_eq!(default_cfg.auto_memory.debounce_ms, 500);
         assert_eq!(default_cfg.auto_memory.reconcile_fallback_secs, 60);
+    }
+
+    #[test]
+    fn auto_memory_discovery_gate_matches_python_policy() {
+        let default_cfg = AutoMemoryDiscoveryConfig::default();
+        assert!(default_cfg.produces_sources());
+        assert!(default_cfg.watches_claude_projects_fleet());
+
+        let settings_only = AutoMemoryDiscoveryConfig {
+            enabled: true,
+            claude_projects: false,
+            read_claude_settings: true,
+        };
+        assert!(settings_only.produces_sources());
+        assert!(!settings_only.watches_claude_projects_fleet());
+
+        let disabled = AutoMemoryDiscoveryConfig {
+            enabled: false,
+            claude_projects: true,
+            read_claude_settings: true,
+        };
+        assert!(!disabled.produces_sources());
+        assert!(!disabled.watches_claude_projects_fleet());
     }
 }

--- a/crates/hippo-daemon/src/auto_memory_poll.rs
+++ b/crates/hippo-daemon/src/auto_memory_poll.rs
@@ -12,9 +12,7 @@ pub fn poll_tick(config: &HippoConfig) -> Result<usize> {
         debug!("auto-memory poll disabled by config");
         return Ok(0);
     }
-    if config.auto_memory.sources.is_empty()
-        && !(config.auto_memory.discovery.enabled && config.auto_memory.discovery.claude_projects)
-    {
+    if config.auto_memory.sources.is_empty() && !config.auto_memory.discovery.produces_sources() {
         debug!("auto-memory enabled but no sources configured and fleet discovery disabled");
         return Ok(0);
     }

--- a/crates/hippo-daemon/src/auto_memory_poll.rs
+++ b/crates/hippo-daemon/src/auto_memory_poll.rs
@@ -12,8 +12,10 @@ pub fn poll_tick(config: &HippoConfig) -> Result<usize> {
         debug!("auto-memory poll disabled by config");
         return Ok(0);
     }
-    if config.auto_memory.sources.is_empty() {
-        debug!("auto-memory enabled but no sources configured");
+    if config.auto_memory.sources.is_empty()
+        && !(config.auto_memory.discovery.enabled && config.auto_memory.discovery.claude_projects)
+    {
+        debug!("auto-memory enabled but no sources configured and fleet discovery disabled");
         return Ok(0);
     }
 

--- a/crates/hippo-daemon/src/watch_auto_memory.rs
+++ b/crates/hippo-daemon/src/watch_auto_memory.rs
@@ -46,10 +46,12 @@ fn configured_source_paths(config: &HippoConfig) -> Vec<PathBuf> {
         .collect()
 }
 
-fn discovery_watches_claude_projects(config: &HippoConfig) -> bool {
-    config.auto_memory.enabled
-        && config.auto_memory.discovery.enabled
-        && config.auto_memory.discovery.claude_projects
+fn discovery_active(config: &HippoConfig) -> bool {
+    config.auto_memory.discovery.produces_sources()
+}
+
+fn fleet_fsevents_enabled(config: &HippoConfig) -> bool {
+    config.auto_memory.discovery.watches_claude_projects_fleet()
 }
 
 fn is_memory_markdown(path: &Path) -> bool {
@@ -153,7 +155,7 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
         warn!("auto-memory watcher: disabled by config");
         return Ok(());
     }
-    if config.auto_memory.sources.is_empty() && !discovery_watches_claude_projects(config) {
+    if config.auto_memory.sources.is_empty() && !discovery_active(config) {
         warn!(
             "auto-memory watcher: enabled but no sources configured and fleet discovery disabled"
         );
@@ -161,7 +163,7 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
     }
 
     let sources = configured_source_paths(config);
-    let fleet_discovery = discovery_watches_claude_projects(config);
+    let fleet_discovery = fleet_fsevents_enabled(config);
     let debounce = Duration::from_millis(config.auto_memory.debounce_ms);
     let fallback = Duration::from_secs(config.auto_memory.reconcile_fallback_secs);
 

--- a/crates/hippo-daemon/src/watch_auto_memory.rs
+++ b/crates/hippo-daemon/src/watch_auto_memory.rs
@@ -46,6 +46,39 @@ fn configured_source_paths(config: &HippoConfig) -> Vec<PathBuf> {
         .collect()
 }
 
+fn discovery_watches_claude_projects(config: &HippoConfig) -> bool {
+    config.auto_memory.enabled
+        && config.auto_memory.discovery.enabled
+        && config.auto_memory.discovery.claude_projects
+}
+
+fn is_memory_markdown(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| ext == "md")
+        && path
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .is_some_and(|name| name == "memory")
+}
+
+fn event_targets_memory_files(
+    event: &Event,
+    sources: &[PathBuf],
+    fleet_discovery: bool,
+) -> Vec<PathBuf> {
+    let mut hits = Vec::new();
+    for path in event.paths.iter() {
+        let resolved = path.canonicalize().unwrap_or_else(|_| path.clone());
+        if sources.iter().any(|source| source == &resolved) {
+            hits.push(resolved);
+            continue;
+        }
+        if fleet_discovery && is_memory_markdown(&resolved) {
+            hits.push(resolved);
+        }
+    }
+    hits
+}
+
 fn spawn_reconcile_file(config: &HippoConfig, path: &Path) -> Result<()> {
     let brain_dir = default_brain_dir();
     let config_path = config.storage.config_dir.join("config.toml");
@@ -114,29 +147,21 @@ fn spawn_reconcile_all(config: &HippoConfig) -> Result<usize> {
     Ok(changed)
 }
 
-fn event_targets_known_source(event: &Event, sources: &[PathBuf]) -> Vec<PathBuf> {
-    let mut hits = Vec::new();
-    for path in event.paths.iter() {
-        let resolved = path.canonicalize().unwrap_or_else(|_| path.clone());
-        if sources.iter().any(|source| source == &resolved) {
-            hits.push(resolved);
-        }
-    }
-    hits
-}
-
 /// Entry point — runs until SIGTERM/ctrl-c.
 pub async fn run(config: &HippoConfig) -> Result<()> {
     if !config.auto_memory.enabled {
         warn!("auto-memory watcher: disabled by config");
         return Ok(());
     }
-    if config.auto_memory.sources.is_empty() {
-        warn!("auto-memory watcher: enabled but no sources configured");
+    if config.auto_memory.sources.is_empty() && !discovery_watches_claude_projects(config) {
+        warn!(
+            "auto-memory watcher: enabled but no sources configured and fleet discovery disabled"
+        );
         return Ok(());
     }
 
     let sources = configured_source_paths(config);
+    let fleet_discovery = discovery_watches_claude_projects(config);
     let debounce = Duration::from_millis(config.auto_memory.debounce_ms);
     let fallback = Duration::from_secs(config.auto_memory.reconcile_fallback_secs);
 
@@ -151,12 +176,21 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
         }
     }
 
-    let watch_dirs: Vec<PathBuf> = sources
+    let mut watch_dirs: Vec<(PathBuf, RecursiveMode)> = sources
         .iter()
-        .filter_map(|path| path.parent().map(Path::to_path_buf))
-        .collect::<std::collections::BTreeSet<_>>()
-        .into_iter()
+        .filter_map(|path| {
+            path.parent()
+                .map(|parent| (parent.to_path_buf(), RecursiveMode::NonRecursive))
+        })
         .collect();
+    if fleet_discovery && let Some(home) = dirs::home_dir() {
+        let projects = home.join(".claude/projects");
+        if projects.is_dir() {
+            watch_dirs.push((projects, RecursiveMode::Recursive));
+        }
+    }
+    let mut unique_dirs = std::collections::BTreeSet::new();
+    watch_dirs.retain(|(dir, _)| unique_dirs.insert(dir.clone()));
 
     let (tx, mut rx) = mpsc::channel::<Event>(256);
     let mut watcher = RecommendedWatcher::new(
@@ -169,13 +203,11 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
     )
     .context("auto-memory watcher: failed to create FSEvents watcher")?;
 
-    for dir in &watch_dirs {
+    for (dir, mode) in &watch_dirs {
         if dir.exists() {
-            watcher
-                .watch(dir, RecursiveMode::NonRecursive)
-                .with_context(|| {
-                    format!("auto-memory watcher: failed to watch {}", dir.display())
-                })?;
+            watcher.watch(dir, *mode).with_context(|| {
+                format!("auto-memory watcher: failed to watch {}", dir.display())
+            })?;
         } else {
             warn!(dir = %dir.display(), "auto-memory watcher: parent directory missing");
         }
@@ -183,6 +215,8 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
 
     info!(
         sources = sources.len(),
+        fleet_discovery,
+        watch_dirs = watch_dirs.len(),
         "auto-memory watcher: listening for FSEvents"
     );
 
@@ -201,7 +235,7 @@ pub async fn run(config: &HippoConfig) -> Result<()> {
                 if matches!(event.kind, EventKind::Access(_)) {
                     continue;
                 }
-                for path in event_targets_known_source(&event, &sources) {
+                for path in event_targets_memory_files(&event, &sources, fleet_discovery) {
                     pending.insert(path, Instant::now());
                 }
             }
@@ -241,7 +275,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn event_targets_known_source_matches_resolved_paths() {
+    fn event_targets_memory_files_matches_configured_sources() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("MEMORY.md");
         std::fs::write(&file, "# test\n").unwrap();
@@ -253,7 +287,7 @@ mod tests {
             paths: vec![resolved.clone()],
             attrs: notify::event::EventAttributes::default(),
         };
-        let hits = event_targets_known_source(&event, std::slice::from_ref(&resolved));
+        let hits = event_targets_memory_files(&event, std::slice::from_ref(&resolved), false);
         assert_eq!(hits, vec![resolved]);
     }
 }

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -78,6 +78,15 @@ Files without a recognized prefix (for example `debugging.md`) remain uncategori
 
 Filter retrieval with `memory_category` (RAG `Filters.memory_category` or `search_knowledge(..., category="feedback")`). Results include `memory_categories` and `memory_links` provenance when the knowledge node projects an auto-memory document.
 
+## Fleet discovery
+
+When `[auto_memory]` is enabled and `[auto_memory.discovery] enabled = true` (default), Hippo discovers every local Claude Code memory directory under `~/.claude/projects/<slug>/memory/` plus trusted `autoMemoryDirectory` overrides read from Claude user/project settings (read-only; Hippo never writes Claude config).
+
+- Explicit `[[auto_memory.sources]]` entries are merged with discovered files; explicit paths win on conflict.
+- Worktrees that share one memory directory are deduplicated by resolved path.
+- Dry-run inventory: `uv run --project brain hippo-auto-memory-inventory`
+- Include/exclude glob patterns: `[auto_memory.discovery] include_patterns` / `exclude_patterns`
+
 ## Continuous reconciliation
 
 When `auto_memory.enabled = true`, `hippo daemon install` writes two LaunchAgents:

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -86,6 +86,7 @@ When `[auto_memory]` is enabled and `[auto_memory.discovery] enabled = true` (de
 - Worktrees that share one memory directory are deduplicated by resolved path.
 - Dry-run inventory: `uv run --project brain hippo-auto-memory-inventory`
 - Include/exclude glob patterns: `[auto_memory.discovery] include_patterns` / `exclude_patterns`
+- FSEvents under `~/.claude/projects` triggers reconcile only for files that pass the same Python discovery policy (excluded projects are skipped with `outcome: skipped`). Custom `autoMemoryDirectory` paths outside the default layout are picked up on periodic poll, not live FSEvents.
 
 ## Continuous reconciliation
 


### PR DESCRIPTION
## Summary
- Add `auto_memory_discovery.py` to discover `~/.claude/projects/*/memory/` and trusted `autoMemoryDirectory` overrides (read-only settings parse)
- Merge discovered Markdown files with explicit `[[auto_memory.sources]]`; deduplicate shared memory directories across worktrees
- Expose `hippo-auto-memory-inventory` dry-run CLI; attach inventory to reconcile poll summary
- Enable fleet-aware FSEvents watching and poll when discovery is on without explicit sources

## Test plan
- [x] `uv run --project brain pytest brain/tests/test_auto_memory*.py` (55 passed)
- [x] `cargo clippy -p hippo-daemon --all-targets -- -D warnings`
- [ ] CI green

Closes SNUG-135