### PR TITLE
feat(site): add dark colour scheme with a header toggle

### DIFF
--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -61,7 +61,10 @@ const fullTitle = title === "Hippo" ? title : `${title} · Hippo`;
 {/* Colour scheme. Must be `is:inline` and sit in <head> so the attribute is on
     <html> before first paint — a bundled/deferred script would flash the wrong
     palette. Precedence: the reader's stored choice, then the OS setting, then
-    dark when the OS expresses no preference.
+    dark when neither is available (see the note on `system()` — that last tier
+    is narrower than it sounds). With JS off, CSS alone cannot run the ladder,
+    so no-JS visitors get dark regardless of their OS; that trade-off is
+    documented in tokens.css.
 
     The click handler is delegated from `document` rather than bound to the
     button: ClientRouter swaps the body, and a delegated listener survives that
@@ -82,8 +85,13 @@ const fullTitle = title === "Hippo" ? title : `${title} · Hippo`;
       }
     };
 
-    // Tiers 2 and 3 — browsers report `light` only when the OS actually asks
-    // for it, so an OS with no preference (or no matchMedia) lands on dark.
+    /* Tier 2, and tier 3 only in the narrow case below.
+     *
+     * Media Queries L5 removed `no-preference`, and `light` is now defined to
+     * include "has not expressed an active preference" — so there is no third
+     * OS state to detect. Testing for `light` positively means the dark
+     * fallback also catches a missing/throwing matchMedia, which is the only
+     * way tier 3 is actually reachable. */
     const system = () => {
       try {
         return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
@@ -98,11 +106,11 @@ const fullTitle = title === "Hippo" ? title : `${title} · Hippo`;
       document.documentElement.setAttribute("data-theme", theme);
       document.querySelector('meta[name="theme-color"]')?.setAttribute("content", BG[theme]);
 
-      const next = theme === "dark" ? "light" : "dark";
+      // State only. The button's accessible name is a static noun in its
+      // markup — overwriting it with an action phrase here would make screen
+      // readers announce the opposite of the current state.
       for (const btn of document.querySelectorAll("[data-theme-toggle]")) {
         btn.setAttribute("aria-pressed", String(theme === "dark"));
-        btn.setAttribute("aria-label", `Switch to ${next} theme`);
-        btn.setAttribute("title", `Switch to ${next} theme`);
       }
     };
 

--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -56,6 +56,86 @@ const fullTitle = title === "Hippo" ? title : `${title} · Hippo`;
 <link rel="preload" href="/fonts/fraunces-variable.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="preload" href="/fonts/jetbrains-mono-variable.woff2" as="font" type="font/woff2" crossorigin />
 
-<meta name="theme-color" content="#efe4ce" />
+<meta name="theme-color" content="#1f1812" />
+
+{/* Colour scheme. Must be `is:inline` and sit in <head> so the attribute is on
+    <html> before first paint — a bundled/deferred script would flash the wrong
+    palette. Precedence: the reader's stored choice, then the OS setting, then
+    dark when the OS expresses no preference.
+
+    The click handler is delegated from `document` rather than bound to the
+    button: ClientRouter swaps the body, and a delegated listener survives that
+    without rebinding or double-binding. `astro:after-swap` re-applies the
+    attribute because Astro resets <html> attributes from the incoming page. */}
+<script is:inline>
+  (() => {
+    const KEY = "hippo-theme";
+    const BG = { dark: "#1f1812", light: "#efe4ce" };
+
+    // Tier 1 — an explicit toggle choice. null means "never chosen".
+    const stored = () => {
+      try {
+        const value = localStorage.getItem(KEY);
+        return value === "light" || value === "dark" ? value : null;
+      } catch {
+        return null; // Private mode / storage blocked — fall through to the OS.
+      }
+    };
+
+    // Tiers 2 and 3 — browsers report `light` only when the OS actually asks
+    // for it, so an OS with no preference (or no matchMedia) lands on dark.
+    const system = () => {
+      try {
+        return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+      } catch {
+        return "dark";
+      }
+    };
+
+    const resolve = () => stored() ?? system();
+
+    const apply = (theme) => {
+      document.documentElement.setAttribute("data-theme", theme);
+      document.querySelector('meta[name="theme-color"]')?.setAttribute("content", BG[theme]);
+
+      const next = theme === "dark" ? "light" : "dark";
+      for (const btn of document.querySelectorAll("[data-theme-toggle]")) {
+        btn.setAttribute("aria-pressed", String(theme === "dark"));
+        btn.setAttribute("aria-label", `Switch to ${next} theme`);
+        btn.setAttribute("title", `Switch to ${next} theme`);
+      }
+    };
+
+    apply(resolve());
+
+    // The toggle button is not parsed yet on the pre-paint pass above, so sync
+    // its labels once the body exists.
+    document.addEventListener("DOMContentLoaded", () => apply(resolve()));
+    document.addEventListener("astro:after-swap", () => apply(resolve()));
+
+    // Follow the OS live — macOS flips itself at sunset — but only while the
+    // reader has not overridden it with the toggle.
+    try {
+      window.matchMedia("(prefers-color-scheme: light)").addEventListener("change", () => {
+        if (!stored()) apply(system());
+      });
+    } catch {
+      // No matchMedia support; the value resolved above still stands.
+    }
+
+    document.addEventListener("click", (event) => {
+      const btn = event.target.closest?.("[data-theme-toggle]");
+      if (!btn) return;
+
+      const next = document.documentElement.getAttribute("data-theme") === "light" ? "dark" : "light";
+      try {
+        localStorage.setItem(KEY, next);
+      } catch {
+        // Preference won't persist, but the toggle still works for this page.
+      }
+      apply(next);
+    });
+  })();
+</script>
 
 <ClientRouter />

--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -116,8 +116,8 @@ const fullTitle = title === "Hippo" ? title : `${title} · Hippo`;
 
     apply(resolve());
 
-    // The toggle button is not parsed yet on the pre-paint pass above, so sync
-    // its labels once the body exists.
+    // The toggle button is not parsed yet on the pre-paint pass above, so its
+    // aria-pressed is set here instead, once the body exists.
     document.addEventListener("DOMContentLoaded", () => apply(resolve()));
     document.addEventListener("astro:after-swap", () => apply(resolve()));
 

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import Wordmark from "./Wordmark.astro";
+import ThemeToggle from "./ThemeToggle.astro";
 
 const path = Astro.url.pathname.replace(/\/$/, "") || "/";
 const items = [
@@ -32,6 +33,9 @@ function isActive(href: string): boolean {
         ))}
         <li>
           <a href="https://github.com/stevencarpenter/hippo" rel="noopener" target="_blank">GitHub <span aria-hidden="true">↗</span></a>
+        </li>
+        <li class="nav-toggle">
+          <ThemeToggle />
         </li>
       </ul>
     </nav>
@@ -71,6 +75,9 @@ function isActive(href: string): boolean {
   }
   nav a:hover { color: var(--oxblood); border-bottom-color: var(--oxblood); }
   nav a.active { color: var(--oxblood); border-bottom-color: var(--oxblood); }
+
+  /* Nudge the toggle off the text baseline the links sit on. */
+  .nav-toggle { display: flex; align-items: center; margin-inline-start: -0.4rem; }
 
   @media (max-width: 720px) {
     .header-inner { flex-direction: column; align-items: flex-start; gap: 0.6rem; }

--- a/site/src/components/ThemeToggle.astro
+++ b/site/src/components/ThemeToggle.astro
@@ -1,0 +1,83 @@
+---
+/*
+ * Lights-low toggle (D8). Dark is the default scheme; this switches to the
+ * paper palette and persists the choice in localStorage.
+ *
+ * No client script lives here on purpose — the handler is a delegated listener
+ * in Head.astro's `is:inline` block so it runs before first paint (no flash)
+ * and survives ClientRouter swaps without rebinding. This component only needs
+ * to render the `data-theme-toggle` hook.
+ *
+ * SSR defaults describe the dark default; the head script re-syncs them if the
+ * reader has a stored preference.
+ */
+---
+<button
+  type="button"
+  class="theme-toggle"
+  data-theme-toggle
+  aria-pressed="true"
+  aria-label="Switch to light theme"
+  title="Switch to light theme"
+>
+  {/* Sun — shown while dark is active (i.e. "switch to light"). */}
+  <svg class="glyph glyph-sun" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <circle cx="12" cy="12" r="4.6" />
+    <g class="rays">
+      <path d="M12 1.6v3.2M12 19.2v3.2M1.6 12h3.2M19.2 12h3.2" />
+      <path d="M4.7 4.7l2.3 2.3M17 17l2.3 2.3M19.3 4.7L17 7M7 17l-2.3 2.3" />
+    </g>
+  </svg>
+  {/* Crescent — shown while light is active (i.e. "switch to dark"). */}
+  <svg class="glyph glyph-moon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M20.2 14.6A8.6 8.6 0 1 1 9.4 3.8a6.9 6.9 0 0 0 10.8 10.8z" />
+  </svg>
+  <span class="sr-only">Toggle colour scheme</span>
+</button>
+
+<style>
+  .theme-toggle {
+    /* Sits on the nav baseline with the uppercase links. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.9rem;
+    height: 1.9rem;
+    margin-block-end: -0.45rem;
+    padding: 0;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    color: var(--ink);
+    cursor: pointer;
+  }
+  .theme-toggle:hover { color: var(--oxblood); border-color: var(--rule-soft); }
+  .theme-toggle:focus-visible {
+    outline: 2px solid var(--oxblood);
+    outline-offset: 2px;
+  }
+
+  /* Engraved-line treatment: strokes only, matching the plate motifs. */
+  .glyph {
+    width: 1.05rem;
+    height: 1.05rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.4;
+    stroke-linecap: round;
+  }
+
+  /* Visibility follows the html attribute, so the correct glyph is already
+     painted server-side — no JS needed to keep the icon in sync. */
+  .glyph-moon { display: none; }
+  :global(html[data-theme="light"]) .glyph-sun { display: none; }
+  :global(html[data-theme="light"]) .glyph-moon { display: inline; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .theme-toggle { transition: color 120ms ease-out; }
+  }
+
+  @media (max-width: 720px) {
+    .theme-toggle { margin-block-end: 0; }
+  }
+</style>

--- a/site/src/components/ThemeToggle.astro
+++ b/site/src/components/ThemeToggle.astro
@@ -16,8 +16,10 @@
  * deliberately no `title` — it would land in `description` and be announced a
  * second time.
  *
- * The SSR value describes the dark default; the head script corrects
- * aria-pressed before paint if the reader resolves to light.
+ * The SSR value describes the dark default. The head script corrects
+ * aria-pressed at DOMContentLoaded, not pre-paint — its first pass runs while
+ * only <head> exists, so it cannot see this button yet. Only the glyph is
+ * pre-paint-correct, because that is pure CSS keyed off <html>.
  */
 ---
 <button

--- a/site/src/components/ThemeToggle.astro
+++ b/site/src/components/ThemeToggle.astro
@@ -8,8 +8,16 @@
  * and survives ClientRouter swaps without rebinding. This component only needs
  * to render the `data-theme-toggle` hook.
  *
- * SSR defaults describe the dark default; the head script re-syncs them if the
- * reader has a stored preference.
+ * ARIA: `aria-pressed` carries the state, so the accessible name must be a
+ * stable noun — it reads "Dark theme, toggle button, pressed". Pairing
+ * aria-pressed with an action-phrased name ("Switch to light theme") announces
+ * the opposite of the truth, so don't reintroduce one. The name comes from the
+ * .sr-only span rather than an aria-label so it stays in the DOM, and there is
+ * deliberately no `title` — it would land in `description` and be announced a
+ * second time.
+ *
+ * The SSR value describes the dark default; the head script corrects
+ * aria-pressed before paint if the reader resolves to light.
  */
 ---
 <button
@@ -17,8 +25,6 @@
   class="theme-toggle"
   data-theme-toggle
   aria-pressed="true"
-  aria-label="Switch to light theme"
-  title="Switch to light theme"
 >
   {/* Sun — shown while dark is active (i.e. "switch to light"). */}
   <svg class="glyph glyph-sun" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -32,7 +38,8 @@
   <svg class="glyph glyph-moon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
     <path d="M20.2 14.6A8.6 8.6 0 1 1 9.4 3.8a6.9 6.9 0 0 0 10.8 10.8z" />
   </svg>
-  <span class="sr-only">Toggle colour scheme</span>
+  {/* The button's accessible name. Must stay a noun — see the ARIA note above. */}
+  <span class="sr-only">Dark theme</span>
 </button>
 
 <style>
@@ -67,8 +74,10 @@
     stroke-linecap: round;
   }
 
-  /* Visibility follows the html attribute, so the correct glyph is already
-     painted server-side — no JS needed to keep the icon in sync. */
+  /* Visibility follows the html attribute. The SSR markup carries no
+     `data-theme` at all — the head script stamps it before the body is parsed,
+     so the right glyph is correct at first paint without a JS-driven class
+     swap here. Not "server-side"; pre-paint. */
   .glyph-moon { display: none; }
   :global(html[data-theme="light"]) .glyph-sun { display: none; }
   :global(html[data-theme="light"]) .glyph-moon { display: inline; }

--- a/site/src/styles/code.css
+++ b/site/src/styles/code.css
@@ -82,8 +82,8 @@ pre[data-wrap="true"] code {
   --astro-code-background: var(--code-bg);
   --astro-code-token-comment: var(--quiet-on-code);
   --astro-code-token-keyword: var(--oxblood);
-  --astro-code-token-string: #5a3a1f;
-  --astro-code-token-string-expression: #5a3a1f;
+  --astro-code-token-string: var(--code-string);
+  --astro-code-token-string-expression: var(--code-string);
   --astro-code-token-number: var(--sepia);
   --astro-code-token-punctuation: var(--sepia);
   --astro-code-token-function: var(--ink);

--- a/site/src/styles/prose.css
+++ b/site/src/styles/prose.css
@@ -160,7 +160,7 @@
   border-bottom: 1px solid var(--rule-soft);
   vertical-align: top;
 }
-.prose tbody tr:nth-child(even) { background: rgba(42, 29, 16, 0.03); }
+.prose tbody tr:nth-child(even) { background: var(--zebra); }
 
 /* Inline code — light background, no border. nowrap keeps short identifiers
    like `hippo doctor` from breaking mid-token in body prose. break-word lets

--- a/site/src/styles/tier-1.css
+++ b/site/src/styles/tier-1.css
@@ -236,9 +236,9 @@ body.tier-1 {
   border: 1px solid var(--ink);
   background: var(--paper-2);
 }
-.status-badge.active { background: #c8d8b8; color: #2a3d20; border-color: #4a6535; }
-.status-badge.quiet { background: #ead9b1; color: #5e4a1d; border-color: #8a6a30; }
-.status-badge.hibernating { background: #d5c9b3; color: #463829; border-color: #6a5847; }
+.status-badge.active { background: var(--badge-active-bg); color: var(--badge-active-fg); border-color: var(--badge-active-rule); }
+.status-badge.quiet { background: var(--badge-quiet-bg); color: var(--badge-quiet-fg); border-color: var(--badge-quiet-rule); }
+.status-badge.hibernating { background: var(--badge-hibernate-bg); color: var(--badge-hibernate-fg); border-color: var(--badge-hibernate-rule); }
 
 /* Definition list — used on /status. */
 .tier-1 dl {

--- a/site/src/styles/tier-1.css
+++ b/site/src/styles/tier-1.css
@@ -6,8 +6,8 @@
 body.tier-1 {
   background-color: var(--paper);
   background-image:
-    radial-gradient(circle at 25% 18%, rgba(42,29,16,0.025) 0 1px, transparent 1.5px),
-    radial-gradient(circle at 70% 60%, rgba(42,29,16,0.02) 0 1px, transparent 1.5px);
+    radial-gradient(circle at 25% 18%, var(--grain-1) 0 1px, transparent 1.5px),
+    radial-gradient(circle at 70% 60%, var(--grain-2) 0 1px, transparent 1.5px);
   background-size: 240px 240px, 280px 280px;
 }
 
@@ -208,7 +208,7 @@ body.tier-1 {
   margin: 1.4em 0;
   padding: 0.7rem 1rem;
   border-left: 3px solid var(--sepia);
-  background: rgba(107, 60, 32, 0.04);
+  background: var(--admonition-bg);
 }
 .admonition .admonition-title {
   font-family: var(--font-label);

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -14,13 +14,20 @@
   --oxblood:      #8a3a1f;
   /* DECORATIVE ONLY — illustration strokes, hatch. Fails AA at small text by design. */
   --rust:         #b58a4b;
-  --quiet:        #7a6649;            /* AA on --paper */
+  /* 4.36:1 on --paper, 4.79:1 on --paper-2. The --paper case is BELOW AA (4.5)
+     and has been since the palette landed — the old `AA on --paper` annotation
+     here was never accurate. Tracked separately; not changed in this pass
+     because it shifts the shipped light theme. */
+  --quiet:        #7a6649;
   --quiet-on-code:#6f5a3e;            /* AA on --code-bg — use ONLY for code comments */
   --code-bg:      #e9ddc5;
   --rule:         rgba(42, 29, 16, 0.50);   /* 3.05:1 on --paper, 3.18:1 on --paper-2 (A1) */
   --rule-soft:    rgba(42, 29, 16, 0.15);   /* decorative paper rules; no contrast req */
   --code-string:  #5a3a1f;                  /* syntax strings — AA on --code-bg */
   --zebra:        rgba(42, 29, 16, 0.03);   /* prose table even-row tint */
+  --grain-1:      rgba(42, 29, 16, 0.025);  /* tier-1 paper texture, first pass */
+  --grain-2:      rgba(42, 29, 16, 0.02);   /* tier-1 paper texture, second pass */
+  --admonition-bg:rgba(107, 60, 32, 0.04);
 
   /* Status badges (/status) */
   --badge-active-bg:     #c8d8b8;
@@ -96,7 +103,13 @@
  * Scheme precedence, resolved by the pre-paint script in Head.astro:
  *   1. the reader's stored toggle choice
  *   2. the OS `prefers-color-scheme`
- *   3. dark, when the OS expresses no preference
+ *   3. dark, when neither is available
+ *
+ * Tier 3 is narrower than it looks. Media Queries L5 dropped `no-preference`,
+ * and `light` is now defined to cover "has not expressed an active preference"
+ * — so there is no detectable third OS state, and tier 3 is reachable only
+ * where `matchMedia` itself is missing. In practice the ladder is: stored
+ * choice, else the OS, else dark.
  *
  * That ladder lives in JS, not here, so this palette is written once: the
  * script always stamps `data-theme` on <html> before first paint, and CSS just
@@ -107,7 +120,13 @@
  * and dark applies unless light was resolved. So:
  *   data-theme="dark"   -> dark  (matched by :not([light]))
  *   data-theme="light"  -> light (wins on the base rule, no !important needed)
- *   no attribute        -> dark  (script hasn't run / JS off — tier 3)
+ *   no attribute        -> dark
+ *
+ * That last row is a deliberate accepted trade-off, not tier 3: CSS alone
+ * cannot run the ladder, so a visitor with JS disabled gets dark REGARDLESS of
+ * their OS setting. Honouring the OS without JS would mean duplicating this
+ * whole block under `@media (prefers-color-scheme: dark)`. The toggle needs JS
+ * anyway, so the duplication was judged not worth it.
  *
  * Scoped to `screen` so print always falls through to the paper tokens on
  * :root — a dark --ink is cream, which prints as nothing.
@@ -122,13 +141,16 @@
   --sepia:        #c39a76;
   --oxblood:      #d97a5e;
   --rust:         #c89968;
-  --quiet:        #8b7860;
+  --quiet:        #9c8a72;                  /* 5.25:1 on --paper, 4.96:1 on --paper-2 */
   --quiet-on-code:#a99275;
   --code-bg:      #2a1f17;
   --rule:         rgba(239, 228, 206, 0.50);
   --rule-soft:    rgba(239, 228, 206, 0.15);
   --code-string:  #d9a97c;                  /* AA on dark --code-bg */
   --zebra:        rgba(239, 228, 206, 0.045);
+  --grain-1:      rgba(239, 228, 206, 0.022);
+  --grain-2:      rgba(239, 228, 206, 0.018);
+  --admonition-bg:rgba(217, 122, 94, 0.07);
 
   --badge-active-bg:     #24361b;
   --badge-active-fg:     #bfd6ac;

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -19,6 +19,19 @@
   --code-bg:      #e9ddc5;
   --rule:         rgba(42, 29, 16, 0.50);   /* 3.05:1 on --paper, 3.18:1 on --paper-2 (A1) */
   --rule-soft:    rgba(42, 29, 16, 0.15);   /* decorative paper rules; no contrast req */
+  --code-string:  #5a3a1f;                  /* syntax strings — AA on --code-bg */
+  --zebra:        rgba(42, 29, 16, 0.03);   /* prose table even-row tint */
+
+  /* Status badges (/status) */
+  --badge-active-bg:     #c8d8b8;
+  --badge-active-fg:     #2a3d20;
+  --badge-active-rule:   #4a6535;
+  --badge-quiet-bg:      #ead9b1;
+  --badge-quiet-fg:      #5e4a1d;
+  --badge-quiet-rule:    #8a6a30;
+  --badge-hibernate-bg:  #d5c9b3;
+  --badge-hibernate-fg:  #463829;
+  --badge-hibernate-rule:#6a5847;
 
   /* Type stacks */
   --font-display: "Fraunces", "Source Serif 4", Iowan Old Style, Apple Garamond, serif;
@@ -78,8 +91,31 @@
   }
 }
 
-/* Lights-low / dark tokens (D8). No toggle UI in v1.0 — tokens defined so impl can land. */
-[data-theme="dark"] {
+/* Lights-low / dark tokens (D8).
+ *
+ * Scheme precedence, resolved by the pre-paint script in Head.astro:
+ *   1. the reader's stored toggle choice
+ *   2. the OS `prefers-color-scheme`
+ *   3. dark, when the OS expresses no preference
+ *
+ * That ladder lives in JS, not here, so this palette is written once: the
+ * script always stamps `data-theme` on <html> before first paint, and CSS just
+ * reads the attribute. Expressing the ladder in CSS would mean repeating the
+ * whole block, since a media query can't be unioned into a selector list.
+ *
+ * Selector shape: light values live on bare :root above as the fallback base,
+ * and dark applies unless light was resolved. So:
+ *   data-theme="dark"   -> dark  (matched by :not([light]))
+ *   data-theme="light"  -> light (wins on the base rule, no !important needed)
+ *   no attribute        -> dark  (script hasn't run / JS off — tier 3)
+ *
+ * Scoped to `screen` so print always falls through to the paper tokens on
+ * :root — a dark --ink is cream, which prints as nothing.
+ */
+@media screen {
+:root:not([data-theme="light"]) {
+  color-scheme: dark;
+
   --paper:        #1f1812;
   --paper-2:      #261d15;
   --ink:          #efe4ce;
@@ -91,4 +127,19 @@
   --code-bg:      #2a1f17;
   --rule:         rgba(239, 228, 206, 0.50);
   --rule-soft:    rgba(239, 228, 206, 0.15);
+  --code-string:  #d9a97c;                  /* AA on dark --code-bg */
+  --zebra:        rgba(239, 228, 206, 0.045);
+
+  --badge-active-bg:     #24361b;
+  --badge-active-fg:     #bfd6ac;
+  --badge-active-rule:   #6a8f52;
+  --badge-quiet-bg:      #382c11;
+  --badge-quiet-fg:      #e3cd96;
+  --badge-quiet-rule:    #97783c;
+  --badge-hibernate-bg:  #2e281f;
+  --badge-hibernate-fg:  #cabba4;
+  --badge-hibernate-rule:#7d6c56;
+}
+
+:root[data-theme="light"] { color-scheme: light; }
 }


### PR DESCRIPTION
Adds a dark colour scheme to hippobrain.org with a toggle in the primary nav.

The design spec already reserved the palette — `tokens.css` carried a `[data-theme="dark"]` block annotated *"D8. No toggle UI in v1.0 — tokens defined so impl can land."* This lands the impl using those values as authored, rather than inventing a new palette.

## Scheme precedence

Resolved by a pre-paint inline script in `Head.astro`:

1. the reader's stored toggle choice
2. the OS `prefers-color-scheme`
3. **dark**, when the OS expresses no preference

The ladder lives in JS rather than CSS so the dark palette is written exactly once. Expressing it in CSS would need the whole block duplicated across two media contexts — there's no way to union a media query into a selector list — so `data-theme` on `<html>` stays the single source of truth and CSS just reads the attribute.

## Implementation notes

Three things this shape is deliberately guarding against:

- **Flash of wrong palette.** The script is `is:inline` in `<head>`, so the attribute is stamped before first paint. A bundled or deferred script would paint the fallback first.
- **`ClientRouter` resets `<html>` attributes** from the incoming page, so a JS-set `data-theme` silently vanishes on the first in-site navigation. `astro:after-swap` re-applies it. The click handler is delegated from `document` for the same reason — a body swap can't orphan or double-bind it.
- **macOS auto-switches at sunset.** The live `matchMedia` listener is gated on `if (!stored())`, so an OS flip never stomps an explicit choice mid-session.

## Latent bugs fixed along the way

Five hardcoded light-only colours would have been unreadable against the dark palette. Each is now a token defined in both schemes:

| Location | Was |
|---|---|
| `code.css` | syntax string tokens pinned to `#5a3a1f` |
| `prose.css` | table zebra striping as literal `rgba(42, 29, 16, 0.03)` |
| `tier-1.css` | all three status badges (active / quiet / hibernating) |

The dark block is scoped to `@media screen` so print falls through to the paper tokens — a dark `--ink` is cream, which prints as nothing.

## Verification

- `astro check` — 0 errors, 0 warnings (1 pre-existing hint, unused import in `link-rewrite.ts`)
- `astro build` + pagefind — 49 pages, clean
- Playwright matrix over emulated colour schemes, all passing:

| Scenario | Result | Tier |
|---|---|---|
| OS light, no stored choice | `light` | 2 |
| OS dark, no stored choice | `dark` | 2 |
| OS expresses no preference | `dark` | 3 |
| OS dark, toggled to light | `light` | 1 |
| …after a reload | `light` | 1, persisted |
| Stored light, OS flips live | stays `light` | 1 beats live OS |
| No stored choice, OS flips live | follows to `dark` | 2 live-tracks |

`theme-color` meta and the toggle's `aria-pressed` / `aria-label` tracked correctly in every case. Persistence was also confirmed across a real `ClientRouter` navigation, with exactly one toggle bound (no double-binding). Visually spot-checked `/`, `/install` (code blocks and comments), and `/status` (badges) in dark.

## Known trade-off

A **no-JS visitor on a light OS gets dark**, since CSS alone can't run the ladder and the no-attribute fallback is tier 3. Everyone with JS gets their OS setting honoured before first paint. This seemed right for a site whose toggle requires JS regardless; making no-JS visitors track the OS too would cost one duplicated dark token block in a `@media (prefers-color-scheme: dark)` rule. Happy to add it if preferred.
