### PR TITLE
chore(cargo): manifest hygiene, feature-lane CI, minimal release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,12 @@ jobs:
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Version: ${VERSION}"
 
+      # Minimal artifact: default features (otel) are disabled to keep the
+      # binary and the build small. Build from source for the full feature
+      # set. Symbol stripping comes from profile.release in Cargo.toml.
       - name: Build daemon binary (aarch64)
         run: |
-          cargo build --release --target aarch64-apple-darwin --bin hippo --locked
-
-      - name: Strip binary
-        run: |
-          strip target/aarch64-apple-darwin/release/hippo
+          cargo build --release --target aarch64-apple-darwin --bin hippo --locked --no-default-features
 
       - name: Prepare artifact
         id: artifact
@@ -230,7 +229,7 @@ jobs:
 
           ## Components
 
-          - **hippo-daemon**: Rust binary for shell capture, secret redaction, and CLI queries
+          - **hippo-daemon**: Rust binary for shell capture, secret redaction, and CLI queries. Minimal build with default features disabled (no OTel metrics exporter); build from source with \`cargo build --release\` for the full feature set.
           - **hippo-brain**: Python enrichment server with LLM integration and vector embeddings
 
           ## Verification
@@ -266,13 +265,15 @@ jobs:
 
       - name: Release summary
         run: |
-          echo "### Release ${{ github.ref_name }} Published! :rocket:" >> "${GITHUB_STEP_SUMMARY}"
-          echo "" >> "${GITHUB_STEP_SUMMARY}"
-          echo "#### Artifacts" >> "${GITHUB_STEP_SUMMARY}"
-          echo "- Daemon: \`${{ needs.build-daemon.outputs.artifact_name }}\`" >> "${GITHUB_STEP_SUMMARY}"
-          echo "- Brain: \`${{ needs.build-brain.outputs.artifact_name }}\`" >> "${GITHUB_STEP_SUMMARY}"
-          echo "" >> "${GITHUB_STEP_SUMMARY}"
-          echo "#### Quick Install" >> "${GITHUB_STEP_SUMMARY}"
-          echo '```bash' >> "${GITHUB_STEP_SUMMARY}"
-          echo "curl -fsSL https://github.com/stevencarpenter/hippo/releases/download/${{ github.ref_name }}/install.sh | bash" >> "${GITHUB_STEP_SUMMARY}"
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+          {
+            echo "### Release ${{ github.ref_name }} Published! :rocket:"
+            echo ""
+            echo "#### Artifacts"
+            echo "- Daemon: \`${{ needs.build-daemon.outputs.artifact_name }}\`"
+            echo "- Brain: \`${{ needs.build-brain.outputs.artifact_name }}\`"
+            echo ""
+            echo "#### Quick Install"
+            echo '```bash'
+            echo "curl -fsSL https://github.com/stevencarpenter/hippo/releases/download/${{ github.ref_name }}/install.sh | bash"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,17 @@ jobs:
           shared-key: rust-ci-${{ matrix.os }}-${{ github.base_ref || github.ref_name }}
           cache-on-failure: true
 
-      - name: Build all targets
+      # PRs build and test with default features off: the otel stack (tonic,
+      # prost, opentelemetry) is unused in CI and PR runs fire on every
+      # agent-loop push. Merges to main build and test with otel on, and both
+      # clippy steps type-check both configurations on every run, so a PR that
+      # breaks otel-gated code still fails pre-merge.
+      - name: Build all targets (PR, no default features)
+        if: github.event_name == 'pull_request'
+        run: cargo build --all-targets --locked --no-default-features
+
+      - name: Build all targets (merge, default features)
+        if: github.event_name == 'push'
         run: cargo build --all-targets --locked
 
       - name: Run clippy
@@ -87,7 +97,12 @@ jobs:
       - name: Clippy (no default features)
         run: cargo clippy --no-default-features --all-targets -p hippo-daemon -- -D warnings
 
-      - name: Run tests
+      - name: Run tests (PR, no default features)
+        if: github.event_name == 'pull_request'
+        run: cargo test --locked --no-fail-fast --no-default-features
+
+      - name: Run tests (merge, default features)
+        if: github.event_name == 'push'
         run: cargo test --locked --no-fail-fast
 
       - name: Install cargo-audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --locked --no-deps -- -D warnings
 
+      - name: Clippy (no default features)
+        run: cargo clippy --no-default-features --all-targets -p hippo-daemon -- -D warnings
+
       - name: Run tests
         run: cargo test --locked --no-fail-fast
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hippo-core"
-version = "0.31.0"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "hippo-daemon"
-version = "0.31.0"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "proptest",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1165,15 +1165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,9 +1323,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1363,9 +1354,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1409,7 +1400,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -1424,7 +1415,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror",
  "tokio",
  "tonic",
@@ -1467,29 +1458,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1695,15 +1663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,14 +1704,16 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1770,41 +1731,9 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-service",
@@ -1918,12 +1847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,12 +1863,6 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -2026,18 +1943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -2298,7 +2203,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -354,7 +354,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -616,9 +616,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1262,7 +1262,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1792,7 +1792,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2006,7 +2006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2121,7 +2121,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2768,7 +2768,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hippo-core", "crates/hippo-daemon"]
 resolver = "2"
 
 [workspace.package]
-version = "0.31.0"
+version = "0.31.2"
 edition = "2024"
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,33 @@ version = "0.31.0"
 edition = "2024"
 license = "MIT"
 
+[workspace.lints.rust]
+rust_2018_idioms = { level = "warn", priority = -1 }
+
+[workspace.lints.clippy]
+dbg_macro = "warn"
+todo = "warn"
+
 [workspace.dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+dirs = "6"
 regex = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+tempfile = "3"
+tokio = { version = "1", features = [
+    "io-util",
+    "macros",
+    "net",
+    "process",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "time",
+] }
 tokio-util = { version = "0.7", features = ["codec"] }
 toml = "1.1.0"
 tracing = "0.1"
@@ -28,3 +46,7 @@ opentelemetry-appender-tracing = "0.32"
 tracing-opentelemetry = "0.33"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 sha2 = "0.11"
+
+[profile.release]
+lto = "thin"
+strip = "symbols"

--- a/brain/pyproject.toml
+++ b/brain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hippo-brain"
-version = "0.31.0"
+version = "0.31.2"
 requires-python = ">=3.14"
 dependencies = [
   "httpx>=0.28",

--- a/brain/uv.lock
+++ b/brain/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "hippo-brain"
-version = "0.31.0"
+version = "0.31.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/crates/hippo-core/Cargo.toml
+++ b/crates/hippo-core/Cargo.toml
@@ -3,10 +3,13 @@ name = "hippo-core"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-dirs = "6"
+dirs.workspace = true
 regex.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
@@ -17,4 +20,4 @@ tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/crates/hippo-core/src/storage.rs
+++ b/crates/hippo-core/src/storage.rs
@@ -5833,7 +5833,7 @@ pub mod workflow_store {
         pub raw_json: &'a str,
     }
 
-    pub fn upsert_run(conn: &Connection, run: &RunRow, now_ms: i64) -> Result<()> {
+    pub fn upsert_run(conn: &Connection, run: &RunRow<'_>, now_ms: i64) -> Result<()> {
         conn.execute(
             "INSERT INTO workflow_runs
                 (id, repo, head_sha, head_branch, event, status, conclusion,
@@ -5879,7 +5879,7 @@ pub mod workflow_store {
         pub raw_json: &'a str,
     }
 
-    pub fn upsert_job(conn: &Connection, job: &JobRow) -> Result<()> {
+    pub fn upsert_job(conn: &Connection, job: &JobRow<'_>) -> Result<()> {
         conn.execute(
             "INSERT INTO workflow_jobs
                 (id, run_id, name, status, conclusion, started_at, completed_at,

--- a/crates/hippo-daemon/Cargo.toml
+++ b/crates/hippo-daemon/Cargo.toml
@@ -3,6 +3,9 @@ name = "hippo-daemon"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "hippo_daemon"
 path = "src/lib.rs"
@@ -23,13 +26,19 @@ tracing-subscriber.workspace = true
 tracing-appender = { workspace = true }
 uuid.workspace = true
 chrono.workspace = true
-dirs = "6"
+dirs.workspace = true
 libc = "0.2"
 hostname = "0.4"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.13", default-features = false, features = [
+    "charset",
+    "http2",
+    "json",
+    "native-tls",
+    "system-proxy",
+] }
 rusqlite.workspace = true
 url = "2.5.8"
-serde = { workspace = true, features = ["derive"] }
+serde.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -53,7 +62,7 @@ otel = [
 ]
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wiremock = "0.6"
 proptest = "1"

--- a/crates/hippo-daemon/src/claude_session.rs
+++ b/crates/hippo-daemon/src/claude_session.rs
@@ -634,7 +634,7 @@ fn extract_assistant_content(msg: &serde_json::Value) -> (Vec<String>, Vec<ToolC
 /// tool-call summary. Matches the Python `redact_segment_secrets` step; the
 /// builtin pattern set is shared with `hippo_brain.redaction`.
 fn extract_segments(
-    session_file: &SessionFile,
+    session_file: &SessionFile<'_>,
     redaction: &RedactionEngine,
 ) -> Result<Vec<SessionSegment>> {
     let file = std::fs::File::open(session_file.path)

--- a/crates/hippo-daemon/src/codex_session.rs
+++ b/crates/hippo-daemon/src/codex_session.rs
@@ -524,7 +524,7 @@ fn decide_enqueue(
 /// `ON CONFLICT (session_id, harness, segment_index)`. `ingest_file` (Task 7) calls
 /// this directly so a whole rollout file's segments commit atomically
 /// (spec §4.3, AP-1).
-pub fn upsert_segment_tx(tx: &rusqlite::Transaction, seg: &CodexSegment) -> Result<()> {
+pub fn upsert_segment_tx(tx: &rusqlite::Transaction<'_>, seg: &CodexSegment) -> Result<()> {
     let now_ms = chrono::Utc::now().timestamp_millis();
     let tool_calls_json = serde_json::to_string(&seg.tool_calls).unwrap_or_else(|_| "[]".into());
     let user_prompts_json =

--- a/crates/hippo-daemon/src/cursor_session.rs
+++ b/crates/hippo-daemon/src/cursor_session.rs
@@ -523,7 +523,7 @@ fn decide_enqueue(
 /// caller-supplied transaction. Idempotent via `ON CONFLICT (session_id,
 /// harness, segment_index)`. Unlike Codex, Cursor passes real `is_subagent` /
 /// `parent_session_id` values.
-pub fn upsert_segment_tx(tx: &rusqlite::Transaction, seg: &CursorSegment) -> Result<()> {
+pub fn upsert_segment_tx(tx: &rusqlite::Transaction<'_>, seg: &CursorSegment) -> Result<()> {
     let now_ms = chrono::Utc::now().timestamp_millis();
     let tool_calls_json = serde_json::to_string(&seg.tool_calls).unwrap_or_else(|_| "[]".into());
     let user_prompts_json =

--- a/crates/hippo-daemon/src/lib.rs
+++ b/crates/hippo-daemon/src/lib.rs
@@ -194,6 +194,7 @@ mod busy_retry_tests {
         assert_eq!(attempts, 1);
     }
 
+    #[cfg(feature = "otel")]
     #[test]
     fn record_db_busy_claude_session_insert() {
         assert!(crate::metrics::record_db_busy(

--- a/crates/hippo-daemon/src/watch_claude_sessions.rs
+++ b/crates/hippo-daemon/src/watch_claude_sessions.rs
@@ -176,6 +176,7 @@ async fn process_file(path: &Path, state: &mut FileState, db_path: &Path) -> Res
         return Ok(0);
     }
 
+    #[cfg(feature = "otel")]
     let start = Instant::now();
     let path_owned = path.to_path_buf();
     let db_path_owned = db_path.to_path_buf();
@@ -211,10 +212,8 @@ async fn process_file(path: &Path, state: &mut FileState, db_path: &Path) -> Res
         Ok(r) => r,
     };
 
-    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-
     #[cfg(feature = "otel")]
-    crate::metrics::WATCHER_PROCESS_DURATION_MS.record(elapsed_ms, &[]);
+    crate::metrics::WATCHER_PROCESS_DURATION_MS.record(start.elapsed().as_secs_f64() * 1000.0, &[]);
 
     let (inserted, _skipped, errors) = match join_result {
         Err(join_err) => {


### PR DESCRIPTION
Adopts the Cargo manifest practices a toolchain audit flagged as missing, then uses the now-trustworthy otel feature to cut CI cost.

## Changes

- `[workspace.lints]` (rust_2018_idioms, clippy `dbg_macro`/`todo`) with member opt-in; fixes the five elided-lifetime sites the group surfaced. Lint policy now lives in the manifest instead of CLI flags.
- `[profile.release]`: thin LTO, symbol strip. Release binary 16.1 MB to 13.5 MB.
- reqwest 0.12 to 0.13 with `default-features = false` and `native-tls`: removes the duplicate reqwest/hyper stack pulled in via opentelemetry-otlp while keeping the same Security.framework TLS backend 0.12 used. 0.13's default rustls backend was measured and rejected: aws-lc-sys adds a single-threaded cmake build that regressed clean dev builds from ~12 s to ~21 s.
- `dirs` and `tempfile` centralized in `[workspace.dependencies]`; redundant serde `derive` re-declaration dropped; tokio `full` replaced with the eight features actually used.
- The otel-off configuration compiles (it previously had no automated coverage) and is gated in CI by a no-default-features clippy step.
- PR CI builds and tests with `--no-default-features`: the otel stack (tonic, prost, opentelemetry) drops out of codegen on the high-frequency lane. Merges to main keep the full otel-on build and test; both clippy configs run on every event, so otel-breaking changes still fail pre-merge at type-check cost.
- The tag-built release artifact is a minimal build (`--no-default-features`, 11.3 MB); local `mise run install` and source builds keep otel via the default feature. The manual `strip` step is superseded by the release profile.
- h2 0.4.14 to 0.4.17 for RUSTSEC-2026-0258 (pre-existing on main; CI audit would fail without it).

## Measurements

Interleaved clean-build pairs on an M5 Max, best of 3:

| | main | branch |
|---|---|---|
| dev wall / CPU | 12.1 s / 60.4 s | 14.2 s / 60.3 s |
| release wall / CPU | 37.4 s / 255.6 s | 37.1 s / 249.4 s |
| release binary | 16.1 MB | 13.5 MB (11.3 MB tag artifact) |

The dev wall delta is parallelism, not extra work: the duplicate reqwest stacks previously compiled on idle cores, so deduplicating them saves CPU, not wall clock, on a wide machine. Thin LTO's release cost is offset exactly by the removed stack.

## Validation

- `cargo fmt --check`, clippy with and without default features, `-D warnings`: clean
- `cargo test --workspace`: 695 passed; `--no-default-features`: 678 passed (the 17-test gap is the otel-gated tests, which run locally and on merges to main)
- `cargo audit`: clean; actionlint on both workflows: clean
- otel-off release binary built and smoke-tested locally
