### PR TITLE
ci: run macOS matrix on main merges only, not every PR

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -25,7 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macOS on merges to main only, not every PR (macOS bills ~10x Linux).
+        # Coverage preserved at merge; revert to `[ubuntu-latest, macos-latest]`
+        # to require macOS pre-merge.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,7 +25,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macOS runs on merges to main (event=push) but not on every PR — macOS
+        # runners bill at ~10x Linux, and PR CI fires on every agent-loop push.
+        # Cross-platform coverage is preserved at merge; release.yml still builds
+        # macOS on tags. Revert to `[ubuntu-latest, macos-latest]` to require
+        # macOS pre-merge.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macOS runs on merges to main (event=push) but not on every PR — macOS
+        # runners bill at ~10x Linux, and PR CI fires on every agent-loop push.
+        # Cross-platform coverage is preserved at merge; release.yml still builds
+        # macOS on tags. Set to include macOS on PRs too if you want it required
+        # pre-merge (revert to `[ubuntu-latest, macos-latest]`).
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macOS on merges to main only, not every PR (macOS bills ~10x Linux).
+        # Coverage preserved at merge; revert to `[ubuntu-latest, macos-latest]`
+        # to require macOS pre-merge.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What
Makes the OS matrix in `rust.yml`, `python.yml`, `extension.yml`, `security.yml` conditional:
- **PRs** → `ubuntu-latest` only (fast, cheap feedback on every agent-loop push)
- **push to main** → `ubuntu-latest` + `macos-latest` (full cross-platform on merge)

## Why
macOS runners bill at **~10× Linux**, and these four workflows fire on every PR push. With agent loops opening/updating many PRs, the macOS legs are the single largest GitHub-hosted Actions cost in this repo. `release.yml` already builds macOS on tags, so release artifacts are unaffected.

## Tradeoff (your call)
macOS is **no longer a required pre-merge check** — a PR could pass ubuntu CI and break macOS, caught on the main-merge run rather than pre-merge. For a solo repo with agent-loop volume that's usually a fine trade, but if you want macOS required before merge, revert the file(s) to `os: [ubuntu-latest, macos-latest]` (noted inline). Could also split the difference (e.g. keep macOS on `rust.yml` PRs only) if one crate is the real cross-platform risk.