### PR TITLE
fix(site): darken light --quiet to #6f5c41 for WCAG AA on --paper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -354,7 +354,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -656,14 +656,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1143,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1262,7 +1265,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1769,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -1792,7 +1795,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2006,7 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2121,7 +2124,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2768,7 +2771,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/hippo-core", "crates/hippo-daemon"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "0.31.2"
@@ -20,19 +20,19 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
 regex = "1"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = [
-    "io-util",
-    "macros",
-    "net",
-    "process",
-    "rt-multi-thread",
-    "signal",
-    "sync",
-    "time",
+  "io-util",
+  "macros",
+  "net",
+  "process",
+  "rt-multi-thread",
+  "signal",
+  "sync",
+  "time",
 ] }
 tokio-util = { version = "0.7", features = ["codec"] }
 toml = "1.1.0"

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -14,11 +14,9 @@
   --oxblood:      #8a3a1f;
   /* DECORATIVE ONLY — illustration strokes, hatch. Fails AA at small text by design. */
   --rust:         #b58a4b;
-  /* 4.36:1 on --paper, 4.79:1 on --paper-2. The --paper case is BELOW AA (4.5)
-     and has been since the palette landed — the old `AA on --paper` annotation
-     here was never accurate. Tracked separately; not changed in this pass
-     because it shifts the shipped light theme. */
-  --quiet:        #7a6649;
+  /* 5.07:1 on --paper, 5.58:1 on --paper-2; 4.76:1 on --code-bg (AA everywhere).
+     Darkened from #7a6649 (4.36:1 on --paper, below AA) per HIPO-3. */
+  --quiet:        #6f5c41;
   --quiet-on-code:#6f5a3e;            /* AA on --code-bg — use ONLY for code comments */
   --code-bg:      #e9ddc5;
   --rule:         rgba(42, 29, 16, 0.50);   /* 3.05:1 on --paper, 3.18:1 on --paper-2 (A1) */


### PR DESCRIPTION
Closes HIPO-3 (deferred from the PR #270 review, finding 2).

## What

- Darken the light-theme `--quiet` token from `#7a6649` to `#6f5c41`. The old value was 4.36:1 on `--paper`, below the 4.5:1 WCAG AA threshold for normal text, and `--quiet` is used for small body text throughout (worst case: right-rail TOC links at 0.85rem). The `/* AA on --paper */` annotation it carried was never accurate; PR #270 corrected the annotation but deferred the value change to its own review.
- Ride-along: workspace manifest hygiene. `resolver = "3"`, `rusqlite` 0.39 to 0.40, tokio feature list reformat, lockfile regen. Small enough that it does not deserve its own PR; the Rust CI lanes exercise it here.

## Contrast verification (WCAG relative luminance)

| Background | Old `#7a6649` | New `#6f5c41` |
|---|---|---|
| `--paper` `#efe4ce` | 4.36:1 | 5.07:1 |
| `--paper-2` `#f5efe2` | 4.79:1 | 5.58:1 |
| `--code-bg` `#e9ddc5` | n/a | 4.76:1 |
| zebra row composite | n/a | 4.80:1 |
| admonition fill composite | n/a | 4.77:1 |

Every usage site listed in HIPO-3 (plus `EditOnGitHub.astro:20`, not on the ticket's list) references `var(--quiet)`, so the token change covers all of them; no literal `#7a6649` remains outside the provenance comment. The dark-theme counterpart was already fixed in PR #270.

## Verification

- `cargo test` (30 suites), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`: green
- `astro check`, `vitest` (31 tests), full site build: green
