### PR TITLE
SNUG-138: auto-memory reliability — probes, watchdog, doctor, recovery

### DIFF
--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -38,6 +38,8 @@ hippo-auto-memory = "hippo_brain.auto_memory:main"
 hippo-auto-memory-poll = "hippo_brain.auto_memory:poll_main"
 hippo-auto-memory-reconcile = "hippo_brain.auto_memory:reconcile_file_main"
 hippo-auto-memory-inventory = "hippo_brain.auto_memory:inventory_main"
+hippo-auto-memory-replay = "hippo_brain.auto_memory:replay_main"
+hippo-auto-memory-probe = "hippo_brain.auto_memory_probe:main"
 hippo-memory-query = "hippo_brain.memory_query:main"
 
 [build-system]

--- a/brain/src/hippo_brain/auto_memory.py
+++ b/brain/src/hippo_brain/auto_memory.py
@@ -657,3 +657,27 @@ def main(argv: list[str] | None = None) -> int:
         conn.close()
     print(json.dumps(result.__dict__, sort_keys=True))
     return 0
+
+
+def replay_main(argv: list[str] | None = None) -> int:
+    """Reset failed auto-memory enrichment rows to pending (operator replay)."""
+    from hippo_brain.auto_memory_health import replay_failed_enrichments
+
+    parser = argparse.ArgumentParser(description="Replay failed Claude auto-memory enrichments.")
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path.home() / ".local" / "share" / "hippo" / "hippo.db",
+    )
+    parser.add_argument("--limit", type=int, default=50)
+    args = parser.parse_args(argv)
+    conn = _open_db(args.db)
+    try:
+        if _schema_version(conn) != EXPECTED_SCHEMA_VERSION:
+            parser.error(f"database schema version must be {EXPECTED_SCHEMA_VERSION}")
+        replayed = replay_failed_enrichments(conn, limit=args.limit)
+        conn.commit()
+    finally:
+        conn.close()
+    print(json.dumps({"replayed": replayed}, sort_keys=True))
+    return 0

--- a/brain/src/hippo_brain/auto_memory.py
+++ b/brain/src/hippo_brain/auto_memory.py
@@ -28,6 +28,7 @@ from hippo_brain.auto_memory_ingest import (
     derive_repository_identity,
     ingest_memory_file,
 )
+from hippo_brain.auto_memory_health import replay_failed_enrichments
 from hippo_brain.auto_memory_reconcile import (
     ReconcileConfig,
     document_absence_outcome,
@@ -661,8 +662,6 @@ def main(argv: list[str] | None = None) -> int:
 
 def replay_main(argv: list[str] | None = None) -> int:
     """Reset failed auto-memory enrichment rows to pending (operator replay)."""
-    from hippo_brain.auto_memory_health import replay_failed_enrichments
-
     parser = argparse.ArgumentParser(description="Replay failed Claude auto-memory enrichments.")
     parser.add_argument(
         "--db",

--- a/brain/src/hippo_brain/auto_memory_constants.py
+++ b/brain/src/hippo_brain/auto_memory_constants.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import uuid
 
 SOURCE_KIND = "claude-auto-memory"
+WATCHER_SOURCE = "auto-memory-watcher"
+# Synthetic probe fixture identity — excluded from all user-facing retrieval (AP-6).
+PROBE_REPOSITORY = "hippo/__hippo_probe__"
+PROBE_LOGICAL_PATH = "synthetic/probe-memory.md"
 CHUNKER_NAME = "markdown-headings"
 CHUNKER_VERSION = 1
 _IDENTITY_NAMESPACE = uuid.UUID("0fc25921-9c30-4c16-85da-b489ea81f087")

--- a/brain/src/hippo_brain/auto_memory_health.py
+++ b/brain/src/hippo_brain/auto_memory_health.py
@@ -41,10 +41,22 @@ def _queue_counts(conn: sqlite3.Connection) -> tuple[int, int]:
     if not table_exists(conn, "memory_enrichment_queue"):
         return 0, 0
     pending = conn.execute(
-        "SELECT COUNT(*) FROM memory_enrichment_queue WHERE status = 'pending'"
+        """
+        SELECT COUNT(*) FROM memory_enrichment_queue meq
+        JOIN memory_revisions mr ON mr.id = meq.revision_id
+        JOIN memory_documents md ON md.id = mr.document_id
+        WHERE meq.status = 'pending' AND md.repository != ?
+        """,
+        (PROBE_REPOSITORY,),
     ).fetchone()[0]
     failed = conn.execute(
-        "SELECT COUNT(*) FROM memory_enrichment_queue WHERE status = 'failed'"
+        """
+        SELECT COUNT(*) FROM memory_enrichment_queue meq
+        JOIN memory_revisions mr ON mr.id = meq.revision_id
+        JOIN memory_documents md ON md.id = mr.document_id
+        WHERE meq.status = 'failed' AND md.repository != ?
+        """,
+        (PROBE_REPOSITORY,),
     ).fetchone()[0]
     return int(pending or 0), int(failed or 0)
 

--- a/brain/src/hippo_brain/auto_memory_health.py
+++ b/brain/src/hippo_brain/auto_memory_health.py
@@ -121,7 +121,9 @@ def _health_row(conn: sqlite3.Connection, source: str) -> dict[str, Any] | None:
     return dict(zip(keys, row, strict=True))
 
 
-def snapshot_health(conn: sqlite3.Connection, *, now_ms: int | None = None) -> AutoMemoryHealthSnapshot:
+def snapshot_health(
+    conn: sqlite3.Connection, *, now_ms: int | None = None
+) -> AutoMemoryHealthSnapshot:
     """Read auto-memory health dimensions from SQLite (no brain HTTP)."""
     now_ms = now_ms or int(time.time() * 1000)
     watcher = _health_row(conn, WATCHER_SOURCE) or {}

--- a/brain/src/hippo_brain/auto_memory_health.py
+++ b/brain/src/hippo_brain/auto_memory_health.py
@@ -1,0 +1,193 @@
+"""Auto-memory capture health: watcher, ingest, queue, and projection signals (SNUG-138)."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from hippo_brain.auto_memory_constants import PROBE_REPOSITORY, SOURCE_KIND, WATCHER_SOURCE
+from hippo_brain.source_filters import table_exists
+
+WATCHER_STALE_MS = 15 * 60 * 1000
+PROJECTION_STALE_MS = 30 * 60 * 1000
+RECONCILE_FAILURE_THRESHOLD = 3
+
+
+@dataclass(frozen=True)
+class AutoMemoryHealthSnapshot:
+    watcher_last_heartbeat_ms: int | None
+    ingest_last_event_ms: int | None
+    ingest_consecutive_failures: int
+    pending_enrichment: int
+    failed_enrichment: int
+    stale_projection_count: int
+    orphan_chunk_links: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "watcher_last_heartbeat_ms": self.watcher_last_heartbeat_ms,
+            "ingest_last_event_ms": self.ingest_last_event_ms,
+            "ingest_consecutive_failures": self.ingest_consecutive_failures,
+            "pending_enrichment": self.pending_enrichment,
+            "failed_enrichment": self.failed_enrichment,
+            "stale_projection_count": self.stale_projection_count,
+            "orphan_chunk_links": self.orphan_chunk_links,
+        }
+
+
+def _queue_counts(conn: sqlite3.Connection) -> tuple[int, int]:
+    if not table_exists(conn, "memory_enrichment_queue"):
+        return 0, 0
+    pending = conn.execute(
+        "SELECT COUNT(*) FROM memory_enrichment_queue WHERE status = 'pending'"
+    ).fetchone()[0]
+    failed = conn.execute(
+        "SELECT COUNT(*) FROM memory_enrichment_queue WHERE status = 'failed'"
+    ).fetchone()[0]
+    return int(pending or 0), int(failed or 0)
+
+
+def _stale_projection_count(conn: sqlite3.Connection, *, now_ms: int) -> int:
+    if not table_exists(conn, "memory_documents"):
+        return 0
+    cutoff = now_ms - PROJECTION_STALE_MS
+    row = conn.execute(
+        """
+        SELECT COUNT(*) FROM memory_documents
+        WHERE state = 'active'
+          AND projection_status = 'pending'
+          AND repository != ?
+          AND updated_at < ?
+        """,
+        (PROBE_REPOSITORY, cutoff),
+    ).fetchone()
+    return int(row[0] or 0)
+
+
+def _orphan_chunk_links(conn: sqlite3.Connection) -> int:
+    if not table_exists(conn, "knowledge_node_memory_chunks"):
+        return 0
+    row = conn.execute(
+        """
+        SELECT COUNT(*) FROM memory_chunks mc
+        LEFT JOIN knowledge_node_memory_chunks knmc ON knmc.memory_chunk_id = mc.id
+        JOIN memory_revisions mr ON mr.id = mc.revision_id
+        JOIN memory_documents md ON md.id = mr.document_id
+        WHERE md.active_revision_id = mr.id
+          AND md.state = 'active'
+          AND md.repository != ?
+          AND knmc.knowledge_node_id IS NULL
+        """,
+        (PROBE_REPOSITORY,),
+    ).fetchone()
+    return int(row[0] or 0)
+
+
+def _health_row(conn: sqlite3.Connection, source: str) -> dict[str, Any] | None:
+    if not table_exists(conn, "source_health"):
+        return None
+    row = conn.execute(
+        """
+        SELECT last_event_ts, last_success_ts, last_error_msg, consecutive_failures,
+               last_heartbeat_ts, updated_at
+        FROM source_health WHERE source = ?
+        """,
+        (source,),
+    ).fetchone()
+    if row is None:
+        return None
+    keys = (
+        "last_event_ts",
+        "last_success_ts",
+        "last_error_msg",
+        "consecutive_failures",
+        "last_heartbeat_ts",
+        "updated_at",
+    )
+    return dict(zip(keys, row, strict=True))
+
+
+def snapshot_health(conn: sqlite3.Connection, *, now_ms: int | None = None) -> AutoMemoryHealthSnapshot:
+    """Read auto-memory health dimensions from SQLite (no brain HTTP)."""
+    now_ms = now_ms or int(time.time() * 1000)
+    watcher = _health_row(conn, WATCHER_SOURCE) or {}
+    ingest = _health_row(conn, SOURCE_KIND) or {}
+    pending, failed = _queue_counts(conn)
+    return AutoMemoryHealthSnapshot(
+        watcher_last_heartbeat_ms=watcher.get("last_heartbeat_ts"),
+        ingest_last_event_ms=ingest.get("last_event_ts"),
+        ingest_consecutive_failures=int(ingest.get("consecutive_failures") or 0),
+        pending_enrichment=pending,
+        failed_enrichment=failed,
+        stale_projection_count=_stale_projection_count(conn, now_ms=now_ms),
+        orphan_chunk_links=_orphan_chunk_links(conn),
+    )
+
+
+def bump_watcher_heartbeat(conn: sqlite3.Connection, *, now_ms: int | None = None) -> None:
+    now_ms = now_ms or int(time.time() * 1000)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO source_health (source, updated_at)
+        VALUES (?, ?)
+        """,
+        (WATCHER_SOURCE, now_ms),
+    )
+    conn.execute(
+        """
+        UPDATE source_health
+        SET last_heartbeat_ts = ?, last_success_ts = ?, consecutive_failures = 0,
+            last_error_msg = NULL, last_error_ts = NULL, updated_at = ?
+        WHERE source = ?
+        """,
+        (now_ms, now_ms, now_ms, WATCHER_SOURCE),
+    )
+
+
+def record_reconcile_failure(
+    conn: sqlite3.Connection,
+    message: str,
+    *,
+    now_ms: int | None = None,
+) -> None:
+    now_ms = now_ms or int(time.time() * 1000)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO source_health (source, updated_at)
+        VALUES (?, ?)
+        """,
+        (SOURCE_KIND, now_ms),
+    )
+    conn.execute(
+        """
+        UPDATE source_health
+        SET consecutive_failures = consecutive_failures + 1,
+            last_error_msg = ?, last_error_ts = ?, updated_at = ?
+        WHERE source = ?
+        """,
+        (message[:500], now_ms, now_ms, SOURCE_KIND),
+    )
+
+
+def replay_failed_enrichments(conn: sqlite3.Connection, *, limit: int = 50) -> int:
+    """Operator-safe replay: reset failed queue rows to pending with bounded retries."""
+    if not table_exists(conn, "memory_enrichment_queue"):
+        return 0
+    now_ms = int(time.time() * 1000)
+    cursor = conn.execute(
+        """
+        UPDATE memory_enrichment_queue
+        SET status = 'pending', retry_count = 0, updated_at = ?
+        WHERE id IN (
+            SELECT meq.id FROM memory_enrichment_queue meq
+            JOIN memory_revisions mr ON mr.id = meq.revision_id
+            JOIN memory_documents md ON md.id = mr.document_id
+            WHERE meq.status = 'failed' AND md.repository != ?
+            LIMIT ?
+        )
+        """,
+        (now_ms, PROBE_REPOSITORY, max(limit, 1)),
+    )
+    return int(cursor.rowcount or 0)

--- a/brain/src/hippo_brain/auto_memory_ingest.py
+++ b/brain/src/hippo_brain/auto_memory_ingest.py
@@ -15,6 +15,7 @@ from urllib.parse import urlsplit
 from hippo_brain.auto_memory_constants import (
     CHUNKER_NAME,
     CHUNKER_VERSION,
+    PROBE_REPOSITORY,
     SOURCE_KIND,
     _IDENTITY_NAMESPACE,
 )
@@ -365,23 +366,29 @@ def ingest_memory_file(
                 for chunk in chunks
             ],
         )
+        is_probe = repository_identity == PROBE_REPOSITORY
+        if not is_probe:
+            conn.execute(
+                "INSERT INTO memory_enrichment_queue "
+                "(revision_id, status, priority, retry_count, max_retries, enqueued_at, updated_at) "
+                "VALUES (?, 'pending', 5, 0, 5, ?, ?)",
+                (revision_id, observed_at, observed_at),
+            )
+            projection_status = "pending"
+        else:
+            projection_status = "ready"
         conn.execute(
-            "INSERT INTO memory_enrichment_queue "
-            "(revision_id, status, priority, retry_count, max_retries, enqueued_at, updated_at) "
-            "VALUES (?, 'pending', 5, 0, 5, ?, ?)",
-            (revision_id, observed_at, observed_at),
-        )
-        conn.execute(
-            "UPDATE memory_documents SET current_revision_id = ?, projection_status = 'pending', "
+            "UPDATE memory_documents SET current_revision_id = ?, projection_status = ?, "
             "last_error = NULL, updated_at = ? WHERE id = ?",
-            (revision_id, observed_at, document_id),
+            (revision_id, projection_status, observed_at, document_id),
         )
-        conn.execute(
-            "UPDATE source_health SET last_event_ts = ?, last_success_ts = ?, "
-            "last_error_msg = NULL, last_error_ts = NULL, "
-            "consecutive_failures = 0, updated_at = ? WHERE source = ?",
-            (observed_at, observed_at, observed_at, SOURCE_KIND),
-        )
+        if not is_probe:
+            conn.execute(
+                "UPDATE source_health SET last_event_ts = ?, last_success_ts = ?, "
+                "last_error_msg = NULL, last_error_ts = NULL, "
+                "consecutive_failures = 0, updated_at = ? WHERE source = ?",
+                (observed_at, observed_at, observed_at, SOURCE_KIND),
+            )
         if previous_redacted is not None and current_revision_id is not None:
             finalize_superseded_revision(
                 conn,

--- a/brain/src/hippo_brain/auto_memory_probe.py
+++ b/brain/src/hippo_brain/auto_memory_probe.py
@@ -1,0 +1,119 @@
+"""Synthetic auto-memory probe — dedicated fixture outside Claude's datastore (SNUG-138)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+
+from hippo_brain.auto_memory_constants import PROBE_LOGICAL_PATH, PROBE_REPOSITORY
+from hippo_brain.auto_memory_ingest import ingest_memory_file
+from hippo_brain.schema_version import EXPECTED_SCHEMA_VERSION
+
+
+def probe_fixture_dir(data_dir: Path) -> Path:
+    return data_dir / "probe-auto-memory"
+
+
+def run_probe(
+    conn: sqlite3.Connection,
+    *,
+    fixture_root: Path,
+    now_ms: int | None = None,
+) -> dict[str, object]:
+    """Create/mutate probe fixture, ingest twice, return ok + lag_ms."""
+    now_ms = now_ms or int(time.time() * 1000)
+    fixture_root.mkdir(parents=True, exist_ok=True)
+    fixture = fixture_root / "probe-memory.md"
+    tag = uuid.uuid4().hex
+    fixture.write_text(f"# Probe {tag}\n\nSynthetic auto-memory probe content.\n")
+    probe_start = int(time.time() * 1000)
+
+    first = ingest_memory_file(
+        conn,
+        fixture,
+        repository=PROBE_REPOSITORY,
+        logical_path=PROBE_LOGICAL_PATH,
+        now_ms=now_ms,
+    )
+    if not first.changed:
+        return {"ok": False, "lag_ms": None, "error": "initial ingest was no-op"}
+
+    row = conn.execute(
+        """
+        SELECT md.updated_at, mr.revision_number
+        FROM memory_documents md
+        JOIN memory_revisions mr ON mr.id = md.current_revision_id
+        WHERE md.repository = ? AND md.logical_path = ?
+        """,
+        (PROBE_REPOSITORY, PROBE_LOGICAL_PATH),
+    ).fetchone()
+    if row is None:
+        return {"ok": False, "lag_ms": None, "error": "probe document missing after ingest"}
+
+    fixture.write_text(
+        fixture.read_text() + f"\n## Mutation\n\nUpdated at {tag}.\n",
+        encoding="utf-8",
+    )
+    second = ingest_memory_file(
+        conn,
+        fixture,
+        repository=PROBE_REPOSITORY,
+        logical_path=PROBE_LOGICAL_PATH,
+        now_ms=now_ms + 1,
+    )
+    if not second.changed or second.revision_number < 2:
+        return {"ok": False, "lag_ms": None, "error": "mutation ingest did not advance revision"}
+
+    updated = conn.execute(
+        "SELECT updated_at FROM memory_documents WHERE repository = ? AND logical_path = ?",
+        (PROBE_REPOSITORY, PROBE_LOGICAL_PATH),
+    ).fetchone()
+    if updated is None:
+        return {"ok": False, "lag_ms": None, "error": "probe document missing after mutation"}
+
+    lag_ms = max(0, int(updated[0]) - probe_start)
+    return {"ok": True, "lag_ms": lag_ms, "revision_number": second.revision_number}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run synthetic Claude auto-memory probe.")
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path.home() / ".local" / "share" / "hippo" / "hippo.db",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=None,
+        help="Hippo data directory for probe fixture (defaults to parent of --db)",
+    )
+    args = parser.parse_args(argv)
+    data_dir = args.data_dir or args.db.parent
+    conn = sqlite3.connect(args.db)
+    try:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        if version != EXPECTED_SCHEMA_VERSION:
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "lag_ms": None,
+                        "error": f"schema version {version} != {EXPECTED_SCHEMA_VERSION}",
+                    }
+                )
+            )
+            return 1
+        result = run_probe(conn, fixture_root=probe_fixture_dir(data_dir))
+        print(json.dumps(result, sort_keys=True))
+        return 0 if result.get("ok") else 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brain/src/hippo_brain/auto_memory_reconcile.py
+++ b/brain/src/hippo_brain/auto_memory_reconcile.py
@@ -24,6 +24,11 @@ from hippo_brain.auto_memory_discovery import (
     merge_configured_sources,
 )
 from hippo_brain.auto_memory_ingest import ingest_memory_file
+from hippo_brain.auto_memory_health import (
+    bump_watcher_heartbeat,
+    record_reconcile_failure,
+    snapshot_health,
+)
 from hippo_brain.auto_memory_lifecycle import (
     RevisionRetention,
     reconcile_configured_sources,
@@ -230,9 +235,11 @@ def reconcile_sources(
                 require_stable=require_stable,
             )
         except (OSError, ValueError, sqlite3.Error) as exc:
+            path = str(Path(source["path"]).expanduser().resolve())
+            record_reconcile_failure(conn, str(exc), now_ms=observed_at)
             results.append(
                 {
-                    "path": str(Path(source["path"]).expanduser().resolve()),
+                    "path": path,
                     "outcome": "error",
                     "changed": False,
                     "revision_id": None,
@@ -277,6 +284,9 @@ def reconcile_sources(
             conn=conn,
             now_ms=observed_at,
         ).to_dict()
+    bump_watcher_heartbeat(conn, now_ms=observed_at)
+    summary["health"] = snapshot_health(conn, now_ms=observed_at).to_dict()
+    conn.commit()
     return summary
 
 

--- a/brain/src/hippo_brain/memory_query.py
+++ b/brain/src/hippo_brain/memory_query.py
@@ -18,7 +18,7 @@ from hippo_brain.auto_memory_categories import (
     list_document_links,
     validate_memory_category_filter,
 )
-from hippo_brain.auto_memory_constants import SOURCE_KIND
+from hippo_brain.auto_memory_constants import PROBE_REPOSITORY, SOURCE_KIND
 from hippo_brain.auto_memory_lifecycle import query_memory_history
 from hippo_brain.mcp_queries import MAX_LIMIT, parse_since
 from hippo_brain.source_filters import table_exists
@@ -144,6 +144,9 @@ def _build_current_filters(req: MemoryQueryRequest) -> tuple[str, list[Any]]:
     if req.repository:
         clauses.append("d.repository = ?")
         params.append(req.repository)
+    else:
+        clauses.append("d.repository != ?")
+        params.append(PROBE_REPOSITORY)
     if req.logical_path:
         clauses.append("d.logical_path = ?")
         params.append(req.logical_path)
@@ -259,6 +262,9 @@ def _build_status_filters(req: MemoryQueryRequest) -> tuple[str, list[Any]]:
     if req.repository:
         clauses.append("d.repository = ?")
         params.append(req.repository)
+    else:
+        clauses.append("d.repository != ?")
+        params.append(PROBE_REPOSITORY)
     if req.logical_path:
         clauses.append("d.logical_path = ?")
         params.append(req.logical_path)

--- a/brain/src/hippo_brain/schema_version.py
+++ b/brain/src/hippo_brain/schema_version.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 
 import sqlite3
 
-EXPECTED_SCHEMA_VERSION: int = 20
+EXPECTED_SCHEMA_VERSION: int = 21
 
 # Versions brain can read without erroring.
 #

--- a/brain/src/hippo_brain/source_filters.py
+++ b/brain/src/hippo_brain/source_filters.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sqlite3
 
+from hippo_brain.auto_memory_constants import PROBE_REPOSITORY
+
 CLAUDE_AUTO_MEMORY_SOURCE = "claude-auto-memory"
 
 # Logical source families keyed by linked_source_ids prefix (see retrieval._fetch_details).
@@ -26,13 +28,16 @@ def source_kind_from_linked_id(link: str) -> str | None:
     return None
 
 
+_MEMORY_PROBE_EXCLUDE = f"AND md.repository != '{PROBE_REPOSITORY}'"
+
 _MEMORY_SOURCE_EXISTS = (
     "EXISTS (SELECT 1 FROM knowledge_node_memory_chunks knmc "
     "JOIN memory_chunks mc ON mc.id = knmc.memory_chunk_id "
     "JOIN memory_revisions mr ON mr.id = mc.revision_id "
     "JOIN memory_documents md ON md.id = mr.document_id "
     "WHERE knmc.knowledge_node_id = kn.id "
-    "AND md.active_revision_id = mr.id AND md.state = 'active')"
+    "AND md.active_revision_id = mr.id AND md.state = 'active' "
+    f"{_MEMORY_PROBE_EXCLUDE})"
 )
 
 _SOURCE_EXISTS: dict[str, str] = {
@@ -50,6 +55,7 @@ _MEMORY_PROJECT_EXISTS = (
     "JOIN memory_documents md ON md.id = mr.document_id "
     "WHERE knmc.knowledge_node_id = kn.id "
     "AND md.active_revision_id = mr.id AND md.state = 'active' "
+    f"{_MEMORY_PROBE_EXCLUDE} "
     "AND (md.repository LIKE ? OR md.source_path LIKE ?))"
 )
 
@@ -61,6 +67,7 @@ _MEMORY_CATEGORY_EXISTS = (
     "JOIN memory_document_categories mdc ON mdc.document_id = md.id "
     "WHERE knmc.knowledge_node_id = kn.id "
     "AND md.active_revision_id = mr.id AND md.state = 'active' "
+    f"{_MEMORY_PROBE_EXCLUDE} "
     "AND mdc.category = ?)"
 )
 

--- a/brain/src/hippo_brain/source_freshness.py
+++ b/brain/src/hippo_brain/source_freshness.py
@@ -81,7 +81,8 @@ _COVERAGE_SQL: dict[str, str] = {
         "WHERE harness = 'cursor' AND probe_tag IS NULL"
     ),
     "claude-auto-memory": (
-        "SELECT COUNT(*), MAX(md.updated_at) FROM memory_documents md WHERE md.state = 'active'"
+        "SELECT COUNT(*), MAX(md.updated_at) FROM memory_documents md "
+        "WHERE md.state = 'active' AND md.repository != 'hippo/__hippo_probe__'"
     ),
 }
 

--- a/brain/tests/test_auto_memory_reliability.py
+++ b/brain/tests/test_auto_memory_reliability.py
@@ -1,0 +1,154 @@
+"""Reliability and operations tests for Claude auto-memory (SNUG-138)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hippo_brain.auto_memory import (
+    claim_pending_memories,
+    ingest_memory_file,
+    mark_memory_enrichment_failed,
+    write_memory_knowledge_node,
+)
+from hippo_brain.auto_memory_constants import PROBE_REPOSITORY
+from hippo_brain.auto_memory_health import (
+    bump_watcher_heartbeat,
+    record_reconcile_failure,
+    replay_failed_enrichments,
+    snapshot_health,
+)
+from hippo_brain.auto_memory_probe import probe_fixture_dir, run_probe
+from hippo_brain.auto_memory_reconcile import reconcile_sources
+from hippo_brain.memory_query import MemoryQueryRequest, query_memory_current
+from hippo_brain.models import EnrichmentResult
+from hippo_brain.mcp_queries import search_knowledge_lexical
+
+
+@pytest.fixture
+def conn(tmp_db):
+    connection, _path = tmp_db
+    yield connection
+
+
+def test_probe_fixture_ingests_and_excludes_from_memory_query(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    fixture_root = probe_fixture_dir(tmp_path)
+    result = run_probe(conn, fixture_root=fixture_root)
+    assert result["ok"] is True
+    assert result.get("lag_ms") is not None
+
+    current = query_memory_current(conn, MemoryQueryRequest(query="Synthetic"))
+    assert all(r["repository"] != PROBE_REPOSITORY for r in current["results"])
+
+    rows = conn.execute(
+        "SELECT COUNT(*) FROM memory_documents WHERE repository = ?",
+        (PROBE_REPOSITORY,),
+    ).fetchone()[0]
+    assert rows == 1
+
+
+def test_probe_rows_excluded_from_lexical_search(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    fixture_root = probe_fixture_dir(tmp_path)
+    run_probe(conn, fixture_root=fixture_root)
+    probe_rev = conn.execute(
+        "SELECT current_revision_id FROM memory_documents WHERE repository = ?",
+        (PROBE_REPOSITORY,),
+    ).fetchone()[0]
+    write_memory_knowledge_node(
+        conn,
+        EnrichmentResult(
+            summary="Synthetic probe",
+            intent="probe",
+            outcome="success",
+            tags=["probe"],
+            embed_text="Synthetic auto-memory probe content",
+        ),
+        int(probe_rev),
+        "mock-model",
+        now_ms=3000,
+    )
+    conn.commit()
+    assert search_knowledge_lexical(conn, "Synthetic", source="claude-auto-memory") == []
+    assert search_knowledge_lexical(conn, "Synthetic auto-memory", source="claude-auto-memory") == []
+
+
+def test_health_snapshot_separates_watcher_queue_and_projection(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    bump_watcher_heartbeat(conn, now_ms=1000)
+    source = tmp_path / "MEMORY.md"
+    source.write_text("# Health\n\nsnapshot dimensions.\n")
+    ingest_memory_file(conn, source, repository="hippo", now_ms=2000)
+    snap = snapshot_health(conn, now_ms=3000)
+    assert snap.watcher_last_heartbeat_ms == 1000
+    assert snap.ingest_last_event_ms is not None
+    assert snap.pending_enrichment >= 1
+    assert snap.failed_enrichment == 0
+
+
+def test_reconcile_failure_increments_ingest_health(
+    conn: sqlite3.Connection,
+) -> None:
+    record_reconcile_failure(conn, "simulated reconcile error", now_ms=5000)
+    row = conn.execute(
+        "SELECT consecutive_failures, last_error_msg FROM source_health WHERE source = 'claude-auto-memory'"
+    ).fetchone()
+    assert row[0] == 1
+    assert "simulated" in row[1]
+
+
+def test_replay_resets_failed_enrichment_rows(conn: sqlite3.Connection, tmp_path: Path) -> None:
+    source = tmp_path / "MEMORY.md"
+    source.write_text("# Replay\n\nfailed then replayed.\n")
+    ingested = ingest_memory_file(conn, source, repository="hippo", now_ms=1000)
+    mark_memory_enrichment_failed(conn, ingested.revision_id, "boom", now_ms=2000)
+    conn.execute(
+        "UPDATE memory_enrichment_queue SET status = 'failed' WHERE revision_id = ?",
+        (ingested.revision_id,),
+    )
+    conn.commit()
+    replayed = replay_failed_enrichments(conn, limit=10)
+    assert replayed == 1
+    status = conn.execute(
+        "SELECT status, retry_count FROM memory_enrichment_queue WHERE revision_id = ?",
+        (ingested.revision_id,),
+    ).fetchone()
+    assert status == ("pending", 0)
+
+
+def test_reconcile_bumps_watcher_and_returns_health_summary(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    source = tmp_path / "MEMORY.md"
+    source.write_text("# Reconcile\n\nhealth summary.\n")
+    summary = reconcile_sources(
+        conn,
+        [{"path": str(source), "repository": "hippo"}],
+        now_ms=4000,
+        require_stable=False,
+    )
+    assert "health" in summary
+    assert summary["health"]["watcher_last_heartbeat_ms"] == 4000
+
+
+def test_crash_recovery_requeues_stale_processing_revision(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    source = tmp_path / "MEMORY.md"
+    source.write_text("# Crash\n\nmid-enrichment interrupt.\n")
+    ingested = ingest_memory_file(conn, source, repository="hippo", now_ms=1000)
+    claims = claim_pending_memories(conn, worker_id="worker-a", limit=1, now_ms=2000)
+    assert len(claims) == 1
+    reclaimed = claim_pending_memories(
+        conn,
+        worker_id="worker-b",
+        limit=1,
+        now_ms=2000 + 600_000 + 1,
+        stale_lock_timeout_ms=600_000,
+    )
+    assert len(reclaimed) == 1
+    assert reclaimed[0].revision_id == ingested.revision_id

--- a/brain/tests/test_auto_memory_reliability.py
+++ b/brain/tests/test_auto_memory_reliability.py
@@ -97,7 +97,9 @@ def test_probe_rows_excluded_from_lexical_search(conn: sqlite3.Connection, tmp_p
     )
     conn.commit()
     assert search_knowledge_lexical(conn, "Synthetic", source="claude-auto-memory") == []
-    assert search_knowledge_lexical(conn, "Synthetic auto-memory", source="claude-auto-memory") == []
+    assert (
+        search_knowledge_lexical(conn, "Synthetic auto-memory", source="claude-auto-memory") == []
+    )
 
 
 def test_health_snapshot_separates_watcher_queue_and_projection(

--- a/brain/tests/test_auto_memory_reliability.py
+++ b/brain/tests/test_auto_memory_reliability.py
@@ -51,6 +51,30 @@ def test_probe_fixture_ingests_and_excludes_from_memory_query(
     assert rows == 1
 
 
+def test_probe_does_not_bump_ingest_health_or_enqueue(
+    conn: sqlite3.Connection, tmp_path: Path
+) -> None:
+    before = conn.execute(
+        "SELECT last_event_ts, consecutive_failures FROM source_health WHERE source = 'claude-auto-memory'"
+    ).fetchone()
+    fixture_root = probe_fixture_dir(tmp_path)
+    run_probe(conn, fixture_root=fixture_root)
+    after = conn.execute(
+        "SELECT last_event_ts, consecutive_failures FROM source_health WHERE source = 'claude-auto-memory'"
+    ).fetchone()
+    assert after == before
+    probe_queue = conn.execute(
+        """
+        SELECT COUNT(*) FROM memory_enrichment_queue meq
+        JOIN memory_revisions mr ON mr.id = meq.revision_id
+        JOIN memory_documents md ON md.id = mr.document_id
+        WHERE md.repository = ?
+        """,
+        (PROBE_REPOSITORY,),
+    ).fetchone()[0]
+    assert probe_queue == 0
+
+
 def test_probe_rows_excluded_from_lexical_search(conn: sqlite3.Connection, tmp_path: Path) -> None:
     fixture_root = probe_fixture_dir(tmp_path)
     run_probe(conn, fixture_root=fixture_root)

--- a/crates/hippo-core/src/schema.sql
+++ b/crates/hippo-core/src/schema.sql
@@ -652,9 +652,10 @@ INSERT OR IGNORE INTO source_health (source, last_event_ts, updated_at) VALUES
     -- with the inference-backend reachability result. Watchdog I-12 reads
     -- consecutive_failures to alarm when preflight has been stuck failing.
     ('brain-preflight',          NULL, unixepoch('now') * 1000),
-    ('claude-auto-memory',       NULL, unixepoch('now') * 1000);
+    ('claude-auto-memory',       NULL, unixepoch('now') * 1000),
+    ('auto-memory-watcher',      NULL, unixepoch('now') * 1000);
 
 -- The `claude_session_offsets` table (deprecated since T-5) is preserved
 -- to avoid breaking existing CREATE SCHEMA users.
 
-PRAGMA user_version = 20;
+PRAGMA user_version = 21;

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -19,7 +19,7 @@ const SCHEMA: &str = concat!(
 /// startup code (e.g. the brain handshake) can cross-check without
 /// re-declaring the value. Keep in sync with
 /// `brain/src/hippo_brain/schema_version.py::EXPECTED_SCHEMA_VERSION`.
-pub const EXPECTED_VERSION: i64 = 20;
+pub const EXPECTED_VERSION: i64 = 21;
 
 /// Idempotent v18→v19 auto-memory DDL (same file as fresh-install assembly).
 const AUTO_MEMORY_SCHEMA: &str = include_str!("schema/auto_memory.sql");
@@ -1444,6 +1444,17 @@ pub fn open_db(path: &Path) -> Result<Connection> {
     if (1..20).contains(&version) {
         conn.execute_batch(AUTO_MEMORY_TAXONOMY_SCHEMA)?;
         conn.execute_batch("PRAGMA user_version = 20;")?;
+    }
+
+    // v20→v21: auto-memory watcher source_health identity.
+    if (1..21).contains(&version) {
+        if table_exists(&conn, "source_health")? {
+            conn.execute_batch(
+                "INSERT OR IGNORE INTO source_health (source, last_event_ts, updated_at)
+                 VALUES ('auto-memory-watcher', NULL, unixepoch('now') * 1000);",
+            )?;
+        }
+        conn.execute_batch("PRAGMA user_version = 21;")?;
     } else if version != 0 && version != EXPECTED_VERSION {
         anyhow::bail!(
             "DB schema version mismatch: expected {}, found {}. \
@@ -1478,7 +1489,8 @@ pub fn open_db(path: &Path) -> Result<Connection> {
                 ('agentic-session-codex',    NULL, unixepoch('now') * 1000),
                 ('agentic-session-cursor',   NULL, unixepoch('now') * 1000),
                 ('brain-preflight',          NULL, unixepoch('now') * 1000),
-                ('claude-auto-memory',       NULL, unixepoch('now') * 1000);",
+                ('claude-auto-memory',       NULL, unixepoch('now') * 1000),
+                ('auto-memory-watcher',      NULL, unixepoch('now') * 1000);",
         );
     }
     Ok(conn)

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -1245,6 +1245,7 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
                 check_claude_session_coverage(&conn, &home.join(".claude/projects"), explain);
         }
         fail_count += check_cursor_session_coverage(config, &conn, explain);
+        fail_count += check_auto_memory_health(config, &conn, explain);
         fail_count += check_watchdog_heartbeat(&conn, explain);
         // Auto-resolved alarm count is informational — never increments fail_count.
         check_resolved_alarm_count(&conn);
@@ -1446,6 +1447,15 @@ pub fn source_freshness_probes() -> Vec<SourceFreshnessProbe> {
                     WHERE harness = 'cursor' AND probe_tag IS NULL",
             thresholds: FreshnessThresholds {
                 soft_ms: 3 * DAY_MS,
+                hard_ms: 30 * DAY_MS,
+            },
+        },
+        SourceFreshnessProbe {
+            name: "claude-auto-memory",
+            query: "SELECT COUNT(*), MAX(updated_at) FROM memory_documents \
+                    WHERE state = 'active' AND repository != 'hippo/__hippo_probe__'",
+            thresholds: FreshnessThresholds {
+                soft_ms: 7 * DAY_MS,
                 hard_ms: 30 * DAY_MS,
             },
         },
@@ -2962,6 +2972,144 @@ fn watchdog_heartbeat_status(age_secs: i64) -> WatchdogHeartbeatStatus {
     } else {
         WatchdogHeartbeatStatus::Fail
     }
+}
+
+/// Auto-memory reliability doctor check (SNUG-138) — SQLite only, no brain HTTP.
+fn check_auto_memory_health(config: &HippoConfig, db: &rusqlite::Connection, explain: bool) -> u32 {
+    if !config.auto_memory.enabled {
+        println!("[--] {:<29}  source disabled", "auto-memory health");
+        return 0;
+    }
+
+    let table_exists: bool = db
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_documents')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    if !table_exists {
+        println!("[--] {:<29}  schema not migrated", "auto-memory health");
+        return 0;
+    }
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let mut fail_count = 0u32;
+
+    let watcher_age: Option<i64> = db
+        .query_row(
+            "SELECT last_heartbeat_ts FROM source_health WHERE source = 'auto-memory-watcher'",
+            [],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten();
+    match watcher_age {
+        None => println!(
+            "[WW] {:<29}  watcher never heartbeated",
+            "auto-memory watcher"
+        ),
+        Some(ts) => {
+            let age_ms = (now_ms - ts).max(0);
+            if age_ms > 15 * 60 * 1000 {
+                println!(
+                    "[!!] {:<29}  heartbeat stale ({} ago)",
+                    "auto-memory watcher",
+                    format_duration_ms(age_ms)
+                );
+                if explain {
+                    println!("     CAUSE: FSEvents watcher or periodic reconcile may be down.");
+                    println!(
+                        "     FIX: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.hippo.auto-memory-watcher.plist"
+                    );
+                }
+                fail_count += 1;
+            } else {
+                println!(
+                    "[OK] {:<29}  heartbeat {}",
+                    "auto-memory watcher",
+                    format_duration_ms(age_ms)
+                );
+            }
+        }
+    }
+
+    let ingest_row: Option<(Option<i64>, i64, Option<String>)> = db
+        .query_row(
+            "SELECT last_event_ts, consecutive_failures, last_error_msg
+             FROM source_health WHERE source = 'claude-auto-memory'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .ok();
+    match ingest_row {
+        None => println!("[WW] {:<29}  no ingest health row", "auto-memory ingest"),
+        Some((last_event, consecutive, err)) => {
+            if consecutive > 3 {
+                println!(
+                    "[!!] {:<29}  {} consecutive failures",
+                    "auto-memory ingest", consecutive
+                );
+                if explain {
+                    if let Some(msg) = err {
+                        println!("     CAUSE: {msg}");
+                    }
+                    println!("     FIX: hippo-auto-memory-poll; inspect auto-memory.log");
+                }
+                fail_count += 1;
+            } else if let Some(ts) = last_event {
+                let age = format_duration_ms((now_ms - ts).max(0));
+                println!("[OK] {:<29}  last ingest {}", "auto-memory ingest", age);
+            } else {
+                println!("[--] {:<29}  no ingest events yet", "auto-memory ingest");
+            }
+        }
+    }
+
+    let (pending, failed): (i64, i64) = db
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM memory_enrichment_queue WHERE status = 'pending'),
+                (SELECT COUNT(*) FROM memory_enrichment_queue WHERE status = 'failed')",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap_or((0, 0));
+    if failed > 0 {
+        println!(
+            "[!!] {:<29}  pending={pending} failed={failed}",
+            "auto-memory enrichment"
+        );
+        if explain {
+            println!("     FIX: hippo-auto-memory-replay --limit 50");
+        }
+        fail_count += 1;
+    } else if pending > 0 {
+        println!("[WW] {:<29}  pending={pending}", "auto-memory enrichment");
+    } else {
+        println!("[OK] {:<29}  queue empty", "auto-memory enrichment");
+    }
+
+    let stale_projections: i64 = db
+        .query_row(
+            "SELECT COUNT(*) FROM memory_documents
+             WHERE state = 'active' AND projection_status = 'pending'
+               AND repository != 'hippo/__hippo_probe__'
+               AND updated_at < ?1",
+            rusqlite::params![now_ms - 30 * 60 * 1000],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+    if stale_projections > 0 {
+        println!(
+            "[WW] {:<29}  {stale_projections} stale pending projection(s)",
+            "auto-memory projection"
+        );
+    } else {
+        println!("[OK] {:<29}  projections fresh", "auto-memory projection");
+    }
+
+    fail_count
 }
 
 /// Check 8: Watchdog heartbeat — verify the watchdog row in source_health is fresh.

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -3069,8 +3069,14 @@ fn check_auto_memory_health(config: &HippoConfig, db: &rusqlite::Connection, exp
     let (pending, failed): (i64, i64) = db
         .query_row(
             "SELECT
-                (SELECT COUNT(*) FROM memory_enrichment_queue WHERE status = 'pending'),
-                (SELECT COUNT(*) FROM memory_enrichment_queue WHERE status = 'failed')",
+                (SELECT COUNT(*) FROM memory_enrichment_queue meq
+                 JOIN memory_revisions mr ON mr.id = meq.revision_id
+                 JOIN memory_documents md ON md.id = mr.document_id
+                 WHERE meq.status = 'pending' AND md.repository != 'hippo/__hippo_probe__'),
+                (SELECT COUNT(*) FROM memory_enrichment_queue meq
+                 JOIN memory_revisions mr ON mr.id = meq.revision_id
+                 JOIN memory_documents md ON md.id = mr.document_id
+                 WHERE meq.status = 'failed' AND md.repository != 'hippo/__hippo_probe__')",
             [],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )

--- a/crates/hippo-daemon/src/lib.rs
+++ b/crates/hippo-daemon/src/lib.rs
@@ -17,6 +17,7 @@ pub mod native_messaging;
 pub mod opencode_session;
 pub mod probe;
 mod probe_agentic;
+mod probe_auto_memory;
 #[cfg(feature = "otel")]
 pub mod process_metrics;
 pub mod schema_handshake;

--- a/crates/hippo-daemon/src/probe.rs
+++ b/crates/hippo-daemon/src/probe.rs
@@ -26,6 +26,7 @@ const VALID_PROBE_SOURCES: &[&str] = &[
     "agentic-session-opencode",
     "agentic-session-codex",
     "browser",
+    "claude-auto-memory",
 ];
 
 type SyncProbeFn = fn(&HippoConfig) -> Result<(bool, Option<i64>)>;
@@ -147,6 +148,16 @@ pub async fn run(config: &HippoConfig, source: Option<&str>) -> Result<()> {
                 write_probe_result(config, "browser", false, None)?;
             }
         }
+    }
+
+    if run_all || source == Some("claude-auto-memory") {
+        run_sync_probe(
+            config,
+            run_all,
+            source,
+            "claude-auto-memory",
+            crate::probe_auto_memory::probe_auto_memory,
+        )?;
     }
 
     if let Some(s) = source

--- a/crates/hippo-daemon/src/probe_auto_memory.rs
+++ b/crates/hippo-daemon/src/probe_auto_memory.rs
@@ -1,0 +1,66 @@
+//! Synthetic auto-memory probe — dedicated fixture outside Claude's datastore.
+
+use anyhow::{Context, Result};
+use hippo_core::config::{HippoConfig, default_brain_dir};
+use hippo_core::storage;
+use std::process::Command;
+use tracing::info;
+
+const PROBE_REPOSITORY: &str = "hippo/__hippo_probe__";
+const PROBE_LOGICAL_PATH: &str = "synthetic/probe-memory.md";
+
+/// Run the auto-memory probe via the Python brain package and poll SQLite.
+pub fn probe_auto_memory(config: &HippoConfig) -> Result<(bool, Option<i64>)> {
+    let probe_start_ms = chrono::Utc::now().timestamp_millis();
+    let brain_dir = default_brain_dir();
+    let db_path = config.db_path();
+    let data_dir = config.storage.data_dir.clone();
+
+    let output = Command::new("uv")
+        .args([
+            "run",
+            "--project",
+            &brain_dir.to_string_lossy(),
+            "hippo-auto-memory-probe",
+            "--db",
+            &db_path.to_string_lossy(),
+            "--data-dir",
+            &data_dir.to_string_lossy(),
+        ])
+        .output()
+        .context("failed to spawn hippo-auto-memory-probe")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("auto-memory probe failed: {stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).context("auto-memory probe returned invalid JSON")?;
+    let ok = parsed.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+    if !ok {
+        let err = parsed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        info!("auto-memory probe: FAIL — {err}");
+        return Ok((false, None));
+    }
+
+    let lag = parsed.get("lag_ms").and_then(|v| v.as_i64());
+    let db = storage::open_db(&db_path).context("cannot open DB for auto-memory probe verify")?;
+    let count: i64 = db.query_row(
+        "SELECT COUNT(*) FROM memory_documents WHERE repository = ?1 AND logical_path = ?2",
+        rusqlite::params![PROBE_REPOSITORY, PROBE_LOGICAL_PATH],
+        |row| row.get(0),
+    )?;
+    if count == 0 {
+        info!("auto-memory probe: document row missing after probe run");
+        return Ok((false, None));
+    }
+
+    let elapsed = chrono::Utc::now().timestamp_millis() - probe_start_ms;
+    let lag_ms = lag.or(Some(elapsed.max(0)));
+    Ok((true, lag_ms))
+}

--- a/crates/hippo-daemon/src/watchdog.rs
+++ b/crates/hippo-daemon/src/watchdog.rs
@@ -183,11 +183,13 @@ pub fn run(config: &HippoConfig) -> Result<()> {
     )? {
         violations.push(v);
     }
-    if let Some(v) = check_i19_stale_memory_projection(&conn, now_ms)? {
-        violations.push(v);
-    }
-    if let Some(v) = check_i20_orphaned_memory_chunk_links(&conn, now_ms)? {
-        violations.push(v);
+    if !bench_pause_window_active() {
+        if let Some(v) = check_i19_stale_memory_projection(&conn, now_ms)? {
+            violations.push(v);
+        }
+        if let Some(v) = check_i20_orphaned_memory_chunk_links(&conn, now_ms)? {
+            violations.push(v);
+        }
     }
 
     // ── Step 4: Insert capture_alarms rows for violations ─────────────────

--- a/crates/hippo-daemon/src/watchdog.rs
+++ b/crates/hippo-daemon/src/watchdog.rs
@@ -37,6 +37,9 @@ const PROBE_INTERVAL_MS: i64 = 300_000;
 const LIVENESS_GRACE_MS: i64 = 120_000;
 const SHELL_LIVENESS_STALE_MS: i64 = PROBE_INTERVAL_MS + LIVENESS_GRACE_MS;
 const BROWSER_ROUNDTRIP_STALE_MS: i64 = PROBE_INTERVAL_MS + LIVENESS_GRACE_MS;
+const AUTO_MEMORY_WATCHER_STALE_MS: i64 = 15 * 60 * 1000;
+const AUTO_MEMORY_PROJECTION_STALE_MS: i64 = 30 * 60 * 1000;
+const AUTO_MEMORY_PROBE_REPOSITORY: &str = "hippo/__hippo_probe__";
 
 // DDL used by the pre-migration safety path only.  The authoritative definition
 // lives in `schema.sql` and `storage.rs`; this is a fallback for the case where
@@ -178,6 +181,12 @@ pub fn run(config: &HippoConfig) -> Result<()> {
         now_ms,
         i64::try_from(config.watchdog.dup_node_alarm_threshold).unwrap_or(i64::MAX),
     )? {
+        violations.push(v);
+    }
+    if let Some(v) = check_i19_stale_memory_projection(&conn, now_ms)? {
+        violations.push(v);
+    }
+    if let Some(v) = check_i20_orphaned_memory_chunk_links(&conn, now_ms)? {
         violations.push(v);
     }
 
@@ -503,6 +512,16 @@ pub fn check_invariants(rows: &[SourceHealthRow], now_ms: i64) -> Vec<InvariantV
         violations.push(v);
     }
 
+    // I-17: Auto-memory watcher heartbeat stale while ingest is active.
+    if !bench_paused && let Some(v) = check_i17_auto_memory_watcher(&by_source, now_ms) {
+        violations.push(v);
+    }
+
+    // I-18: Auto-memory reconcile/ingest repeated failures.
+    if !bench_paused && let Some(v) = check_i18_auto_memory_ingest_proxy(&by_source, now_ms) {
+        violations.push(v);
+    }
+
     violations
 }
 
@@ -638,6 +657,133 @@ pub fn check_i12_brain_preflight_stuck(
         });
     }
     None
+}
+
+/// I-17: Auto-memory watcher heartbeat stale while ingest has been active.
+pub fn check_i17_auto_memory_watcher(
+    by_source: &std::collections::HashMap<&str, &SourceHealthRow>,
+    now_ms: i64,
+) -> Option<InvariantViolation> {
+    let ingest = by_source.get("claude-auto-memory")?;
+    let watcher = by_source.get("auto-memory-watcher")?;
+    let ingest_ts = ingest.last_event_ts?;
+    if now_ms - ingest_ts > AUTO_MEMORY_WATCHER_STALE_MS * 4 {
+        return None;
+    }
+    let heartbeat = watcher.last_heartbeat_ts.or(watcher.last_success_ts)?;
+    let age_ms = now_ms - heartbeat;
+    if age_ms > AUTO_MEMORY_WATCHER_STALE_MS {
+        Some(InvariantViolation {
+            invariant_id: "I-17".to_string(),
+            source: "auto-memory-watcher".to_string(),
+            since_ms: age_ms,
+            details: json!({
+                "last_heartbeat_ts": watcher.last_heartbeat_ts,
+                "ingest_last_event_ts": ingest.last_event_ts,
+                "note": "FSEvents watcher or periodic reconcile may be stalled",
+            }),
+        })
+    } else {
+        None
+    }
+}
+
+/// I-18: Auto-memory reconcile/ingest repeated failures.
+pub fn check_i18_auto_memory_ingest_proxy(
+    by_source: &std::collections::HashMap<&str, &SourceHealthRow>,
+    now_ms: i64,
+) -> Option<InvariantViolation> {
+    let row = by_source.get("claude-auto-memory")?;
+    if row.consecutive_failures <= 3 {
+        return None;
+    }
+    let since = row.last_error_ts.or(row.last_event_ts).unwrap_or(now_ms);
+    Some(InvariantViolation {
+        invariant_id: "I-18".to_string(),
+        source: "claude-auto-memory".to_string(),
+        since_ms: now_ms - since,
+        details: json!({
+            "consecutive_failures": row.consecutive_failures,
+            "last_error_msg": row.last_error_msg.clone(),
+        }),
+    })
+}
+
+/// I-19: Stale searchable projection after source mutation.
+pub fn check_i19_stale_memory_projection(
+    conn: &Connection,
+    now_ms: i64,
+) -> Result<Option<InvariantViolation>> {
+    let table_exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_documents')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !table_exists {
+        return Ok(None);
+    }
+    let cutoff = now_ms - AUTO_MEMORY_PROJECTION_STALE_MS;
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_documents
+         WHERE state = 'active'
+           AND projection_status = 'pending'
+           AND repository != ?1
+           AND updated_at < ?2",
+        rusqlite::params![AUTO_MEMORY_PROBE_REPOSITORY, cutoff],
+        |row| row.get(0),
+    )?;
+    if count == 0 {
+        return Ok(None);
+    }
+    Ok(Some(InvariantViolation {
+        invariant_id: "I-19".to_string(),
+        source: "claude-auto-memory".to_string(),
+        since_ms: AUTO_MEMORY_PROJECTION_STALE_MS,
+        details: json!({
+            "stale_projection_count": count,
+            "note": "active documents still pending enrichment projection",
+        }),
+    }))
+}
+
+/// I-20: Orphaned active memory chunk links (no knowledge node).
+pub fn check_i20_orphaned_memory_chunk_links(
+    conn: &Connection,
+    now_ms: i64,
+) -> Result<Option<InvariantViolation>> {
+    let table_exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                       WHERE type='table' AND name='knowledge_node_memory_chunks')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !table_exists {
+        return Ok(None);
+    }
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_chunks mc
+         LEFT JOIN knowledge_node_memory_chunks knmc ON knmc.memory_chunk_id = mc.id
+         JOIN memory_revisions mr ON mr.id = mc.revision_id
+         JOIN memory_documents md ON md.id = mr.document_id
+         WHERE md.active_revision_id = mr.id
+           AND md.state = 'active'
+           AND md.repository != ?1
+           AND knmc.knowledge_node_id IS NULL",
+        rusqlite::params![AUTO_MEMORY_PROBE_REPOSITORY],
+        |row| row.get(0),
+    )?;
+    if count == 0 {
+        return Ok(None);
+    }
+    Ok(Some(InvariantViolation {
+        invariant_id: "I-20".to_string(),
+        source: "claude-auto-memory".to_string(),
+        since_ms: 0,
+        details: json!({
+            "orphan_chunk_links": count,
+            "checked_at_ms": now_ms,
+        }),
+    }))
 }
 
 /// I-11: Opencode-session coverage proxy.

--- a/crates/hippo-daemon/tests/source_audit/doctor_freshness.rs
+++ b/crates/hippo-daemon/tests/source_audit/doctor_freshness.rs
@@ -37,6 +37,7 @@ fn probes_cover_every_source_from_the_audit_matrix() {
             "agentic-session-opencode",
             "agentic-session-codex",
             "agentic-session-cursor",
+            "claude-auto-memory",
         ],
         "probe list must stay in sync with docs/capture/sources.md"
     );

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -129,6 +129,28 @@ Tuning knobs in `[auto_memory]`:
 
 During enrichment failure or pending retries, the last-known-good projection stays queryable (`projection_status = stale`). Poll/reconcile JSON reports `pending_enrichment` and `failed_enrichment` per source.
 
+## Reliability and operations (SNUG-138)
+
+Source health is split across SQLite identities (no brain HTTP required for doctor):
+
+| Identity | Signal |
+|----------|--------|
+| `auto-memory-watcher` | FSEvents / periodic reconcile heartbeat (`last_heartbeat_ts`) |
+| `claude-auto-memory` | Ingest success, reconcile failures (`consecutive_failures`) |
+| `memory_enrichment_queue` | Pending vs failed enrichment depth (doctor SQL) |
+| Active projections | `projection_status` lag after mutation (watchdog I-19) |
+
+Synthetic probe (`hippo probe claude-auto-memory` or launchd `com.hippo.probe`) writes only under `$DATA_DIR/probe-auto-memory/` with repository `hippo/__hippo_probe__`. Probe rows are excluded from `query_memory`, `search_knowledge`, and RAG.
+
+Operator commands:
+
+- `hippo-auto-memory-poll` / `hippo-auto-memory-reconcile` — bounded reconcile with health summary JSON
+- `hippo-auto-memory-replay` — reset failed queue rows to pending (probe repository excluded)
+- `hippo doctor` — watcher, ingest, queue, and projection lines
+- `mise run acceptance:auto-memory` — offline acceptance against a temp database
+
+Watchdog invariants: I-17 (watcher stale), I-18 (repeated reconcile failure), I-19 (stale projection), I-20 (orphaned chunk links).
+
 ## Storage and rollback
 
 Schema v19 adds only additive tables: `memory_documents`, `memory_revisions`, `memory_chunks`, `memory_enrichment_queue`, and `knowledge_node_memory_chunks`. Existing source and knowledge tables are unchanged.

--- a/docs/capture/sources.md
+++ b/docs/capture/sources.md
@@ -20,6 +20,7 @@ For the rules every contributor must follow when adding a new source, see [`anti
 | 10 | **Probe events** | `com.hippo.probe` LaunchAgent → `crates/hippo-daemon/src/probe.rs` → per-source synthetic-event path | `events` / `browser_events` / `claude_sessions` with `probe_tag IS NOT NULL` | I-8 | (drives the others' probes) | healthy |
 | 11 | **Watchdog heartbeat** | `com.hippo.watchdog` → `crates/hippo-daemon/src/watchdog.rs` → `source_health WHERE source='watchdog'` UPDATE every cycle | `source_health` only | I-7 | n/a | healthy |
 | 12 | **Opencode sessions** | `com.hippo.opencode-poll` LaunchAgent (every `[opencode] poll_interval_secs`) → `hippo opencode-poll` → `opencode_session.rs::poll_tick` reads opencode's own SQLite → upserts `agentic_sessions` + enqueues `agentic_enrichment_queue` | `agentic_sessions` (harness='opencode'), `agentic_enrichment_queue`, `knowledge_node_agentic_sessions` | I-11 | Yes (assertion-only: opencode `session.time_updated` in window → matching `agentic_sessions` row) | new in v14 |
+| 13 | **Claude auto-memory** | `com.hippo.auto-memory-watcher` + `com.hippo.auto-memory` → `hippo-auto-memory-reconcile` / `hippo-auto-memory-poll` (Python) | `memory_documents`, `memory_revisions`, `memory_enrichment_queue`, `knowledge_node_memory_chunks` | I-17–I-20 | Yes (`hippo probe claude-auto-memory`; fixture `hippo/__hippo_probe__` excluded from retrieval) | healthy — SNUG-138 |
 
 ## Per-source notes
 

--- a/mise.toml
+++ b/mise.toml
@@ -392,6 +392,10 @@ run = "uv run --project brain hippo-brain serve"
 description = "Ingest one explicit Claude Code auto-memory Markdown file"
 run = "uv run --project brain hippo-auto-memory"
 
+[tasks."acceptance:auto-memory"]
+description = "Offline auto-memory reliability acceptance (SNUG-138)"
+run = "uv run --project brain pytest brain/tests/test_auto_memory_reliability.py brain/tests/test_auto_memory_lifecycle.py::test_full_lifecycle_add_update_history_rename_delete -q"
+
 [tasks."brain:api"]
 description = "Call the structured brain API CLI: mise run brain:api -- <operation> [args]"
 run = '''


### PR DESCRIPTION
## Summary
- Adds auto-memory source health (`auto-memory-watcher` + ingest dimensions), synthetic probe (`hippo/__hippo_probe__` fixture excluded from retrieval), and operator replay (`hippo-auto-memory-replay`).
- Watchdog invariants I-17–I-20 (watcher stale, reconcile failures, stale projections, orphan chunk links) plus doctor SQLite-only diagnostics.
- Schema v21 seeds watcher health row; `mise run acceptance:auto-memory` runs offline reliability + lifecycle acceptance.

## Test plan
- [x] `uv run --project brain pytest brain/tests/test_auto_memory_reliability.py -q`
- [x] `cargo build -p hippo-daemon -p hippo-core`
- [x] `cargo fmt` / clippy pre-commit hooks
- [ ] CI green
- [ ] `mise run acceptance:auto-memory`

Closes SNUG-138 / completes auto-memory epic SNUG-130.