### PR TITLE
SNUG-100 slice 3: permanent Firefox extension install path

### DIFF
--- a/crates/hippo-daemon/src/browser_health.rs
+++ b/crates/hippo-daemon/src/browser_health.rs
@@ -1,5 +1,10 @@
 //! Browser capture health semantics shared by `hippo doctor` and the watchdog.
 
+use std::path::{Path, PathBuf};
+
+/// Gecko extension ID from `extension/firefox/manifest.json`.
+pub const FIREFOX_EXTENSION_ID: &str = "hippo-browser@local";
+
 /// Extension heartbeats every 5 minutes (`extension/firefox/src/heartbeat.ts`).
 /// Tolerate one missed tick plus launchd/SQLite jitter (same grace as I-4).
 pub const BROWSER_HEARTBEAT_STALE_MS: i64 = 300_000 + 120_000;
@@ -76,6 +81,108 @@ pub fn browser_capture_state_label(
     }
 }
 
+#[derive(Default)]
+struct FirefoxProfileEntry {
+    name: Option<String>,
+    path: Option<String>,
+    is_relative: bool,
+}
+
+fn parse_firefox_profiles_ini(content: &str) -> Vec<FirefoxProfileEntry> {
+    let mut profiles = Vec::new();
+    let mut current: Option<FirefoxProfileEntry> = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(section) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            if let Some(entry) = current.take().filter(|e| e.path.is_some()) {
+                profiles.push(entry);
+            }
+            current = section
+                .starts_with("Profile")
+                .then_some(FirefoxProfileEntry {
+                    is_relative: true,
+                    ..FirefoxProfileEntry::default()
+                });
+            continue;
+        }
+        let Some(entry) = current.as_mut() else {
+            continue;
+        };
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        match key.trim() {
+            "Name" => entry.name = Some(value.trim().to_string()),
+            "Path" => entry.path = Some(value.trim().to_string()),
+            "IsRelative" => entry.is_relative = value.trim() != "0",
+            _ => {}
+        }
+    }
+    if let Some(entry) = current.filter(|e| e.path.is_some()) {
+        profiles.push(entry);
+    }
+    profiles
+}
+
+fn resolve_firefox_profile_path(firefox_root: &Path, entry: &FirefoxProfileEntry) -> PathBuf {
+    let path = entry.path.as_deref().unwrap_or_default();
+    if entry.is_relative {
+        firefox_root.join(path)
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+/// Resolve the Firefox Developer Edition profile directory (mirrors `mise run install:ext`).
+pub fn firefox_dev_edition_profile_dir(home: &Path) -> Option<PathBuf> {
+    let firefox_root = home.join("Library/Application Support/Firefox");
+    let profiles_ini = firefox_root.join("profiles.ini");
+    let content = std::fs::read_to_string(&profiles_ini).ok()?;
+    let profiles = parse_firefox_profiles_ini(&content);
+
+    for entry in &profiles {
+        if entry.name.as_deref() == Some("dev-edition-default") {
+            let resolved = resolve_firefox_profile_path(&firefox_root, entry);
+            if resolved.is_dir() {
+                return Some(resolved);
+            }
+        }
+    }
+    for entry in &profiles {
+        if entry
+            .path
+            .as_deref()
+            .is_some_and(|path| path.contains("dev-edition"))
+        {
+            let resolved = resolve_firefox_profile_path(&firefox_root, entry);
+            if resolved.is_dir() {
+                return Some(resolved);
+            }
+        }
+    }
+    None
+}
+
+pub fn firefox_extension_xpi_path(profile_dir: &Path) -> PathBuf {
+    profile_dir.join(format!("extensions/{FIREFOX_EXTENSION_ID}.xpi"))
+}
+
+pub fn firefox_extension_xpi_installed(profile_dir: &Path) -> bool {
+    firefox_extension_xpi_path(profile_dir).is_file()
+}
+
+/// True when `prefs.js` allows unsigned extension side-loads (required for local .xpi).
+pub fn firefox_unsigned_install_allowed(prefs_js: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(prefs_js) else {
+        return false;
+    };
+    content.lines().any(|line| {
+        let line = line.trim();
+        line.starts_with("user_pref(\"xpinstall.signatures.required\"") && line.contains("false")
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,5 +223,76 @@ mod tests {
             browser_extension_connectivity(true, Some(600), 24 * 60),
             BrowserExtensionConnectivity::Disconnected
         );
+    }
+
+    #[test]
+    fn profiles_ini_prefers_dev_edition_default_name() {
+        let ini = r#"
+[Install4F96D1932A9F858E]
+Default=Profiles/abc123.default-release
+Locked=1
+
+[Profile0]
+Name=default-release
+IsRelative=1
+Path=Profiles/abc123.default-release
+
+[Profile1]
+Name=dev-edition-default
+IsRelative=1
+Path=Profiles/xyz789.dev-edition-default
+"#;
+        let profiles = parse_firefox_profiles_ini(ini);
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[1].name.as_deref(), Some("dev-edition-default"));
+    }
+
+    #[test]
+    fn unsigned_install_pref_detects_false_value() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefs = tmp.path().join("prefs.js");
+        std::fs::write(
+            &prefs,
+            r#"user_pref("xpinstall.signatures.required", false);"#,
+        )
+        .unwrap();
+        assert!(firefox_unsigned_install_allowed(&prefs));
+        std::fs::write(
+            &prefs,
+            r#"user_pref("xpinstall.signatures.required", true);"#,
+        )
+        .unwrap();
+        assert!(!firefox_unsigned_install_allowed(&prefs));
+    }
+
+    #[test]
+    fn extension_xpi_path_uses_gecko_id() {
+        let profile = Path::new("/tmp/profile");
+        assert_eq!(
+            firefox_extension_xpi_path(profile),
+            PathBuf::from("/tmp/profile/extensions/hippo-browser@local.xpi")
+        );
+    }
+
+    #[test]
+    fn dev_edition_profile_dir_resolves_from_profiles_ini() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let firefox_root = home.join("Library/Application Support/Firefox");
+        let profile_rel = "Profiles/xyz.dev-edition-default";
+        std::fs::create_dir_all(firefox_root.join(profile_rel)).unwrap();
+        std::fs::write(
+            firefox_root.join("profiles.ini"),
+            format!(
+                r#"[Profile0]
+Name=dev-edition-default
+IsRelative=1
+Path={profile_rel}
+"#
+            ),
+        )
+        .unwrap();
+        let resolved = firefox_dev_edition_profile_dir(home).unwrap();
+        assert_eq!(resolved, firefox_root.join(profile_rel));
     }
 }

--- a/crates/hippo-daemon/src/browser_health.rs
+++ b/crates/hippo-daemon/src/browser_health.rs
@@ -134,7 +134,11 @@ fn resolve_firefox_profile_path(firefox_root: &Path, entry: &FirefoxProfileEntry
     }
 }
 
-/// Resolve the Firefox Developer Edition profile directory (mirrors `mise run install:ext`).
+/// Resolve the Firefox Developer Edition profile directory.
+///
+/// Strategy mirrors `mise.toml` `[tasks."install:ext"]` (Python configparser
+/// block): prefer `Name=dev-edition-default`, then any profile whose `Path`
+/// contains `dev-edition`.
 pub fn firefox_dev_edition_profile_dir(home: &Path) -> Option<PathBuf> {
     let firefox_root = home.join("Library/Application Support/Firefox");
     let profiles_ini = firefox_root.join("profiles.ini");
@@ -143,10 +147,7 @@ pub fn firefox_dev_edition_profile_dir(home: &Path) -> Option<PathBuf> {
 
     for entry in &profiles {
         if entry.name.as_deref() == Some("dev-edition-default") {
-            let resolved = resolve_firefox_profile_path(&firefox_root, entry);
-            if resolved.is_dir() {
-                return Some(resolved);
-            }
+            return Some(resolve_firefox_profile_path(&firefox_root, entry));
         }
     }
     for entry in &profiles {
@@ -155,10 +156,7 @@ pub fn firefox_dev_edition_profile_dir(home: &Path) -> Option<PathBuf> {
             .as_deref()
             .is_some_and(|path| path.contains("dev-edition"))
         {
-            let resolved = resolve_firefox_profile_path(&firefox_root, entry);
-            if resolved.is_dir() {
-                return Some(resolved);
-            }
+            return Some(resolve_firefox_profile_path(&firefox_root, entry));
         }
     }
     None
@@ -173,13 +171,19 @@ pub fn firefox_extension_xpi_installed(profile_dir: &Path) -> bool {
 }
 
 /// True when `prefs.js` allows unsigned extension side-loads (required for local .xpi).
+///
+/// Matches the grep in `mise.toml` `[tasks."install:ext"]`:
+/// `^user_pref\("xpinstall\.signatures\.required",[[:space:]]*false\)`
 pub fn firefox_unsigned_install_allowed(prefs_js: &Path) -> bool {
     let Ok(content) = std::fs::read_to_string(prefs_js) else {
         return false;
     };
     content.lines().any(|line| {
         let line = line.trim();
-        line.starts_with("user_pref(\"xpinstall.signatures.required\"") && line.contains("false")
+        let Some(rest) = line.strip_prefix("user_pref(\"xpinstall.signatures.required\",") else {
+            return false;
+        };
+        rest.trim().starts_with("false)")
     })
 }
 
@@ -263,6 +267,12 @@ Path=Profiles/xyz789.dev-edition-default
         )
         .unwrap();
         assert!(!firefox_unsigned_install_allowed(&prefs));
+        std::fs::write(
+            &prefs,
+            r#"// user_pref("xpinstall.signatures.required", false);"#,
+        )
+        .unwrap();
+        assert!(!firefox_unsigned_install_allowed(&prefs));
     }
 
     #[test]
@@ -294,5 +304,28 @@ Path={profile_rel}
         .unwrap();
         let resolved = firefox_dev_edition_profile_dir(home).unwrap();
         assert_eq!(resolved, firefox_root.join(profile_rel));
+    }
+
+    #[test]
+    fn dev_edition_profile_dir_returns_configured_path_when_dir_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let firefox_root = home.join("Library/Application Support/Firefox");
+        let profile_rel = "Profiles/missing.dev-edition-default";
+        std::fs::create_dir_all(&firefox_root).unwrap();
+        std::fs::write(
+            firefox_root.join("profiles.ini"),
+            format!(
+                r#"[Profile0]
+Name=dev-edition-default
+IsRelative=1
+Path={profile_rel}
+"#
+            ),
+        )
+        .unwrap();
+        let resolved = firefox_dev_edition_profile_dir(home).unwrap();
+        assert_eq!(resolved, firefox_root.join(profile_rel));
+        assert!(!resolved.is_dir());
     }
 }

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -4006,35 +4006,14 @@ fn expected_claude_session_hook_path(data_dir: &std::path::Path) -> Option<PathB
         .map(|brain_dir| brain_dir.join("shell/claude-session-hook.sh"))
 }
 
-/// Check that the Firefox extension's compiled dist/ bundle exists, the
-/// Native Messaging manifest is installed, and the extension is side-loaded
-/// into the Firefox Developer Edition profile (survives restarts).
+/// Check that the Firefox extension's compiled dist/ bundle exists and the
+/// extension is side-loaded into the Firefox Developer Edition profile
+/// (survives restarts).
 ///
-/// The extension's `manifest.json` references `dist/background.js` and
-/// `dist/content.js`, but `dist/` is gitignored — it must be produced by
-/// `mise run build:ext:dist`. If dist/ is missing the extension loads cleanly
-/// as a temporary add-on in Firefox but captures nothing (silent no-op).
+/// Native Messaging manifest is checked separately by `check_nm_manifest`.
+/// Profile resolution mirrors `mise.toml` `[tasks."install:ext"]` (lines ~113–146).
 fn check_firefox_extension() -> u32 {
-    let mut fail_count = 0_u32;
-
-    // Native Messaging manifest — the bridge between Firefox and hippo-daemon.
-    let nm_manifest = dirs::home_dir().map(|h| {
-        h.join("Library/Application Support/Mozilla/NativeMessagingHosts/hippo_daemon.json")
-    });
-    match nm_manifest {
-        Some(path) if path.exists() => println!("[OK] Firefox Native Messaging manifest installed"),
-        Some(path) => {
-            println!(
-                "[!!] Firefox Native Messaging manifest missing: {}",
-                path.display()
-            );
-            println!("     Fix: hippo daemon install --force");
-            fail_count += 1;
-        }
-        None => println!("[--] Firefox Native Messaging check skipped (no home dir)"),
-    }
-
-    fail_count += check_firefox_extension_permanent_install();
+    let mut fail_count = check_firefox_extension_permanent_install();
 
     // Extension dist/ files. We locate the repo via the canonical path of the
     // currently running binary — typically `<repo>/target/release/hippo`, with
@@ -4052,11 +4031,18 @@ fn check_firefox_extension() -> u32 {
 /// Firefox Developer Edition profile.
 fn check_firefox_extension_permanent_install() -> u32 {
     let Some(home) = dirs::home_dir() else {
-        println!("[--] Firefox extension install  skipped (no home dir)");
+        println!("[--] Firefox extension install   skipped (no home dir)");
         return 0;
     };
     let Some(profile) = browser_health::firefox_dev_edition_profile_dir(&home) else {
-        println!("[--] Firefox extension install  no Dev Edition profile");
+        println!("[--] Firefox extension install   no Dev Edition profile");
+        return 0;
+    };
+    if !profile.is_dir() {
+        println!(
+            "[--] Firefox extension install   Dev Edition profile dir missing ({})",
+            profile.display()
+        );
         return 0;
     };
     let xpi = browser_health::firefox_extension_xpi_path(&profile);
@@ -4388,7 +4374,7 @@ mod tests {
             .collect();
         assert_eq!(missing, vec!["dist/background.js", "dist/content.js"]);
 
-        check_firefox_extension_dist_at(&ext);
+        assert_eq!(check_firefox_extension_dist_at(&ext), 1);
     }
 
     #[test]
@@ -4406,7 +4392,7 @@ mod tests {
             .collect();
         assert!(missing.is_empty());
 
-        check_firefox_extension_dist_at(&ext);
+        assert_eq!(check_firefox_extension_dist_at(&ext), 0);
     }
 
     #[test]

--- a/crates/hippo-daemon/src/commands.rs
+++ b/crates/hippo-daemon/src/commands.rs
@@ -1216,8 +1216,8 @@ pub async fn handle_doctor(config: &HippoConfig, explain: bool) -> Result<()> {
     // Check Claude session hook
     check_claude_session_hook(config);
 
-    // Check Firefox extension build + Native Messaging manifest
-    check_firefox_extension();
+    // Check Firefox extension build + Native Messaging manifest + permanent install
+    fail_count += check_firefox_extension();
 
     // Per-source capture-freshness audit (one line per raw data source
     // hippo is supposed to collect). Uses day-level thresholds — complements
@@ -1776,8 +1776,11 @@ fn print_browser_staleness_explain(
                 "     CAUSE:  Firefox is running but the extension has never heartbeated the daemon"
             );
             println!(
-                "     FIX:    Load the extension (about:debugging → Load Temporary Add-on → extension/firefox/manifest.json); \
+                "     FIX:    Install the extension permanently (`mise run install:ext`; survives restarts); \
                  verify NM manifest via `hippo daemon install --force`"
+            );
+            println!(
+                "     DEV:    about:debugging → Load Temporary Add-on is for active extension development only"
             );
         }
         BrowserExtensionConnectivity::Disconnected => {
@@ -1785,8 +1788,10 @@ fn print_browser_staleness_explain(
                 "     CAUSE:  Extension heartbeat is stale — native messaging or the daemon socket may be wedged"
             );
             println!(
-                "     FIX:    Restart Firefox; run `hippo probe --source browser`; tail -f ~/.local/share/hippo/daemon.stderr.log"
+                "     FIX:    Restart Firefox; run `hippo probe --source browser`; \
+                 if the extension was loaded via about:debugging, run `mise run install:ext` for a permanent install"
             );
+            println!("     LOGS:   tail -f ~/.local/share/hippo/daemon.stderr.log");
         }
         BrowserExtensionConnectivity::Connected => {
             if probe_ok == Some(0) {
@@ -4001,14 +4006,17 @@ fn expected_claude_session_hook_path(data_dir: &std::path::Path) -> Option<PathB
         .map(|brain_dir| brain_dir.join("shell/claude-session-hook.sh"))
 }
 
-/// Check that the Firefox extension's compiled dist/ bundle exists and the
-/// Native Messaging manifest is installed.
+/// Check that the Firefox extension's compiled dist/ bundle exists, the
+/// Native Messaging manifest is installed, and the extension is side-loaded
+/// into the Firefox Developer Edition profile (survives restarts).
 ///
 /// The extension's `manifest.json` references `dist/background.js` and
 /// `dist/content.js`, but `dist/` is gitignored — it must be produced by
 /// `mise run build:ext:dist`. If dist/ is missing the extension loads cleanly
 /// as a temporary add-on in Firefox but captures nothing (silent no-op).
-fn check_firefox_extension() {
+fn check_firefox_extension() -> u32 {
+    let mut fail_count = 0_u32;
+
     // Native Messaging manifest — the bridge between Firefox and hippo-daemon.
     let nm_manifest = dirs::home_dir().map(|h| {
         h.join("Library/Application Support/Mozilla/NativeMessagingHosts/hippo_daemon.json")
@@ -4021,9 +4029,12 @@ fn check_firefox_extension() {
                 path.display()
             );
             println!("     Fix: hippo daemon install --force");
+            fail_count += 1;
         }
         None => println!("[--] Firefox Native Messaging check skipped (no home dir)"),
     }
+
+    fail_count += check_firefox_extension_permanent_install();
 
     // Extension dist/ files. We locate the repo via the canonical path of the
     // currently running binary — typically `<repo>/target/release/hippo`, with
@@ -4031,19 +4042,55 @@ fn check_firefox_extension() {
     // layout, skip rather than false-alarm.
     let Some(repo_root) = repo_root_from_current_exe() else {
         println!("[--] Firefox extension dist/ check skipped (could not locate repo root)");
-        return;
+        return fail_count;
     };
-    check_firefox_extension_dist_at(&repo_root.join("extension/firefox"));
+    fail_count += check_firefox_extension_dist_at(&repo_root.join("extension/firefox"));
+    fail_count
 }
 
-fn check_firefox_extension_dist_at(ext_dir: &std::path::Path) {
+/// Verify `mise run install:ext` has side-loaded the unsigned .xpi into the
+/// Firefox Developer Edition profile.
+fn check_firefox_extension_permanent_install() -> u32 {
+    let Some(home) = dirs::home_dir() else {
+        println!("[--] Firefox extension install  skipped (no home dir)");
+        return 0;
+    };
+    let Some(profile) = browser_health::firefox_dev_edition_profile_dir(&home) else {
+        println!("[--] Firefox extension install  no Dev Edition profile");
+        return 0;
+    };
+    let xpi = browser_health::firefox_extension_xpi_path(&profile);
+    if browser_health::firefox_extension_xpi_installed(&profile) {
+        let prefs = profile.join("prefs.js");
+        if prefs.is_file() && !browser_health::firefox_unsigned_install_allowed(&prefs) {
+            println!(
+                "[WW] Firefox extension installed but xpinstall.signatures.required is not false"
+            );
+            println!("     Firefox may delete the unsigned .xpi on restart.");
+            println!("     Fix: about:config → xpinstall.signatures.required = false");
+        } else {
+            println!(
+                "[OK] Firefox extension installed permanently ({})",
+                xpi.display()
+            );
+        }
+        0
+    } else {
+        println!("[!!] Firefox extension not permanently installed");
+        println!("     Temporary about:debugging loads do not survive Firefox restarts.");
+        println!("     Fix: mise run install:ext");
+        1
+    }
+}
+
+fn check_firefox_extension_dist_at(ext_dir: &std::path::Path) -> u32 {
     if !ext_dir.exists() {
         // Not fatal: release installs won't have the repo extension dir.
         println!(
             "[--] Firefox extension dir not found at {}",
             ext_dir.display()
         );
-        return;
+        return 0;
     }
     let required = ["dist/background.js", "dist/content.js"];
     let missing: Vec<&str> = required
@@ -4056,6 +4103,7 @@ fn check_firefox_extension_dist_at(ext_dir: &std::path::Path) {
             "[OK] Firefox extension dist/ built ({})",
             ext_dir.join("dist").display()
         );
+        0
     } else {
         println!(
             "[!!] Firefox extension dist/ missing: {}",
@@ -4063,6 +4111,7 @@ fn check_firefox_extension_dist_at(ext_dir: &std::path::Path) {
         );
         println!("     The extension loads but captures nothing when dist/ is absent.");
         println!("     Fix: mise run build:ext:dist");
+        1
     }
 }
 
@@ -4364,7 +4413,10 @@ mod tests {
     fn test_check_firefox_extension_dist_at_handles_missing_ext_dir() {
         // Nonexistent path must not panic — release installs won't have it.
         let tmp = tempdir().unwrap();
-        check_firefox_extension_dist_at(&tmp.path().join("does-not-exist"));
+        assert_eq!(
+            check_firefox_extension_dist_at(&tmp.path().join("does-not-exist")),
+            0
+        );
     }
 
     #[tokio::test]

--- a/docs/capture/operator-runbook.md
+++ b/docs/capture/operator-runbook.md
@@ -109,6 +109,35 @@ Pick the first `[!!]` failure. The CAUSE/FIX/DOC block will tell you which file 
 - `[!!] watchdog heartbeat: 4m ago (FAIL)` → I-7 violation. Watchdog crashed or its launchd job is missing. Check `launchctl list | grep hippo`. If `com.hippo.watchdog` is missing, run `hippo daemon install --force`.
 - `[!!] fallback files: 5 files > 24h (recovery broken)` → I-9 violation. Daemon is up but old fallback files under `~/.local/share/hippo/fallback/` aren't being drained. Check the daemon's launchd logs (`~/.local/share/hippo/daemon.stderr.log` and the rolling `daemon.YYYY-MM-DD.log` files written by the tracing appender) for write errors.
 
+### "Browser capture is idle or doctor shows browser [!!]"
+
+Firefox Developer Edition is the supported browser. Capture requires both the extension and the native-messaging host.
+
+```bash
+# Snapshot + remediation (browser lines show extension connectivity + last_error)
+hippo doctor --explain
+
+# One-shot synthetic round-trip
+hippo probe --source browser
+```
+
+**Permanent extension install (survives restarts):**
+
+1. One-time in Firefox Dev Edition: `about:config` → `xpinstall.signatures.required` = `false`
+2. From the hippo repo: `mise run install:ext` (also runs as part of `mise run install`)
+3. Restart Firefox if it was running during install
+4. Verify: `hippo doctor` should show `[OK] Firefox extension installed permanently`
+
+`about:debugging → Load Temporary Add-on` is for active extension development only — those loads are cleared when Firefox restarts and will fail I-4 / doctor browser checks after a restart until you run `mise run install:ext` again.
+
+**Native messaging host:**
+
+```bash
+hippo daemon install --force   # writes ~/Library/Application Support/Mozilla/NativeMessagingHosts/hippo_daemon.json
+```
+
+See [`extension/firefox/README.md`](../../extension/firefox/README.md) and the Browser section in [`sources.md`](sources.md).
+
 ### "Brain queue is backing up"
 
 Capture and enrichment are decoupled (I-10). A backed-up brain queue is an enrichment problem, not a capture problem; events are still landing.

--- a/docs/capture/sources.md
+++ b/docs/capture/sources.md
@@ -48,7 +48,9 @@ The watcher's resume state lives in `claude_session_offsets` per file. Content-h
 
 The Firefox extension is a TypeScript build (`extension/firefox/`); the daemon-side adapter is `native_messaging.rs`. The extension only captures from allow-listed domains (`[browser.allowlist]` in `config.toml`). Page content is extracted via Mozilla Readability on page departure — full readable article text plus URL, title, dwell time, and scroll depth. URL query parameters listed in `[browser.url_redaction]` are stripped before storage.
 
-The native messaging manifest at `~/Library/Application Support/Mozilla/NativeMessagingHosts/hippo-native-messaging.json` is installed by `hippo daemon install --force`.
+**Permanent install (survives Firefox restarts):** `mise run install:ext` builds the extension, packages it as an unsigned `.xpi`, and side-loads it into the Firefox Developer Edition profile at `~/Library/Application Support/Firefox/Profiles/*.dev-edition-default/extensions/hippo-browser@local.xpi`. Requires `xpinstall.signatures.required = false` in `about:config` (Dev Edition only). `mise run install` invokes this automatically. `hippo doctor` verifies the `.xpi` is present when a Dev Edition profile exists. Use `about:debugging → Load Temporary Add-on` only for active extension development — those loads are cleared on restart.
+
+The native messaging manifest at `~/Library/Application Support/Mozilla/NativeMessagingHosts/hippo_daemon.json` is installed by `hippo daemon install --force`.
 
 ### Workflow runs (GitHub Actions)
 


### PR DESCRIPTION
## Summary
- Add `hippo doctor` check for permanently side-loaded `.xpi` in Firefox Dev Edition profile (mirrors `mise run install:ext`)
- Count missing permanent install and NM manifest as doctor failures
- Update browser `--explain` FIX strings to prefer `mise run install:ext` over `about:debugging`
- Document permanent install path in `docs/capture/sources.md` and `operator-runbook.md`

## Test plan
- [x] `cargo test -p hippo-daemon browser_health::`
- [x] `cargo test -p hippo-daemon commands::tests::test_check_firefox`
- [x] `cargo clippy -p hippo-daemon --all-targets -- -D warnings`

## Linear
SNUG-100 slice 3 — epic remains open (7-day acceptance criterion not met).