### PR TITLE
SNUG-96: observability docs + Grafana capture alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Hippo captures shell commands (including stdout/stderr), Claude Code session tra
 
 **MCP access is broad.** Adding hippo to Claude Code's MCP config grants the model read access to your shell history, Claude transcripts, and browser history — including via prompt injection through code or documents you ask Claude to read.
 
-**Telemetry is off by default.** The OTel stack (`otel/`) is optional, points at `localhost:4317`, and only emits when `[telemetry] enabled = true`. See [`otel/README.md`](otel/README.md).
+**Telemetry is off by default.** The OTel stack (`otel/`) is optional, points at `localhost:4317`, and only emits when `[telemetry] enabled = true`. See [`otel/README.md`](otel/README.md) for setup and [`docs/observability.md`](docs/observability.md) for dashboards and alert rules.
 
 **Network exposure.** The brain HTTP server binds `127.0.0.1:9175`. The daemon's Unix socket lives at `~/.local/share/hippo/daemon.sock`.
 

--- a/brain/tests/test_otel_dashboards.py
+++ b/brain/tests/test_otel_dashboards.py
@@ -1,10 +1,10 @@
-"""Drift-prevention tests for Grafana dashboard JSON files.
+"""Drift-prevention tests for Grafana dashboard JSON and alert rule YAML.
 
 These tests guard against the class of bugs where dashboard PromQL expressions
-reference metric names that do not exist in the OTel instrumentation — either
-because an instrument was renamed, removed, or never created. A failure here
-tells the developer exactly which dashboard and metric drifted, and which file
-to look at for the authoritative name.
+or provisioned alert queries reference metric names that do not exist in the
+OTel instrumentation — either because an instrument was renamed, removed, or
+never created. A failure here tells the developer exactly which dashboard
+or alert rule drifted, and which file to look at for the authoritative name.
 
 The guarantee is enforced in two layers that chain together:
   * Test 1 / Test 4 check that every metric a dashboard references is in the
@@ -23,11 +23,14 @@ import json
 import re
 from pathlib import Path
 
+import yaml
+
 # ---------------------------------------------------------------------------
 # Repo root, resolved relative to this file so the tests work from any cwd.
 # ---------------------------------------------------------------------------
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DASHBOARDS_DIR = _REPO_ROOT / "otel" / "grafana" / "dashboards"
+_ALERTING_DIR = _REPO_ROOT / "otel" / "grafana" / "alerting"
 
 # ---------------------------------------------------------------------------
 # Canonical EMITTED metric names for production dashboards.
@@ -137,6 +140,19 @@ _PROD_DASHBOARD_NAMES = frozenset(
         "hippo-daemon.json",
         "hippo-enrichment.json",
         "hippo-processes.json",
+    ]
+)
+
+# Provisioned capture-reliability alert rules (SNUG-96).
+_PROD_ALERT_FILES = frozenset(["hippo-capture-alerts.yml"])
+
+_REQUIRED_ALERT_UIDS = frozenset(
+    [
+        "hippo_daemon_events_dropped",
+        "hippo_watcher_events_dropped",
+        "hippo_watchdog_stall",
+        "hippo_probe_failure_rate",
+        "hippo_invariant_violation",
     ]
 )
 
@@ -835,3 +851,64 @@ def test_rust_parser_skips_builders_without_build():
 
     incomplete = '.u64_counter("hippo.test.incomplete")  // never reaches build'
     assert _rust_emitter_names(incomplete) == set()
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Provisioned Grafana alert rules must reference only allowed metrics
+# and include the SNUG-96 capture-reliability alert set.
+# ---------------------------------------------------------------------------
+
+
+def _load_prod_alert_rules() -> list[tuple[str, dict]]:
+    results = []
+    for name in sorted(_PROD_ALERT_FILES):
+        path = _ALERTING_DIR / name
+        assert path.exists(), (
+            f"Expected alert provisioning file not found: {path}. "
+            "If it was intentionally removed, update _PROD_ALERT_FILES."
+        )
+        results.append((name, yaml.safe_load(path.read_text())))
+    return results
+
+
+def _collect_alert_exprs(alert_doc: dict) -> list[tuple[str, str]]:
+    """Return (rule_uid, promql_expr) for every Prometheus query in alert data."""
+    results: list[tuple[str, str]] = []
+    for group in alert_doc.get("groups", []):
+        for rule in group.get("rules", []):
+            uid = rule.get("uid", "?")
+            for query in rule.get("data", []):
+                model = query.get("model", {})
+                if model.get("datasource", {}).get("type") == "prometheus":
+                    expr = model.get("expr", "")
+                    if expr:
+                        results.append((uid, expr))
+    return results
+
+
+def test_alert_rules_reference_allowed_metrics():
+    """Every hippo_* metric in provisioned alert PromQL must be in EMITTED_METRICS."""
+    violations: list[str] = []
+    for filename, doc in _load_prod_alert_rules():
+        for uid, expr in _collect_alert_exprs(doc):
+            for raw in _extract_metric_names(expr):
+                normalized = _normalize_metric_name(raw)
+                if normalized not in EMITTED_METRICS:
+                    violations.append(
+                        f"{filename} rule {uid}: {raw!r} (normalized {normalized!r}) "
+                        f"not in EMITTED_METRICS"
+                    )
+    assert not violations, "Alert rule metric drift:\n" + "\n".join(violations)
+
+
+def test_required_capture_alert_rules_exist():
+    """SNUG-96 acceptance: daemon drops, watcher drops, watchdog stall, probe fail, invariant."""
+    found: set[str] = set()
+    for _filename, doc in _load_prod_alert_rules():
+        for group in doc.get("groups", []):
+            for rule in group.get("rules", []):
+                uid = rule.get("uid")
+                if uid:
+                    found.add(uid)
+    missing = _REQUIRED_ALERT_UIDS - found
+    assert not missing, f"Missing required alert rule uids: {sorted(missing)}"

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,107 @@
+# Observability
+
+How to run Hippo's optional OpenTelemetry stack, which dashboards to open, and which provisioned alerts fire when capture paths degrade. Companion to [`otel/README.md`](../otel/README.md) (stack setup and commands) and [`capture/operator-runbook.md`](capture/operator-runbook.md) (first-aid when alarms fire).
+
+Telemetry is **off by default**. Nothing is emitted until you build with OTel support, enable `[telemetry]` in config, and start the Docker stack.
+
+## Quick start
+
+```bash
+mise run otel:up          # Grafana + Prometheus + collector on localhost
+mise run build:otel       # daemon with OTel feature
+hippo config edit         # [telemetry] enabled = true
+export HIPPO_OTEL_ENABLED=1   # brain + MCP
+mise run restart
+open http://localhost:3030
+```
+
+Default Grafana login: `admin` / `hippo` (anonymous Admin is also enabled for local use).
+
+## Architecture
+
+```
+hippo-daemon ──┐
+               ├── OTLP ──→ OTel Collector ──→ Tempo (traces)
+hippo-brain  ──┤                            ──→ Loki (logs)
+hippo-mcp   ──┘                            ──→ Prometheus (metrics)
+                                               Grafana (dashboards + alerts)
+```
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| Grafana | **3030** | Dashboards, Explore, provisioned alert rules |
+| Prometheus | 9090 | Metrics storage (30d / 10GB default retention) |
+| OTel Collector | 4317 (gRPC), 4318 (HTTP) | OTLP ingest |
+| Tempo | 3200 | Trace storage |
+| Loki | 3100 | Log aggregation |
+
+Persistent data: `~/.local/share/hippo/otel/`. Stack restarts do not wipe state.
+
+## Dashboards
+
+All dashboards provision automatically from `otel/grafana/dashboards/` into the **Hippo** folder. No manual import.
+
+| Dashboard | UID | URL | What it shows |
+|-----------|-----|-----|---------------|
+| **Hippo Overview** | `hippo-overview` | http://localhost:3030/d/hippo-overview | Health grade, capture lag, probe success/lag, invariant violations, alarm firings, daemon drops |
+| **Hippo Daemon** | `hippo-daemon` | http://localhost:3030/d/hippo-daemon | Event ingest/drop rates, flush latency, redactions, fallback writes, watcher throughput |
+| **Hippo Enrichment** | `hippo-enrichment` | http://localhost:3030/d/hippo-enrichment | Brain queue depth, LLM latency, enrichment throughput, MCP tool metrics |
+| **Hippo Processes** | `hippo-processes` | http://localhost:3030/d/hippo-processes | `process.*` CPU/memory for daemon and brain |
+
+Metric names in PromQL use Prometheus exporter suffixes (`_total`, `_milliseconds`, etc.). The canonical allow-list and drift tests live in `brain/tests/test_otel_dashboards.py`.
+
+## Provisioned alert rules
+
+Alert rules provision from `otel/grafana/alerting/hippo-capture-alerts.yml` on stack start. They appear under **Alerting → Alert rules** in the **Hippo** folder.
+
+| Alert | Fires when | `for` | Severity |
+|-------|------------|-------|----------|
+| Daemon events dropped | `rate(hippo_daemon_events_dropped_total[5m]) > 0` | 5m | warning |
+| FS watcher events dropped | `rate(hippo_watcher_events_dropped_total[5m]) > 0` | 5m | warning |
+| Watchdog not running | `rate(hippo_watchdog_run_total[5m]) < 0.001` | 5m | critical |
+| Probe failure rate high | `ok=false` probe runs > 10% over 15m | 15m | warning |
+| Capture invariant violation | `rate(hippo_watchdog_invariant_violation_total[15m]) > 0` | 15m | critical |
+
+All rules use `noDataState: OK` so a stack with telemetry disabled does not page. When OTel is enabled but a rule has no series, treat that as "instrument not emitting" rather than healthy silence.
+
+**Notification routing:** this repo provisions rules only. Wire contact points and notification policies in Grafana UI (or add provisioning YAML) when you want Slack/PagerDuty delivery.
+
+## Enabling telemetry
+
+### Daemon (Rust)
+
+```toml
+# ~/.config/hippo/config.toml
+[telemetry]
+enabled = true
+endpoint = "http://localhost:4317"
+```
+
+Build: `mise run build:otel` or `cargo build --features otel`.
+
+### Brain / MCP (Python)
+
+```bash
+export HIPPO_OTEL_ENABLED=1
+# optional: export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+## Commands
+
+```bash
+mise run otel:up       # start stack
+mise run otel:down     # stop stack
+mise run otel:status   # container health
+mise run otel:logs     # tail compose logs
+mise run otel:backup   # snapshot persisted data
+```
+
+See [`otel/README.md`](../otel/README.md) for retention overrides, reset workflow, and process-metric details.
+
+## When alerts fire
+
+1. `hippo doctor --explain` — isolated checks with CAUSE/FIX per failure
+2. `hippo alarms list` — unacknowledged capture alarms from SQLite ground truth
+3. [`capture/operator-runbook.md`](capture/operator-runbook.md) — version mismatch, enrichment wedge, probe failures
+
+SQLite `source_health` remains the correctness source during OTel outages; dashboards and alerts are time-series views on the same invariants.

--- a/otel/README.md
+++ b/otel/README.md
@@ -25,6 +25,8 @@ mise run restart
 open http://localhost:3030
 ```
 
+Dashboard inventory, provisioned alert rules, and on-call pointers: [`docs/observability.md`](../docs/observability.md).
+
 Hippo persists OTEL data on the host under `~/.local/share/hippo/otel/`, so restarting or recreating
 the Docker Compose stack does not wipe Grafana, Prometheus, Loki, or Tempo state.
 

--- a/otel/docker-compose.yml
+++ b/otel/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     volumes:
       - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/alerting:/etc/grafana/provisioning/alerting:ro
       - ${HOME}/.local/share/hippo/otel/grafana:/var/lib/grafana
     ports:
       - "3030:3000"

--- a/otel/grafana/alerting/hippo-capture-alerts.yml
+++ b/otel/grafana/alerting/hippo-capture-alerts.yml
@@ -1,0 +1,303 @@
+# Provisioned Grafana alert rules for Hippo capture reliability.
+# Loaded from /etc/grafana/provisioning/alerting on stack start.
+# Metric names use Prometheus exporter suffixes (see brain/tests/test_otel_dashboards.py).
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: hippo_capture_1m
+    folder: Hippo
+    interval: 1m
+    rules:
+      - uid: hippo_daemon_events_dropped
+        title: Daemon events dropped
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: sum(rate(hippo_daemon_events_dropped_total[5m]))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: Daemon is dropping shell/browser events before SQLite insert
+          description: >-
+            hippo_daemon_events_dropped_total rate is positive for 5+ minutes.
+            Check daemon logs and fallback JSONL under ~/.local/share/hippo/.
+          runbook_url: https://github.com/stevencarpenter/hippo/blob/main/docs/capture/operator-runbook.md
+        labels:
+          severity: warning
+          component: daemon
+        isPaused: false
+
+      - uid: hippo_watcher_events_dropped
+        title: FS watcher events dropped
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: sum(rate(hippo_watcher_events_dropped_total[5m]))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: Claude session watcher channel is saturated
+          description: >-
+            hippo_watcher_events_dropped_total rate is positive for 5+ minutes.
+            FSEvents notifications are being dropped; session ingest may lag.
+        labels:
+          severity: warning
+          component: watcher
+        isPaused: false
+
+      - uid: hippo_watchdog_stall
+        title: Watchdog not running
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: sum(rate(hippo_watchdog_run_total[5m]))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.001
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: Watchdog evaluation loop has stalled
+          description: >-
+            hippo_watchdog_run_total rate is near zero for 5+ minutes while OTel
+            metrics are flowing. Expected ~1 run/min via com.hippo.watchdog.
+        labels:
+          severity: critical
+          component: watchdog
+        isPaused: false
+
+      - uid: hippo_probe_failure_rate
+        title: Probe failure rate high
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: >-
+                sum(rate(hippo_probe_run_total{ok="false"}[15m]))
+                /
+                clamp_min(sum(rate(hippo_probe_run_total[15m])), 1e-9)
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.1
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 15m
+        annotations:
+          summary: Synthetic probe failure rate exceeds 10%
+          description: >-
+            More than 10% of hippo_probe_run_total executions report ok=false
+            over a 15-minute window. Run `hippo probe` and `hippo doctor --explain`.
+        labels:
+          severity: warning
+          component: probe
+        isPaused: false
+
+      - uid: hippo_invariant_violation
+        title: Capture invariant violation
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: sum(rate(hippo_watchdog_invariant_violation_total[15m]))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 15m
+        annotations:
+          summary: Watchdog detected a capture invariant violation
+          description: >-
+            hippo_watchdog_invariant_violation_total rate is positive. Check
+            `hippo alarms list` and docs/capture/architecture.md invariants I-1..I-15.
+        labels:
+          severity: critical
+          component: watchdog
+        isPaused: false


### PR DESCRIPTION
## Summary
- Add `docs/observability.md` — stack URLs, dashboard inventory, alert table, enablement, on-call pointers
- Provision five capture-reliability Grafana alert rules (daemon drops, watcher drops, watchdog stall, probe failure rate, invariant violations)
- Mount `otel/grafana/alerting/` in docker-compose; link from README and `otel/README.md`
- Extend `test_otel_dashboards.py` with alert metric drift + required-rule UID tests

Closes SNUG-96 acceptance gaps (dashboards already existed on main).

## Test plan
- [x] `pytest brain/tests/test_otel_dashboards.py` (12 passed)