### PR TITLE
a11y(site): hide theme toggle when JS is disabled

### DIFF
--- a/site/src/components/ThemeToggle.astro
+++ b/site/src/components/ThemeToggle.astro
@@ -76,6 +76,14 @@
     stroke-linecap: round;
   }
 
+  /* No-JS gate (HIPO-2). The SSR markup carries no `data-theme`; the head
+     script stamps it on <html> before the body is parsed on every JS-enabled
+     load. So a missing attribute means the click handler never registered, and
+     the button would be a dead control that still announces aria-pressed to
+     screen readers. Hiding on attribute absence removes it from the a11y tree
+     with no flash or layout shift, and needs no separate `js` class. */
+  :global(html:not([data-theme])) .theme-toggle { display: none; }
+
   /* Visibility follows the html attribute. The SSR markup carries no
      `data-theme` at all — the head script stamps it before the body is parsed,
      so the right glyph is correct at first paint without a JS-driven class


### PR DESCRIPTION
Closes HIPO-2 (deferred from the PR #270 review, finding 6).

## What

`ThemeToggle.astro` rendered unconditionally, but its click handler lives entirely in the `is:inline` head script in `Head.astro`. With JS disabled the button stayed keyboard-reachable and announced `aria-pressed`, yet did nothing when activated.

The ticket offered two options: gate visibility on a `js` class, or render the button from the head script. This takes a leaner variant of the first: the head script stamps `data-theme` on `<html>` pre-paint on every JS-enabled load, and the SSR markup never carries the attribute, so attribute absence is already a reliable JS-off signal. One scoped rule hides the control:

```css
:global(html:not([data-theme])) .theme-toggle { display: none; }
```

`display: none` also removes it from the accessibility tree, which is the actual complaint. No flash or layout shift (the attribute lands before body parse), and ClientRouter swaps stay correct because `astro:after-swap` re-stamps the attribute before paint, the same mechanism the existing glyph selectors rely on.

No-JS visitors still get dark regardless of OS; that documented trade-off is unchanged, and the toggle needed JS to function either way.

## Verification

- `astro check`, `vitest` (31 tests), full site build: green
- Confirmed the compiled selector in the built CSS bundle: `html:not([data-theme]) .theme-toggle[data-astro-cid-...]{display:none}`
