### PR TITLE
feat(auto-memory): agent-oriented memory query interfaces (SNUG-137)

### DIFF
--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -38,6 +38,7 @@ hippo-auto-memory = "hippo_brain.auto_memory:main"
 hippo-auto-memory-poll = "hippo_brain.auto_memory:poll_main"
 hippo-auto-memory-reconcile = "hippo_brain.auto_memory:reconcile_file_main"
 hippo-auto-memory-inventory = "hippo_brain.auto_memory:inventory_main"
+hippo-memory-query = "hippo_brain.memory_query:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -11,6 +11,11 @@ from pathlib import Path
 from mcp.server.fastmcp import FastMCP
 
 from hippo_brain.agent_query import AgentQueryRequest, run_agent_query
+from hippo_brain.memory_query import (
+    MemoryQueryRequest,
+    query_memory_current,
+    run_memory_history_query,
+)
 from hippo_brain.client import InferenceClient
 from hippo_brain.embeddings import (
     EMBED_DIM,
@@ -174,6 +179,8 @@ mcp = FastMCP(
         "Hippo is a local knowledge base capturing shell activity, Claude sessions, "
         "and browser history. Use ask to get synthesized answers about past activity. "
         "Use search_knowledge for raw semantic or lexical search over knowledge nodes. "
+        "Use query_memory for current Claude auto-memory documents and "
+        "query_memory_history for explicit revision history. "
         "Use search_events for raw event history. "
         "Use get_entities to explore the knowledge graph."
     ),
@@ -880,6 +887,101 @@ async def agent_query(
     elapsed = time.monotonic() - t0
     _hist(_tool_duration, elapsed * 1000, tool="agent_query")
     logger.info("agent_query completed in %.3fs", elapsed)
+    return result
+
+
+@mcp.tool()
+async def query_memory(
+    query: str = "",
+    repository: str = "",
+    category: str = "",
+    logical_path: str = "",
+    document_uuid: str = "",
+    since: str = "",
+    limit: int = 20,
+    offset: int = 0,
+    include_non_queryable: bool = False,
+    include_source_path: bool = False,
+) -> dict:
+    """Query current Claude auto-memory documents (projected chunks only by default).
+
+    Returns bounded provenance-rich chunks. Use ``query_memory_history`` for
+    explicit prior revisions. Local ``source_path`` is omitted unless
+    ``include_source_path=true`` (diagnostics only).
+    """
+    limit = _clamp_limit(limit)
+    _add(_tool_calls, tool="query_memory")
+    t0 = time.monotonic()
+    req = MemoryQueryRequest(
+        query=query,
+        repository=repository,
+        category=category,
+        logical_path=logical_path,
+        document_uuid=document_uuid,
+        since=since,
+        limit=limit,
+        offset=offset,
+        include_non_queryable=include_non_queryable,
+        include_source_path=include_source_path,
+    )
+    conn = _open_retrieval_conn()
+    try:
+        try:
+            result = query_memory_current(conn, req)
+        except ValueError as exc:
+            _add(_tool_errors, tool="query_memory")
+            return {"error": str(exc)}
+    finally:
+        conn.close()
+    elapsed = time.monotonic() - t0
+    _hist(_tool_duration, elapsed * 1000, tool="query_memory")
+    logger.info("query_memory completed: %d results in %.3fs", len(result["results"]), elapsed)
+    return result
+
+
+@mcp.tool()
+async def query_memory_history(
+    repository: str = "",
+    logical_path: str = "",
+    document_uuid: str = "",
+    limit: int = 50,
+    include_source_path: bool = False,
+) -> dict:
+    """Return bounded revision history for one auto-memory document.
+
+    Requires ``document_uuid`` or both ``repository`` and ``logical_path``.
+    History never mixes into ``query_memory`` current results.
+    """
+    limit = _clamp_limit(limit) or 50
+    _add(_tool_calls, tool="query_memory_history")
+    t0 = time.monotonic()
+    if not document_uuid and not (repository and logical_path):
+        return {
+            "error": "document_uuid or repository+logical_path is required for history",
+        }
+    conn = _open_retrieval_conn()
+    try:
+        try:
+            result = run_memory_history_query(
+                conn,
+                repository=repository,
+                logical_path=logical_path,
+                document_uuid=document_uuid,
+                limit=limit,
+                include_source_path=include_source_path,
+            )
+        except ValueError as exc:
+            _add(_tool_errors, tool="query_memory_history")
+            return {"error": str(exc)}
+    finally:
+        conn.close()
+    elapsed = time.monotonic() - t0
+    _hist(_tool_duration, elapsed * 1000, tool="query_memory_history")
+    logger.info(
+        "query_memory_history completed: %d revisions in %.3fs",
+        len(result["results"]),
+        elapsed,
+    )
     return result
 
 

--- a/brain/src/hippo_brain/mcp.py
+++ b/brain/src/hippo_brain/mcp.py
@@ -14,6 +14,7 @@ from hippo_brain.agent_query import AgentQueryRequest, run_agent_query
 from hippo_brain.memory_query import (
     MemoryQueryRequest,
     query_memory_current,
+    resolve_limit,
     run_memory_history_query,
 )
 from hippo_brain.client import InferenceClient
@@ -909,7 +910,7 @@ async def query_memory(
     explicit prior revisions. Local ``source_path`` is omitted unless
     ``include_source_path=true`` (diagnostics only).
     """
-    limit = _clamp_limit(limit)
+    limit = resolve_limit(limit)
     _add(_tool_calls, tool="query_memory")
     t0 = time.monotonic()
     req = MemoryQueryRequest(
@@ -952,7 +953,7 @@ async def query_memory_history(
     Requires ``document_uuid`` or both ``repository`` and ``logical_path``.
     History never mixes into ``query_memory`` current results.
     """
-    limit = _clamp_limit(limit) or 50
+    limit = resolve_limit(limit, default=50)
     _add(_tool_calls, tool="query_memory_history")
     t0 = time.monotonic()
     if not document_uuid and not (repository and logical_path):

--- a/brain/src/hippo_brain/memory_query.py
+++ b/brain/src/hippo_brain/memory_query.py
@@ -41,6 +41,12 @@ class MemoryQueryRequest:
     include_source_path: bool = False
 
 
+def resolve_limit(limit: int, *, default: int = 20) -> int:
+    if limit <= 0:
+        raise ValueError("limit must be greater than 0")
+    return min(limit, MAX_LIMIT)
+
+
 def clamp_limit(limit: int) -> int:
     if limit <= 0:
         return 0
@@ -190,16 +196,8 @@ def query_memory_current(
             "truncated": False,
         }
 
-    limit = clamp_limit(req.limit)
+    limit = resolve_limit(req.limit, default=20)
     offset = max(req.offset, 0)
-    if limit == 0:
-        return {
-            "view": "current",
-            "results": [],
-            "limit": 0,
-            "offset": offset,
-            "truncated": False,
-        }
 
     where_sql, params = _build_current_filters(req)
 
@@ -225,7 +223,7 @@ def query_memory_current(
         _shape_chunk_row(conn, row, include_source_path=req.include_source_path) for row in rows
     ]
 
-    if req.include_non_queryable:
+    if req.include_non_queryable and not results:
         status_where, status_params = _build_status_filters(req)
         status_sql = (
             "SELECT d.id AS document_id, d.uuid AS document_uuid, d.repository, "
@@ -235,14 +233,22 @@ def query_memory_current(
             f"WHERE {status_where} "
             "AND (d.state != 'active' OR d.projection_status NOT IN ('ready', 'stale') "
             "OR d.active_revision_id IS NULL) "
-            "ORDER BY d.updated_at DESC LIMIT ?"
+            "ORDER BY d.updated_at DESC LIMIT ? OFFSET ?"
         )
-        status_rows = conn.execute(status_sql, (*status_params, limit)).fetchall()
-        seen_docs = {item["document_uuid"] for item in results}
-        for row in status_rows:
-            if row["document_uuid"] in seen_docs:
-                continue
-            results.append(_shape_status_row(row, include_source_path=req.include_source_path))
+        status_rows = conn.execute(status_sql, (*status_params, limit + 1, offset)).fetchall()
+        truncated = len(status_rows) > limit
+        status_rows = status_rows[:limit]
+        results = [
+            _shape_status_row(row, include_source_path=req.include_source_path)
+            for row in status_rows
+        ]
+        return {
+            "view": "current",
+            "results": results,
+            "limit": limit,
+            "offset": offset,
+            "truncated": truncated,
+        }
 
     return {
         "view": "current",
@@ -289,7 +295,7 @@ def run_memory_history_query(
     include_source_path: bool = False,
 ) -> dict[str, Any]:
     """Explicit bounded revision history (never mixed into current results)."""
-    limit = clamp_limit(limit) or 50
+    limit = resolve_limit(limit, default=50)
     conn.row_factory = sqlite3.Row
     history = query_memory_history(
         conn,

--- a/brain/src/hippo_brain/memory_query.py
+++ b/brain/src/hippo_brain/memory_query.py
@@ -47,12 +47,6 @@ def resolve_limit(limit: int, *, default: int = 20) -> int:
     return min(limit, MAX_LIMIT)
 
 
-def clamp_limit(limit: int) -> int:
-    if limit <= 0:
-        return 0
-    return min(limit, MAX_LIMIT)
-
-
 def _truncate(text: str, max_len: int = MAX_EXCERPT_CHARS) -> str:
     if len(text) <= max_len:
         return text

--- a/brain/src/hippo_brain/memory_query.py
+++ b/brain/src/hippo_brain/memory_query.py
@@ -1,0 +1,407 @@
+"""Read-only auto-memory query API for agents and humans (SNUG-137).
+
+Current projected memory is the default; revision history is explicit and bounded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hippo_brain.auto_memory_categories import (
+    list_document_categories,
+    list_document_links,
+    validate_memory_category_filter,
+)
+from hippo_brain.auto_memory_constants import SOURCE_KIND
+from hippo_brain.auto_memory_lifecycle import query_memory_history
+from hippo_brain.mcp_queries import MAX_LIMIT, parse_since
+from hippo_brain.source_filters import table_exists
+
+MAX_EXCERPT_CHARS = 600
+
+
+@dataclass(frozen=True)
+class MemoryQueryRequest:
+    query: str = ""
+    repository: str = ""
+    category: str = ""
+    logical_path: str = ""
+    document_uuid: str = ""
+    since: str = ""
+    source_kind: str = SOURCE_KIND
+    limit: int = 20
+    offset: int = 0
+    include_non_queryable: bool = False
+    include_source_path: bool = False
+
+
+def clamp_limit(limit: int) -> int:
+    if limit <= 0:
+        return 0
+    return min(limit, MAX_LIMIT)
+
+
+def _truncate(text: str, max_len: int = MAX_EXCERPT_CHARS) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max(max_len - 1, 1)] + "…"
+
+
+def _categories_payload(conn: sqlite3.Connection, document_id: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "category": item.category,
+            "source": item.source,
+            "confidence": item.confidence,
+            "model": item.model,
+            "enrichment_version": item.enrichment_version,
+            "created_at": item.created_at,
+            "updated_at": item.updated_at,
+        }
+        for item in list_document_categories(conn, document_id)
+    ]
+
+
+def _links_payload(conn: sqlite3.Connection, document_id: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "target_logical_path": link["target_logical_path"],
+            "anchor_text": link["anchor_text"],
+            "resolution": link["resolution"],
+            "target_document_id": link["target_document_id"],
+        }
+        for link in list_document_links(conn, document_id)
+    ]
+
+
+def _shape_chunk_row(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    *,
+    include_source_path: bool,
+) -> dict[str, Any]:
+    document_id = int(row["document_id"])
+    payload: dict[str, Any] = {
+        "document_uuid": row["document_uuid"],
+        "repository": row["repository"],
+        "logical_path": row["logical_path"],
+        "document_state": row["document_state"],
+        "projection_status": row["projection_status"],
+        "source_kind": row["source_kind"],
+        "revision_number": row["revision_number"],
+        "content_hash": row["content_hash"],
+        "chunk_id": row["chunk_id"],
+        "chunk_ordinal": row["chunk_ordinal"],
+        "heading_path": row["heading_path"] or "",
+        "source_mtime_ms": row["source_mtime_ms"],
+        "revision_created_at": row["revision_created_at"],
+        "enriched_at": row["enriched_at"],
+        "observed_at": row["observed_at"],
+        "knowledge_node_uuid": row["knowledge_node_uuid"] or "",
+        "evidence_excerpt": _truncate(row["chunk_content"] or ""),
+        "memory_categories": _categories_payload(conn, document_id),
+        "memory_links": _links_payload(conn, document_id),
+    }
+    if include_source_path:
+        payload["source_path"] = row["source_path"]
+    return payload
+
+
+def _shape_status_row(row: sqlite3.Row, *, include_source_path: bool) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "document_uuid": row["document_uuid"],
+        "repository": row["repository"],
+        "logical_path": row["logical_path"],
+        "document_state": row["document_state"],
+        "projection_status": row["projection_status"],
+        "source_kind": row["source_kind"],
+        "observed_at": row["observed_at"],
+        "updated_at": row["updated_at"],
+        "last_error": row["last_error"],
+        "evidence_excerpt": "",
+    }
+    if include_source_path:
+        payload["source_path"] = row["source_path"]
+    return payload
+
+
+def _build_current_filters(req: MemoryQueryRequest) -> tuple[str, list[Any]]:
+    clauses: list[str] = ["d.source_kind = ?"]
+    params: list[Any] = [req.source_kind or SOURCE_KIND]
+
+    if req.include_non_queryable:
+        pass  # status stubs are appended separately; chunk query stays strict.
+    else:
+        clauses.append("d.state = 'active'")
+        clauses.append("d.active_revision_id IS NOT NULL")
+
+    if req.repository:
+        clauses.append("d.repository = ?")
+        params.append(req.repository)
+    if req.logical_path:
+        clauses.append("d.logical_path = ?")
+        params.append(req.logical_path)
+    if req.document_uuid:
+        clauses.append("d.uuid = ?")
+        params.append(req.document_uuid)
+
+    since_ms = parse_since(req.since)
+    if since_ms:
+        clauses.append("d.updated_at >= ?")
+        params.append(since_ms)
+
+    if req.category:
+        validate_memory_category_filter(req.category)
+        clauses.append(
+            "EXISTS (SELECT 1 FROM memory_document_categories mdc "
+            "WHERE mdc.document_id = d.id AND mdc.category = ?)"
+        )
+        params.append(req.category)
+
+    if req.query:
+        pattern = f"%{req.query}%"
+        clauses.append(
+            "(mc.content LIKE ? OR COALESCE(r.summary, '') LIKE ? "
+            "OR COALESCE(r.diff_text, '') LIKE ?)"
+        )
+        params.extend([pattern, pattern, pattern])
+
+    return " AND ".join(clauses), params
+
+
+def query_memory_current(
+    conn: sqlite3.Connection,
+    req: MemoryQueryRequest,
+) -> dict[str, Any]:
+    """Return bounded current auto-memory chunks (or status stubs when non-queryable)."""
+    conn.row_factory = sqlite3.Row
+    if not table_exists(conn, "memory_documents"):
+        return {
+            "view": "current",
+            "results": [],
+            "limit": req.limit,
+            "offset": req.offset,
+            "truncated": False,
+        }
+
+    limit = clamp_limit(req.limit)
+    offset = max(req.offset, 0)
+    if limit == 0:
+        return {
+            "view": "current",
+            "results": [],
+            "limit": 0,
+            "offset": offset,
+            "truncated": False,
+        }
+
+    where_sql, params = _build_current_filters(req)
+
+    sql = (
+        "SELECT d.id AS document_id, d.uuid AS document_uuid, d.repository, "
+        "d.logical_path, d.source_path, d.state AS document_state, "
+        "d.projection_status, d.source_kind, d.observed_at, "
+        "r.revision_number, r.content_hash, r.source_mtime_ms, r.created_at AS revision_created_at, "
+        "r.enriched_at, mc.id AS chunk_id, mc.ordinal AS chunk_ordinal, "
+        "mc.heading_path, mc.content AS chunk_content, kn.uuid AS knowledge_node_uuid "
+        "FROM memory_documents d "
+        "JOIN memory_revisions r ON r.id = d.active_revision_id "
+        "JOIN memory_chunks mc ON mc.revision_id = r.id "
+        "LEFT JOIN knowledge_node_memory_chunks knmc ON knmc.memory_chunk_id = mc.id "
+        "LEFT JOIN knowledge_nodes kn ON kn.id = knmc.knowledge_node_id "
+        f"WHERE {where_sql} "
+        "ORDER BY d.updated_at DESC, mc.ordinal ASC LIMIT ? OFFSET ?"
+    )
+    rows = conn.execute(sql, (*params, limit + 1, offset)).fetchall()
+    truncated = len(rows) > limit
+    rows = rows[:limit]
+    results: list[dict[str, Any]] = [
+        _shape_chunk_row(conn, row, include_source_path=req.include_source_path) for row in rows
+    ]
+
+    if req.include_non_queryable:
+        status_where, status_params = _build_status_filters(req)
+        status_sql = (
+            "SELECT d.id AS document_id, d.uuid AS document_uuid, d.repository, "
+            "d.logical_path, d.source_path, d.state AS document_state, "
+            "d.projection_status, d.source_kind, d.observed_at, d.updated_at, d.last_error "
+            "FROM memory_documents d "
+            f"WHERE {status_where} "
+            "AND (d.state != 'active' OR d.projection_status NOT IN ('ready', 'stale') "
+            "OR d.active_revision_id IS NULL) "
+            "ORDER BY d.updated_at DESC LIMIT ?"
+        )
+        status_rows = conn.execute(status_sql, (*status_params, limit)).fetchall()
+        seen_docs = {item["document_uuid"] for item in results}
+        for row in status_rows:
+            if row["document_uuid"] in seen_docs:
+                continue
+            results.append(_shape_status_row(row, include_source_path=req.include_source_path))
+
+    return {
+        "view": "current",
+        "results": results,
+        "limit": limit,
+        "offset": offset,
+        "truncated": truncated,
+    }
+
+
+def _build_status_filters(req: MemoryQueryRequest) -> tuple[str, list[Any]]:
+    clauses: list[str] = ["d.source_kind = ?"]
+    params: list[Any] = [req.source_kind or SOURCE_KIND]
+    if req.repository:
+        clauses.append("d.repository = ?")
+        params.append(req.repository)
+    if req.logical_path:
+        clauses.append("d.logical_path = ?")
+        params.append(req.logical_path)
+    if req.document_uuid:
+        clauses.append("d.uuid = ?")
+        params.append(req.document_uuid)
+    since_ms = parse_since(req.since)
+    if since_ms:
+        clauses.append("d.updated_at >= ?")
+        params.append(since_ms)
+    if req.category:
+        validate_memory_category_filter(req.category)
+        clauses.append(
+            "EXISTS (SELECT 1 FROM memory_document_categories mdc "
+            "WHERE mdc.document_id = d.id AND mdc.category = ?)"
+        )
+        params.append(req.category)
+    return " AND ".join(clauses), params
+
+
+def run_memory_history_query(
+    conn: sqlite3.Connection,
+    *,
+    repository: str = "",
+    logical_path: str = "",
+    document_uuid: str = "",
+    limit: int = 50,
+    include_source_path: bool = False,
+) -> dict[str, Any]:
+    """Explicit bounded revision history (never mixed into current results)."""
+    limit = clamp_limit(limit) or 50
+    conn.row_factory = sqlite3.Row
+    history = query_memory_history(
+        conn,
+        repository=repository or None,
+        logical_path=logical_path or None,
+        document_uuid=document_uuid or None,
+        limit=limit,
+    )
+    results: list[dict[str, Any]] = []
+    for row in history:
+        item = {
+            "document_uuid": row["document_uuid"],
+            "repository": row["repository"],
+            "logical_path": row["logical_path"],
+            "document_state": row["document_state"],
+            "revision_number": row["revision_number"],
+            "content_hash": row["content_hash"],
+            "change_kind": row["change_kind"],
+            "summary": row["summary"],
+            "diff_text": row["diff_text"],
+            "source_mtime_ms": row["source_mtime_ms"],
+            "revision_created_at": row["created_at"],
+            "enriched_at": row["enriched_at"],
+        }
+        if include_source_path:
+            item["source_path"] = row["source_path"]
+        results.append(item)
+    return {
+        "view": "history",
+        "results": results,
+        "limit": limit,
+        "offset": 0,
+        "truncated": len(results) >= limit,
+    }
+
+
+def _default_db_path() -> Path:
+    return Path.home() / ".local" / "share" / "hippo" / "hippo.db"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="hippo-memory-query",
+        description="Query Claude auto-memory documents (current or explicit history).",
+    )
+    parser.add_argument("query", nargs="?", default="", help="Optional text filter")
+    parser.add_argument("--repository", default="")
+    parser.add_argument("--category", default="")
+    parser.add_argument("--logical-path", default="")
+    parser.add_argument("--document-uuid", default="")
+    parser.add_argument("--since", default="", help="Freshness window like 24h or 7d")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--offset", type=int, default=0)
+    parser.add_argument("--history", action="store_true", help="Return revision history")
+    parser.add_argument(
+        "--include-non-queryable",
+        action="store_true",
+        help="Include pending/failed/unavailable status stubs",
+    )
+    parser.add_argument(
+        "--include-source-path",
+        action="store_true",
+        help="Include absolute local paths (local diagnostics only)",
+    )
+    parser.add_argument("--db", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    db_path = args.db or _default_db_path()
+    if not db_path.exists():
+        print(f"database not found: {db_path}", file=sys.stderr)
+        return 1
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        if args.history:
+            if not args.document_uuid and not (args.repository and args.logical_path):
+                parser.error(
+                    "--history requires --document-uuid or --repository and --logical-path"
+                )
+            payload = run_memory_history_query(
+                conn,
+                repository=args.repository,
+                logical_path=args.logical_path,
+                document_uuid=args.document_uuid,
+                limit=args.limit,
+                include_source_path=args.include_source_path,
+            )
+        else:
+            req = MemoryQueryRequest(
+                query=args.query,
+                repository=args.repository,
+                category=args.category,
+                logical_path=args.logical_path,
+                document_uuid=args.document_uuid,
+                since=args.since,
+                limit=args.limit,
+                offset=args.offset,
+                include_non_queryable=args.include_non_queryable,
+                include_source_path=args.include_source_path,
+            )
+            payload = query_memory_current(conn, req)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brain/src/hippo_brain/openapi.py
+++ b/brain/src/hippo_brain/openapi.py
@@ -191,6 +191,42 @@ def build_openapi_spec() -> dict:
                     },
                 }
             },
+            "/memory/query": {
+                "post": {
+                    "operationId": "memoryQuery",
+                    "summary": "Query current projected Claude auto-memory chunks.",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/MemoryQueryRequest"}
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": _json_response("#/components/schemas/MemoryQueryResponse"),
+                        "400": _error_response("Invalid request body."),
+                    },
+                }
+            },
+            "/memory/history": {
+                "post": {
+                    "operationId": "memoryHistory",
+                    "summary": "Bounded revision history for one auto-memory document.",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/MemoryHistoryRequest"}
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": _json_response("#/components/schemas/MemoryQueryResponse"),
+                        "400": _error_response("Invalid request body."),
+                    },
+                }
+            },
             "/control/pause": {
                 "post": {
                     "operationId": "pauseEnrichment",
@@ -440,6 +476,49 @@ def build_openapi_spec() -> dict:
                             },
                         },
                         "limit": {"type": "integer"},
+                        "truncated": {"type": "boolean"},
+                    },
+                    "additionalProperties": True,
+                },
+                "MemoryQueryRequest": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "repository": {"type": "string"},
+                        "category": {
+                            "type": "string",
+                            "enum": ["feedback", "project", "reference", "user", "index"],
+                        },
+                        "logical_path": {"type": "string"},
+                        "document_uuid": {"type": "string"},
+                        "since": {"type": "string"},
+                        "limit": {"type": "integer", "minimum": 1},
+                        "offset": {"type": "integer", "minimum": 0},
+                        "include_non_queryable": {"type": "boolean"},
+                        "include_source_path": {"type": "boolean"},
+                    },
+                },
+                "MemoryHistoryRequest": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {"type": "string"},
+                        "logical_path": {"type": "string"},
+                        "document_uuid": {"type": "string"},
+                        "limit": {"type": "integer", "minimum": 1},
+                        "include_source_path": {"type": "boolean"},
+                    },
+                },
+                "MemoryQueryResponse": {
+                    "type": "object",
+                    "required": ["view", "results", "limit", "offset", "truncated"],
+                    "properties": {
+                        "view": {"type": "string", "enum": ["current", "history"]},
+                        "results": {
+                            "type": "array",
+                            "items": {"type": "object", "additionalProperties": True},
+                        },
+                        "limit": {"type": "integer"},
+                        "offset": {"type": "integer"},
                         "truncated": {"type": "boolean"},
                     },
                     "additionalProperties": True,

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -16,6 +16,11 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from hippo_brain.agent_query import AgentQueryRequest, run_agent_query
+from hippo_brain.memory_query import (
+    MemoryQueryRequest,
+    query_memory_current,
+    run_memory_history_query,
+)
 from hippo_brain.client import InferenceClient
 from hippo_brain.openapi import build_openapi_spec
 from hippo_brain.schema_version import (
@@ -956,6 +961,87 @@ class BrainServer:
 
         return JSONResponse(result)
 
+    async def memory_query(self, request: Request) -> JSONResponse:
+        """Query current projected Claude auto-memory documents."""
+        body = await request.json()
+        limit = body.get("limit", 20)
+        offset = body.get("offset", 0)
+        try:
+            limit = int(limit)
+            offset = int(offset)
+        except TypeError, ValueError:
+            return JSONResponse({"error": "limit and offset must be integers"}, status_code=400)
+        if limit <= 0:
+            return JSONResponse({"error": "limit must be greater than 0"}, status_code=400)
+        if limit > MAX_QUERY_LIMIT:
+            return JSONResponse(
+                {"error": f"limit must be <= {MAX_QUERY_LIMIT}"},
+                status_code=400,
+            )
+        if offset < 0:
+            return JSONResponse({"error": "offset must be >= 0"}, status_code=400)
+
+        req = MemoryQueryRequest(
+            query=body.get("query", ""),
+            repository=body.get("repository", ""),
+            category=body.get("category", ""),
+            logical_path=body.get("logical_path", ""),
+            document_uuid=body.get("document_uuid", ""),
+            since=body.get("since", ""),
+            limit=limit,
+            offset=offset,
+            include_non_queryable=bool(body.get("include_non_queryable", False)),
+            include_source_path=bool(body.get("include_source_path", False)),
+        )
+        conn = self._get_conn()
+        try:
+            result = query_memory_current(conn, req)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        finally:
+            conn.close()
+        return JSONResponse(result)
+
+    async def memory_history(self, request: Request) -> JSONResponse:
+        """Explicit bounded revision history for one auto-memory document."""
+        body = await request.json()
+        repository = body.get("repository", "")
+        logical_path = body.get("logical_path", "")
+        document_uuid = body.get("document_uuid", "")
+        if not document_uuid and not (repository and logical_path):
+            return JSONResponse(
+                {"error": "document_uuid or repository+logical_path is required"},
+                status_code=400,
+            )
+        limit = body.get("limit", 50)
+        try:
+            limit = int(limit)
+        except TypeError, ValueError:
+            return JSONResponse({"error": "limit must be an integer"}, status_code=400)
+        if limit <= 0:
+            return JSONResponse({"error": "limit must be greater than 0"}, status_code=400)
+        if limit > MAX_QUERY_LIMIT:
+            return JSONResponse(
+                {"error": f"limit must be <= {MAX_QUERY_LIMIT}"},
+                status_code=400,
+            )
+
+        conn = self._get_conn()
+        try:
+            result = run_memory_history_query(
+                conn,
+                repository=repository,
+                logical_path=logical_path,
+                document_uuid=document_uuid,
+                limit=limit,
+                include_source_path=bool(body.get("include_source_path", False)),
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        finally:
+            conn.close()
+        return JSONResponse(result)
+
     async def control_pause(self, request: Request) -> JSONResponse:
         """Pause the enrichment loop. Idempotent.
 
@@ -1892,6 +1978,8 @@ class BrainServer:
             Route("/query", self.query, methods=["POST"]),
             Route("/ask", self.ask, methods=["POST"]),
             Route("/agent/query", self.agent_query, methods=["POST"]),
+            Route("/memory/query", self.memory_query, methods=["POST"]),
+            Route("/memory/history", self.memory_history, methods=["POST"]),
             Route("/control/pause", self.control_pause, methods=["POST"]),
             Route("/control/resume", self.control_resume, methods=["POST"]),
             Route("/openapi.json", self.openapi_json, methods=["GET"]),

--- a/brain/src/hippo_brain/server.py
+++ b/brain/src/hippo_brain/server.py
@@ -19,6 +19,7 @@ from hippo_brain.agent_query import AgentQueryRequest, run_agent_query
 from hippo_brain.memory_query import (
     MemoryQueryRequest,
     query_memory_current,
+    resolve_limit,
     run_memory_history_query,
 )
 from hippo_brain.client import InferenceClient
@@ -967,17 +968,10 @@ class BrainServer:
         limit = body.get("limit", 20)
         offset = body.get("offset", 0)
         try:
-            limit = int(limit)
+            limit = resolve_limit(int(limit), default=20)
             offset = int(offset)
-        except TypeError, ValueError:
-            return JSONResponse({"error": "limit and offset must be integers"}, status_code=400)
-        if limit <= 0:
-            return JSONResponse({"error": "limit must be greater than 0"}, status_code=400)
-        if limit > MAX_QUERY_LIMIT:
-            return JSONResponse(
-                {"error": f"limit must be <= {MAX_QUERY_LIMIT}"},
-                status_code=400,
-            )
+        except (TypeError, ValueError) as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
         if offset < 0:
             return JSONResponse({"error": "offset must be >= 0"}, status_code=400)
 
@@ -1015,16 +1009,9 @@ class BrainServer:
             )
         limit = body.get("limit", 50)
         try:
-            limit = int(limit)
-        except TypeError, ValueError:
-            return JSONResponse({"error": "limit must be an integer"}, status_code=400)
-        if limit <= 0:
-            return JSONResponse({"error": "limit must be greater than 0"}, status_code=400)
-        if limit > MAX_QUERY_LIMIT:
-            return JSONResponse(
-                {"error": f"limit must be <= {MAX_QUERY_LIMIT}"},
-                status_code=400,
-            )
+            limit = resolve_limit(int(limit), default=50)
+        except (TypeError, ValueError) as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
 
         conn = self._get_conn()
         try:

--- a/brain/tests/test_mcp_server.py
+++ b/brain/tests/test_mcp_server.py
@@ -55,8 +55,14 @@ class TestToolRegistration:
     def test_agent_query_registered(self):
         assert "agent_query" in mcp._tool_manager._tools
 
-    def test_exactly_ten_tools(self):
-        assert len(mcp._tool_manager._tools) == 10
+    def test_query_memory_registered(self):
+        assert "query_memory" in mcp._tool_manager._tools
+
+    def test_query_memory_history_registered(self):
+        assert "query_memory_history" in mcp._tool_manager._tools
+
+    def test_exactly_twelve_tools(self):
+        assert len(mcp._tool_manager._tools) == 12
 
 
 class TestAgentQueryTool:

--- a/brain/tests/test_memory_query.py
+++ b/brain/tests/test_memory_query.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hippo_brain.auto_memory import ingest_memory_file, write_memory_knowledge_node
+from hippo_brain.auto_memory_lifecycle import RevisionRetention, reconcile_configured_sources
+from hippo_brain.memory_query import (
+    MemoryQueryRequest,
+    query_memory_current,
+    run_memory_history_query,
+)
+from hippo_brain.models import EnrichmentResult
+from hippo_brain.mcp import query_memory, query_memory_history
+
+
+@pytest.fixture
+def conn(tmp_db):
+    connection, _path = tmp_db
+    yield connection
+
+
+def _publish(conn: sqlite3.Connection, revision_id: int, summary: str) -> None:
+    result = EnrichmentResult(
+        summary=summary,
+        intent="memory",
+        outcome="success",
+        tags=["memory"],
+        embed_text=summary,
+    )
+    node_id = write_memory_knowledge_node(
+        conn, result, revision_id, "mock-model", now_ms=revision_id * 1000
+    )
+    assert node_id is not None
+
+
+def _seed_memory_corpus(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    fixture_dir = (
+        Path(__file__).parent.parent
+        / "src"
+        / "hippo_brain"
+        / "_fixtures"
+        / "auto_memory_spike"
+        / "source"
+    )
+    for name in ("MEMORY.md", "feedback_candor.md", "project_architecture.md"):
+        target = tmp_path / name
+        target.write_text((fixture_dir / name).read_text(encoding="utf-8"))
+        ingested = ingest_memory_file(conn, target, repository="hippo", now_ms=1000)
+        _publish(conn, ingested.revision_id, f"summary for {name}")
+
+
+def test_current_query_defaults_to_projected_active_memory(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    _seed_memory_corpus(conn, tmp_path)
+    out = query_memory_current(conn, MemoryQueryRequest(limit=50))
+    assert out["view"] == "current"
+    assert len(out["results"]) >= 3
+    for row in out["results"]:
+        assert row["document_state"] == "active"
+        assert row["projection_status"] in ("ready", "stale", "pending", "processing")
+        assert row["repository"] == "hippo"
+        assert row["evidence_excerpt"]
+        assert "source_path" not in row
+        assert row["content_hash"]
+        assert row["chunk_id"] is not None
+
+
+def test_repository_and_category_filters(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    _seed_memory_corpus(conn, tmp_path)
+    feedback = query_memory_current(
+        conn,
+        MemoryQueryRequest(repository="hippo", category="feedback", limit=10),
+    )
+    assert feedback["results"]
+    assert all("feedback" in row["logical_path"] for row in feedback["results"])
+    assert all(
+        any(cat["category"] == "feedback" for cat in row["memory_categories"])
+        for row in feedback["results"]
+    )
+
+
+def test_text_query_matches_chunk_content(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    path = tmp_path / "MEMORY.md"
+    path.write_text("# Busy\n\nSQLite busy_timeout matters.\n")
+    ingested = ingest_memory_file(conn, path, repository="hippo", now_ms=1000)
+    _publish(conn, ingested.revision_id, "busy timeout note")
+
+    hits = query_memory_current(conn, MemoryQueryRequest(query="busy_timeout", limit=5))
+    assert len(hits["results"]) == 1
+    assert "busy_timeout" in hits["results"][0]["evidence_excerpt"]
+
+
+def test_history_is_explicit_and_separate(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    path = tmp_path / "MEMORY.md"
+    path.write_text("# One\n\nalpha\n")
+    first = ingest_memory_file(conn, path, repository="hippo", now_ms=1000)
+    _publish(conn, first.revision_id, "alpha")
+    path.write_text("# One\n\nbeta\n")
+    ingest_memory_file(conn, path, repository="hippo", now_ms=2000)
+
+    current = query_memory_current(
+        conn, MemoryQueryRequest(repository="hippo", logical_path="MEMORY.md")
+    )
+    assert len(current["results"]) >= 1
+    assert "alpha" in current["results"][0]["evidence_excerpt"]
+
+    history = run_memory_history_query(
+        conn, repository="hippo", logical_path="MEMORY.md", limit=10
+    )
+    assert history["view"] == "history"
+    assert len(history["results"]) == 2
+    assert history["results"][0]["revision_number"] == 2
+    assert "source_path" not in history["results"][0]
+
+
+def test_include_source_path_is_opt_in(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    path = tmp_path / "MEMORY.md"
+    path.write_text("# Path\n\nsecret path test\n")
+    ingested = ingest_memory_file(conn, path, repository="hippo", now_ms=1000)
+    _publish(conn, ingested.revision_id, "path test")
+
+    row = query_memory_current(
+        conn,
+        MemoryQueryRequest(
+            repository="hippo",
+            logical_path="MEMORY.md",
+            include_source_path=True,
+        ),
+    )["results"][0]
+    assert str(path) in row["source_path"]
+
+
+def test_non_queryable_status_stubs(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    path = tmp_path / "MEMORY.md"
+    path.write_text("# Pending\n\nnot enriched yet\n")
+    ingest_memory_file(conn, path, repository="hippo", now_ms=1000)
+
+    default = query_memory_current(
+        conn, MemoryQueryRequest(repository="hippo", logical_path="MEMORY.md")
+    )
+    assert default["results"] == []
+
+    with_status = query_memory_current(
+        conn,
+        MemoryQueryRequest(
+            repository="hippo",
+            logical_path="MEMORY.md",
+            include_non_queryable=True,
+        ),
+    )
+    assert len(with_status["results"]) == 1
+    assert with_status["results"][0]["projection_status"] == "pending"
+    assert with_status["results"][0]["evidence_excerpt"] == ""
+
+
+def test_unavailable_document_excluded_from_default_query(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    path = tmp_path / "MEMORY.md"
+    path.write_text("# Gone\n\ndata\n")
+    ingested = ingest_memory_file(conn, path, repository="hippo", now_ms=1000)
+    _publish(conn, ingested.revision_id, "gone")
+    path.unlink()
+
+    reconcile_configured_sources(
+        conn,
+        [{"path": str(path), "repository": "hippo", "logical_path": "MEMORY.md"}],
+        retention=RevisionRetention(absence_confirm_polls=2),
+        now_ms=2000,
+    )
+    assert query_memory_current(conn, MemoryQueryRequest(query="data"))["results"] == []
+
+    diagnostic = query_memory_current(
+        conn,
+        MemoryQueryRequest(query="data", include_non_queryable=True),
+    )
+    assert diagnostic["results"]
+    assert diagnostic["results"][0]["document_state"] == "unavailable"
+
+
+def test_memory_query_does_not_return_agentic_session_rows(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    path = tmp_path / "MEMORY.md"
+    path.write_text("# Memory only\n\nauto memory corpus\n")
+    ingested = ingest_memory_file(conn, path, repository="hippo", now_ms=1000)
+    _publish(conn, ingested.revision_id, "auto memory corpus")
+
+    conn.execute(
+        "INSERT INTO agentic_sessions "
+        "(session_id, harness, segment_index, start_time, end_time, cwd, project_dir, "
+        "summary_text, message_count, tool_calls_json, probe_tag) "
+        "VALUES ('sess-1', 'claude-code', 0, 1000, 2000, '/tmp/hippo', '/tmp/hippo', "
+        "'session log about cargo', 1, '[]', NULL)"
+    )
+    conn.execute(
+        "INSERT INTO knowledge_nodes (uuid, content, embed_text, outcome, tags, created_at) "
+        "VALUES ('sess-node', '{\"summary\":\"session log about cargo\"}', "
+        "'session log about cargo', '', '[]', 1500)"
+    )
+    session_node_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    session_id = conn.execute("SELECT id FROM agentic_sessions").fetchone()[0]
+    conn.execute(
+        "INSERT INTO knowledge_node_agentic_sessions (knowledge_node_id, agentic_session_id) "
+        "VALUES (?, ?)",
+        (session_node_id, session_id),
+    )
+    conn.commit()
+
+    hits = query_memory_current(conn, MemoryQueryRequest(query="memory", limit=10))
+    assert hits["results"]
+    assert all("session log" not in row["evidence_excerpt"] for row in hits["results"])
+    assert all(row["repository"] == "hippo" for row in hits["results"])
+
+
+def test_cli_and_mcp_match_for_fixture(conn: sqlite3.Connection, tmp_path: Path, tmp_db) -> None:
+    _seed_memory_corpus(conn, tmp_path)
+    _conn, db_path = tmp_db
+
+    cli = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(Path(__file__).parent.parent),
+            "hippo-memory-query",
+            "architecture",
+            "--repository",
+            "hippo",
+            "--category",
+            "project",
+            "--db",
+            str(db_path),
+            "--limit",
+            "5",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=str(Path(__file__).parent.parent.parent),
+    )
+    cli_payload = json.loads(cli.stdout)
+
+    from hippo_brain.mcp import _state
+
+    _state.db_path = str(db_path)
+    mcp_payload = asyncio.run(
+        query_memory(
+            query="architecture",
+            repository="hippo",
+            category="project",
+            limit=5,
+        )
+    )
+    assert "error" not in mcp_payload
+    assert cli_payload["results"] == mcp_payload["results"]
+
+    cli_history = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(Path(__file__).parent.parent),
+            "hippo-memory-query",
+            "--history",
+            "--repository",
+            "hippo",
+            "--logical-path",
+            "MEMORY.md",
+            "--db",
+            str(db_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=str(Path(__file__).parent.parent.parent),
+    )
+    hist_cli = json.loads(cli_history.stdout)
+
+    hist_mcp = asyncio.run(
+        query_memory_history(repository="hippo", logical_path="MEMORY.md", limit=50)
+    )
+    assert "error" not in hist_mcp
+    assert hist_cli["results"] == hist_mcp["results"]

--- a/brain/tests/test_memory_query.py
+++ b/brain/tests/test_memory_query.py
@@ -111,9 +111,7 @@ def test_history_is_explicit_and_separate(conn: sqlite3.Connection, tmp_path: Pa
     assert len(current["results"]) >= 1
     assert "alpha" in current["results"][0]["evidence_excerpt"]
 
-    history = run_memory_history_query(
-        conn, repository="hippo", logical_path="MEMORY.md", limit=10
-    )
+    history = run_memory_history_query(conn, repository="hippo", logical_path="MEMORY.md", limit=10)
     assert history["view"] == "history"
     assert len(history["results"]) == 2
     assert history["results"][0]["revision_number"] == 2

--- a/brain/tests/test_memory_query.py
+++ b/brain/tests/test_memory_query.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import sqlite3
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest

--- a/brain/tests/test_openapi.py
+++ b/brain/tests/test_openapi.py
@@ -39,6 +39,8 @@ def test_openapi_spec_lists_all_brain_routes():
         "/query",
         "/ask",
         "/agent/query",
+        "/memory/query",
+        "/memory/history",
         "/control/pause",
         "/control/resume",
         "/openapi.json",
@@ -53,6 +55,8 @@ def test_openapi_spec_lists_all_brain_routes():
     assert paths["/query"]["post"]["operationId"] == "queryKnowledge"
     assert paths["/ask"]["post"]["operationId"] == "askQuestion"
     assert paths["/agent/query"]["post"]["operationId"] == "agentQuery"
+    assert paths["/memory/query"]["post"]["operationId"] == "memoryQuery"
+    assert paths["/memory/history"]["post"]["operationId"] == "memoryHistory"
     assert paths["/control/pause"]["post"]["operationId"] == "pauseEnrichment"
     assert paths["/control/resume"]["post"]["operationId"] == "resumeEnrichment"
     assert paths["/openapi.json"]["get"]["operationId"] == "getOpenApiSpec"

--- a/brain/tests/test_server.py
+++ b/brain/tests/test_server.py
@@ -257,6 +257,81 @@ def test_agent_query_missing_query_returns_400(tmp_db):
     assert resp.json()["error"] == "query is required"
 
 
+def _seed_memory_document(conn, tmp_path):
+    from hippo_brain.auto_memory import ingest_memory_file, write_memory_knowledge_node
+    from hippo_brain.models import EnrichmentResult
+
+    path = tmp_path / "MEMORY.md"
+    path.write_text("# HTTP\n\nmemory contract test\n")
+    ingested = ingest_memory_file(conn, path, repository="hippo", now_ms=1000)
+    result = EnrichmentResult(
+        summary="memory contract test",
+        intent="memory",
+        outcome="success",
+        tags=["memory"],
+        embed_text="memory contract test",
+    )
+    write_memory_knowledge_node(conn, result, ingested.revision_id, "mock-model", now_ms=1000)
+    return ingested
+
+
+def test_memory_query_happy_path(tmp_db, tmp_path):
+    conn, db_path = tmp_db
+    _seed_memory_document(conn, tmp_path)
+    app = _make_app(str(db_path))
+    client = TestClient(app)
+
+    resp = client.post(
+        "/memory/query",
+        json={"query": "contract", "repository": "hippo", "limit": 5},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["view"] == "current"
+    assert data["results"]
+    assert "source_path" not in data["results"][0]
+
+
+def test_memory_query_invalid_limit_returns_400(tmp_db):
+    _, db_path = tmp_db
+    app = _make_app(str(db_path))
+    client = TestClient(app)
+
+    resp = client.post("/memory/query", json={"limit": 0})
+    assert resp.status_code == 400
+    assert "limit must be greater than 0" in resp.json()["error"]
+
+
+def test_memory_history_requires_identity(tmp_db):
+    _, db_path = tmp_db
+    app = _make_app(str(db_path))
+    client = TestClient(app)
+
+    resp = client.post("/memory/history", json={})
+    assert resp.status_code == 400
+    assert "document_uuid or repository+logical_path is required" in resp.json()["error"]
+
+
+def test_memory_history_matches_cli_shape(tmp_db, tmp_path):
+    conn, db_path = tmp_db
+    _seed_memory_document(conn, tmp_path)
+    app = _make_app(str(db_path))
+    client = TestClient(app)
+
+    resp = client.post(
+        "/memory/history",
+        json={
+            "repository": "hippo",
+            "logical_path": "MEMORY.md",
+            "limit": 10,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["view"] == "history"
+    assert data["results"][0]["revision_number"] == 1
+
+
 def test_query_empty_text_returns_400(tmp_db):
     conn, db_path = tmp_db
     app = _make_app(str(db_path))

--- a/brain/tests/test_server.py
+++ b/brain/tests/test_server.py
@@ -469,7 +469,7 @@ def test_brain_server_get_routes(tmp_db):
     _, db_path = tmp_db
     server = _make_server(str(db_path))
     routes = server.get_routes()
-    assert len(routes) == 11
+    assert len(routes) == 13
     paths = [r.path for r in routes]
     assert "/health" in paths
     assert "/sessions" in paths
@@ -1060,7 +1060,7 @@ def test_knowledge_list_routes_included(tmp_db):
     paths = [r.path for r in routes]
     assert "/knowledge" in paths
     assert "/knowledge/{id:int}" in paths
-    assert len(routes) == 11
+    assert len(routes) == 13
 
 
 # ---- /knowledge/{id} ----
@@ -1247,7 +1247,7 @@ def test_events_list_routes_included(tmp_db):
     routes = server.get_routes()
     paths = [r.path for r in routes]
     assert "/events" in paths
-    assert len(routes) == 11
+    assert len(routes) == 13
 
 
 # ---- /sessions ----
@@ -1368,7 +1368,7 @@ def test_sessions_list_routes_included(tmp_db):
     routes = server.get_routes()
     paths = [r.path for r in routes]
     assert "/sessions" in paths
-    assert len(routes) == 11
+    assert len(routes) == 13
 
 
 # ---- _record_preflight_to_source_health ----

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -39,7 +39,32 @@ Auto-memory is an always-on source: like shell, Claude, and browser activity, it
 search_knowledge(query="busy timeout", mode="lexical", source="claude-auto-memory", project="owner/repository")
 ```
 
-Results include `source`, `source_path`, `repository`, `logical_path`, `content_hash`, and capture time. Only the active revision is ever queryable: superseding a revision replaces its knowledge node (and vector), and a revision superseded before its enrichment finishes is discarded rather than published, so stale memory content never appears in answers.
+For a dedicated read-only memory contract (current projected chunks, explicit history, provenance without local paths by default), use:
+
+| Surface | Current memory | Revision history |
+|---------|----------------|------------------|
+| MCP | `query_memory(...)` | `query_memory_history(...)` |
+| HTTP | `POST /memory/query` | `POST /memory/history` |
+| CLI | `hippo-memory-query "term" --repository owner/repo` | `hippo-memory-query --history --repository owner/repo --logical-path MEMORY.md` |
+
+**Claude Code / Codex / opencode (MCP):**
+
+```json
+{"tool": "query_memory", "arguments": {"query": "auth design", "repository": "owner/repo", "category": "project", "limit": 10}}
+```
+
+**Human CLI:**
+
+```sh
+uv run --project brain hippo-memory-query "busy timeout" --repository owner/repository --limit 5
+uv run --project brain hippo-memory-query --history --repository owner/repository --logical-path MEMORY.md
+```
+
+Filters: `repository`, `category`, `logical_path`, `document_uuid`, `since` (e.g. `7d`). Default results include only active, successfully projected chunks (`projection_status` ready/stale). Use `include_non_queryable=true` to list pending/failed/unavailable status stubs. Use `include_source_path=true` only for local diagnostics.
+
+Results include `repository`, `logical_path`, `document_uuid`, `chunk_id`, `content_hash`, `source_mtime_ms`, `enriched_at`, `evidence_excerpt`, `memory_categories`, and `memory_links`. Absolute `source_path` is omitted unless explicitly requested.
+
+Results from `search_knowledge` include `source`, `source_path`, `repository`, `logical_path`, `content_hash`, and capture time. Only the active revision is ever queryable: superseding a revision replaces its knowledge node (and vector), and a revision superseded before its enrichment finishes is discarded rather than published, so stale memory content never appears in answers.
 
 ## Revision history
 


### PR DESCRIPTION
## Summary
- Add `memory_query.py` canonical layer: current projected memory chunks with provenance, plus explicit bounded history
- Expose via MCP (`query_memory`, `query_memory_history`), HTTP (`POST /memory/query`, `/memory/history`), and CLI (`hippo-memory-query`)
- Contract tests verify MCP/CLI parity, history separation, path privacy, and no conflation with agentic session logs

## Test plan
- [x] `pytest brain/tests/test_memory_query.py`
- [x] `pytest brain/tests/test_openapi.py`
- [x] `pytest brain/tests/test_mcp_server.py::TestToolRegistration`
- [x] `pytest brain/tests/test_auto_memory*.py`