### PR TITLE
SNUG-122 follow-up: tighten trust contract coverage

### DIFF
--- a/brain/src/hippo_brain/_fixtures/source_trust_contracts.json
+++ b/brain/src/hippo_brain/_fixtures/source_trust_contracts.json
@@ -97,7 +97,9 @@
       "tables": ["memory_documents", "memory_revisions", "memory_chunks", "knowledge_node_memory_chunks"],
       "identity_fields": ["memory_documents.id", "linked_source_ids:memory-<chunk_id>"],
       "timestamp_fields": ["memory_revisions.created_at", "memory_documents.updated_at"],
-      "eligibility": "memory_documents.state = active AND active_revision_id match"
+      "eligibility": "memory_documents.state = active AND active_revision_id match",
+      "safe_citation_fields": ["repository", "source_path", "heading", "content"],
+      "citation_example": "Claude auto-memory chunk from ~/.claude/projects/.../memory/MEMORY.md (repo: hippo): heading 'Capture reliability'."
     },
     {
       "id": "source_health",

--- a/brain/tests/test_source_trust_contracts.py
+++ b/brain/tests/test_source_trust_contracts.py
@@ -27,6 +27,7 @@ _REQUIRED_FAMILIES = frozenset(
         "opencode",
         "browser",
         "workflow",
+        "claude-auto-memory",
         "source_health",
         "watchdog-probe",
     }
@@ -38,6 +39,7 @@ _REQUIRED_MD_HEADINGS = (
     "## Agentic sessions",
     "## Browser visits",
     "## GitHub CI",
+    "## Claude auto-memory",
     "## `source_health`",
     "## Watchdog and probe metadata",
 )
@@ -70,7 +72,7 @@ def test_contracts_json_entries_have_core_fields(contracts_data: dict) -> None:
     for family in contracts_data["families"]:
         assert "id" in family
         assert "tables" in family and family["tables"]
-        assert "identity_fields" in family or family["id"] in ("watchdog-probe",)
+        assert "identity_fields" in family
 
 
 def test_contracts_md_exists_and_has_sections(contracts_md: str) -> None:

--- a/docs/capture/source-trust-contracts.md
+++ b/docs/capture/source-trust-contracts.md
@@ -163,6 +163,10 @@ Retrieval applies eligibility from [`retrieval_eligibility.py`](../../brain/src/
 | **Safe to cite** | `repository`, `source_path`, chunk `heading`, `content` excerpt, active revision only (`state = 'active'`) |
 | **Do not cite** | Superseded revisions (`active_revision_id` mismatch) |
 
+**Safe citation example**
+
+> Claude auto-memory chunk from `~/.claude/projects/.../memory/MEMORY.md` (repo: hippo): heading "Capture reliability".
+
 ---
 
 ## `source_health` (capture freshness metadata)


### PR DESCRIPTION
## Summary
- Add `claude-auto-memory` to required contract families and MD heading assertions
- Add citation example for claude-auto-memory in JSON fixture and docs
- Remove dead `watchdog-probe` exception in core-fields test

Post-merge nits from SNUG-122 thermo review.

## Test plan
- [x] `pytest brain/tests/test_source_trust_contracts.py`