### PR TITLE
[codex] bump version to 0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,12 +710,12 @@ dependencies = [
  "hostname",
  "libc",
  "notify",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry_sdk",
  "proptest",
- "reqwest",
+ "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1375,20 +1375,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -1403,11 +1389,11 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -1415,62 +1401,47 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.31.0",
- "reqwest",
+ "opentelemetry",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
  "tonic-prost",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand",
- "thiserror",
 ]
 
 [[package]]
@@ -1482,7 +1453,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "percent-encoding",
  "portable-atomic",
  "rand",
@@ -1650,6 +1621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,9 +1752,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1796,6 +1774,37 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
  "tower",
  "tower-http",
  "tower-service",
@@ -2429,6 +2438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,12 +2555,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ toml = "1.1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
-opentelemetry = "0.31"
+opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
-opentelemetry-appender-tracing = "0.31"
-tracing-opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
+opentelemetry-appender-tracing = "0.32"
+tracing-opentelemetry = "0.33"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 sha2 = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.30.0"
+version = "0.30.1"
 edition = "2024"
 license = "MIT"
 

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.30.0"
+version = "0.30.1"
 requires-python = ">=3.14"
 dependencies = [
   "httpx>=0.28",

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.30.0"
+version = "0.30.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/docs/superpowers/plans/2026-07-06-otel-0.32-stack-upgrade.md
+++ b/docs/superpowers/plans/2026-07-06-otel-0.32-stack-upgrade.md
@@ -1,0 +1,90 @@
+# OpenTelemetry 0.32 Stack Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore Hippo's Rust build by upgrading every directly declared OpenTelemetry integration crate to the compatible 0.32 API family.
+
+**Architecture:** Treat the OpenTelemetry API, SDK, OTLP exporter, tracing appender, and tracing bridge as one compatibility unit. Change only workspace dependency versions and the lockfile unless the aligned build identifies a concrete 0.32 API migration in `telemetry.rs`.
+
+**Tech Stack:** Rust 2024, Cargo workspace dependencies, OpenTelemetry Rust 0.32, mise
+
+---
+
+### Task 1: Align the OpenTelemetry dependency family
+
+**Files:**
+- Modify: `Cargo.toml:24-28`
+- Modify: `Cargo.lock`
+
+- [x] **Step 1: Verify the existing regression is red**
+
+Run: `cargo test -p hippo-daemon --lib`
+
+Expected: FAIL in `crates/hippo-daemon/src/telemetry.rs` with trait errors that report both `opentelemetry_sdk` 0.31 and 0.32 in the dependency graph.
+
+- [x] **Step 2: Align the workspace dependency declarations**
+
+Replace the OpenTelemetry workspace dependency block with:
+
+```toml
+opentelemetry = "0.32"
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
+opentelemetry-appender-tracing = "0.32"
+tracing-opentelemetry = "0.33"
+```
+
+- [x] **Step 3: Resolve the coordinated lockfile update**
+
+Run: `cargo check -p hippo-daemon --lib`
+
+Expected: Cargo updates only dependencies required by the new manifest constraints;
+`Cargo.lock` resolves the direct OpenTelemetry family to `opentelemetry` 0.32.0,
+`opentelemetry_sdk` 0.32.1, `opentelemetry-otlp` 0.32.0,
+`opentelemetry-appender-tracing` 0.32.0, and `tracing-opentelemetry` 0.33.0.
+
+- [x] **Step 4: Verify the targeted Rust tests are green**
+
+Run: `cargo test -p hippo-daemon --lib`
+
+Expected: PASS. If compilation reports a specific 0.32 API change in `crates/hippo-daemon/src/telemetry.rs`, make only the compiler-directed compatibility edit and rerun this command.
+
+### Task 2: Prove dependency and repository health
+
+**Files:**
+- Verify: `Cargo.toml`
+- Verify: `Cargo.lock`
+- Verify: `crates/hippo-daemon/src/telemetry.rs`
+
+- [x] **Step 1: Prove the duplicate 0.31 family is gone**
+
+Run: `cargo tree -p hippo-daemon --duplicates | rg 'opentelemetry(_sdk)? v0\.31'`
+
+Expected: no output and exit status 1 from `rg`, meaning no 0.31 OpenTelemetry API or SDK remains in the daemon graph.
+
+- [x] **Step 2: Run the canonical repository test gate**
+
+Run: `mise run test`
+
+Expected: exit status 0 with Rust, Python, lint, and formatting checks passing.
+
+- [x] **Step 3: Run the source-built diagnostic command**
+
+Run: `mise run doctor`
+
+Expected: the current source compiles and `hippo doctor` executes. Runtime source-health warnings are reported separately from build failure.
+
+- [x] **Step 4: Inspect the final scope**
+
+Run: `git status --short && git diff --check && git diff --stat HEAD`
+
+Expected: only the plan, `Cargo.toml`, `Cargo.lock`, and any strictly required `telemetry.rs` compatibility edit are changed; `git diff --check` emits no errors.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add docs/superpowers/plans/2026-07-06-otel-0.32-stack-upgrade.md Cargo.toml Cargo.lock crates/hippo-daemon/src/telemetry.rs
+git commit -m "fix: coordinate OpenTelemetry 0.32 stack upgrade"
+```
+
+If `telemetry.rs` is unchanged, omit it from `git add`.

--- a/docs/superpowers/specs/2026-07-06-otel-0.32-stack-upgrade-design.md
+++ b/docs/superpowers/specs/2026-07-06-otel-0.32-stack-upgrade-design.md
@@ -1,0 +1,41 @@
+# OpenTelemetry 0.32 Stack Upgrade
+
+## Problem
+
+PR #228 upgraded only `opentelemetry_sdk` from 0.31 to 0.32.1. The remaining
+OpenTelemetry crates stayed on the 0.31 family, so Cargo resolves both API
+families and `hippo-daemon` fails to compile because their exporter and provider
+traits are distinct Rust types.
+
+## Design
+
+Upgrade the complete direct OpenTelemetry dependency family as one compatibility
+unit:
+
+- `opentelemetry` 0.32
+- `opentelemetry_sdk` 0.32.1
+- `opentelemetry-otlp` 0.32
+- `opentelemetry-appender-tracing` 0.32
+- `tracing-opentelemetry` 0.33
+
+`tracing-opentelemetry` 0.33 is the release that depends on
+`opentelemetry` 0.32. Preserve the existing features and telemetry behavior.
+Adapt `telemetry.rs` only where the 0.32 APIs require source changes; do not
+change telemetry configuration, signal coverage, endpoints, or runtime policy.
+
+## Verification
+
+The existing build failure is the regression test. Verification must prove:
+
+1. `cargo tree -p hippo-daemon --duplicates` contains no mixed 0.31/0.32
+   OpenTelemetry family.
+2. `mise run test` completes successfully.
+3. `mise run doctor` builds the current source and executes successfully.
+
+## Scope
+
+In scope: workspace dependency declarations, `Cargo.lock`, required 0.32 API
+adaptations, and directly related tests.
+
+Out of scope: telemetry redesign, new metrics, exporter changes, dependency
+upgrades outside the OpenTelemetry compatibility family, and PR #213.


### PR DESCRIPTION
Bump Hippo to 0.30.1 across the Rust workspace and `hippo-brain` packaging manifests.

This is the patch release follow-up to the coordinated OpenTelemetry 0.32 stack upgrade.

Checks:
- `mise run test`