### PR TITLE
SNUG-108: Add --force to hippo-bench corpus init

### DIFF
--- a/brain/src/hippo_brain/bench/cli.py
+++ b/brain/src/hippo_brain/bench/cli.py
@@ -45,7 +45,7 @@ _OVERLAY_CAP = 50
 
 def _cmd_corpus_init(args: argparse.Namespace) -> int:
     corpus_version = args.bump_version if args.bump_version else args.corpus_version
-    force = bool(args.bump_version)
+    force = bool(args.force or args.bump_version)
     dest_sqlite = corpus_sqlite_path(corpus_version)
     dest_jsonl = corpus_jsonl_path(corpus_version)
     manifest = corpus_manifest_path(corpus_version)
@@ -67,8 +67,17 @@ def _cmd_corpus_init(args: argparse.Namespace) -> int:
         )
     except FileExistsError as e:
         print(f"error: {e}")
-        print("Use --bump-version to overwrite.")
+        print(
+            "Existing corpus artifacts (if any):\n"
+            f"  sqlite:   {dest_sqlite}\n"
+            f"  jsonl:    {dest_jsonl}\n"
+            f"  manifest: {manifest}\n"
+            "Use --force to overwrite at the same version, or --bump-version VERSION "
+            "to create a new corpus version."
+        )
         return 1
+    if args.bump_version:
+        print(f"corpus version: {corpus_version}")
     print(f"wrote {len(entries)} entries")
     print(f"sqlite: {dest_sqlite}")
     print(f"jsonl:  {dest_jsonl}")
@@ -447,6 +456,11 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="VERSION",
         help="Override corpus version string and force-overwrite existing corpus.",
+    )
+    ci.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing corpus artifacts at the same version.",
     )
     ci.set_defaults(func=_cmd_corpus_init)
 

--- a/brain/src/hippo_brain/bench/corpus.py
+++ b/brain/src/hippo_brain/bench/corpus.py
@@ -925,6 +925,8 @@ def init_corpus(
         raise FileExistsError(f"dest_sqlite already exists: {dest_sqlite}")
     if dest_jsonl.exists() and not force:
         raise FileExistsError(f"dest_jsonl already exists: {dest_jsonl}")
+    if manifest_path.exists() and not force:
+        raise FileExistsError(f"manifest already exists: {manifest_path}")
 
     cleanup_paths = [dest_sqlite, dest_jsonl, manifest_path]
     sampled_at = _dt.datetime.now(tz=_dt.UTC).isoformat()

--- a/brain/tests/test_bench_cli.py
+++ b/brain/tests/test_bench_cli.py
@@ -40,6 +40,7 @@ def test_cli_corpus_help_lists_v2_args(capsys):
     assert "--corpus-buckets" in out
     assert "--shell-min" in out
     assert "--bump-version" in out
+    assert "--force" in out
 
 
 def test_cli_determinism_help_lists_mode_and_budgets(capsys):

--- a/brain/tests/test_bench_corpus.py
+++ b/brain/tests/test_bench_corpus.py
@@ -379,6 +379,7 @@ def test_overwrite_protection(seeded_db, tmp_path):
     init_corpus(**common_kwargs)
     with pytest.raises(FileExistsError):
         init_corpus(**common_kwargs)
+    init_corpus(**common_kwargs, force=True)
 
 
 # ── 9. Probe-tag exclusion ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `--force` flag to `hippo-bench corpus init` for same-version overwrite (sqlite, jsonl, manifest)
- Guard manifest path in `init_corpus` collision check
- Improve collision error to list all three artifact paths and mention `--force` / `--bump-version`
- Print corpus version when `--bump-version` is used

## Test plan
- [x] `pytest brain/tests/test_bench_corpus.py::test_overwrite_protection`
- [x] `pytest brain/tests/test_bench_cli.py::test_cli_corpus_help_lists_v2_args`

Closes SNUG-108