### PR TITLE
chore(site): make theme-color meta and favicon scheme-aware

### DIFF
--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,7 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <!-- Scheme-aware (HIPO-4): follows the OS prefers-color-scheme. Favicons
-       cannot read the site's stored toggle choice, so OS scheme is the best
-       available signal. Values mirror tokens.css --paper / --ink per scheme. -->
+  <!-- Scheme-aware (HIPO-4): follows the OS prefers-color-scheme in
+       Chrome/Firefox/Edge. Safari loads SVG favicons but ignores embedded
+       media queries and always renders the light base rules; the deferred
+       favicon.ico/apple-touch-icon work (see Head.astro) is the eventual
+       Safari fix. Favicons cannot read the site's stored toggle choice, so
+       OS scheme is the best available signal. Values mirror tokens.css
+       --paper / --ink per scheme. -->
   <style>
     .ground { fill: #efe4ce; }
     .stroke { stroke: #2a1d10; }

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,6 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" fill="#efe4ce"/>
-  <g fill="none" stroke="#2a1d10" stroke-width="1.4" stroke-linecap="round">
+  <!-- Scheme-aware (HIPO-4): follows the OS prefers-color-scheme. Favicons
+       cannot read the site's stored toggle choice, so OS scheme is the best
+       available signal. Values mirror tokens.css --paper / --ink per scheme. -->
+  <style>
+    .ground { fill: #efe4ce; }
+    .stroke { stroke: #2a1d10; }
+    @media (prefers-color-scheme: dark) {
+      .ground { fill: #1f1812; }
+      .stroke { stroke: #efe4ce; }
+    }
+  </style>
+  <rect class="ground" width="32" height="32"/>
+  <g class="stroke" fill="none" stroke-width="1.4" stroke-linecap="round">
     <path d="M16 6 C24 7, 27 13, 25 19 C23 24, 18 25, 14 23 C11 22, 10 19, 12 16 C13 14, 17 14, 18 16"/>
     <path d="M18 16 C19 18, 17 20, 14 19"/>
   </g>

--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -56,12 +56,17 @@ const fullTitle = title === "Hippo" ? title : `${title} · Hippo`;
 <link rel="preload" href="/fonts/fraunces-variable.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="preload" href="/fonts/jetbrains-mono-variable.woff2" as="font" type="font/woff2" crossorigin />
 
-{/* Media-scoped so the browser chrome matches the OS scheme before the head
-    script runs. Known seam: a no-JS light-OS visitor now gets a light chrome
-    bar over the dark no-JS page rendering (the documented tokens.css
-    trade-off); accepted, since the OS-matching bar is right for the vastly
-    more common JS-enabled load. The head script overrides both metas' content
-    when a stored toggle choice exists, which media queries cannot express. */}
+{/* Media-scoped so browsers that honour theme-color (Chrome, Firefox,
+    Samsung Internet, Safari <= 18.6) match the OS scheme before the head
+    script runs. Safari 26+ ignores theme-color for regular tabs (installed
+    web apps only) and derives chrome colour from the body/fixed-element
+    background instead, so these metas and the script's sync loop are inert
+    there. Known seam on supporting browsers: a no-JS light-OS visitor gets a
+    light chrome bar over the dark no-JS page rendering (the documented
+    tokens.css trade-off); accepted, since the OS-matching bar is right for
+    the vastly more common JS-enabled load. The head script overrides both
+    metas' content when a stored toggle choice exists, which media queries
+    cannot express. */}
 <meta name="theme-color" content="#efe4ce" media="(prefers-color-scheme: light)" />
 <meta name="theme-color" content="#1f1812" media="(prefers-color-scheme: dark)" />
 

--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -56,7 +56,14 @@ const fullTitle = title === "Hippo" ? title : `${title} · Hippo`;
 <link rel="preload" href="/fonts/fraunces-variable.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="preload" href="/fonts/jetbrains-mono-variable.woff2" as="font" type="font/woff2" crossorigin />
 
-<meta name="theme-color" content="#1f1812" />
+{/* Media-scoped so the browser chrome matches the OS scheme before the head
+    script runs. Known seam: a no-JS light-OS visitor now gets a light chrome
+    bar over the dark no-JS page rendering (the documented tokens.css
+    trade-off); accepted, since the OS-matching bar is right for the vastly
+    more common JS-enabled load. The head script overrides both metas' content
+    when a stored toggle choice exists, which media queries cannot express. */}
+<meta name="theme-color" content="#efe4ce" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#1f1812" media="(prefers-color-scheme: dark)" />
 
 {/* Colour scheme. Must be `is:inline` and sit in <head> so the attribute is on
     <html> before first paint — a bundled/deferred script would flash the wrong
@@ -104,7 +111,11 @@ const fullTitle = title === "Hippo" ? title : `${title} · Hippo`;
 
     const apply = (theme) => {
       document.documentElement.setAttribute("data-theme", theme);
-      document.querySelector('meta[name="theme-color"]')?.setAttribute("content", BG[theme]);
+      // Both media-scoped metas get the resolved value, so whichever one the
+      // browser honours reflects the stored choice, not just the OS scheme.
+      for (const meta of document.querySelectorAll('meta[name="theme-color"]')) {
+        meta.setAttribute("content", BG[theme]);
+      }
 
       // State only. The button's accessible name is a static noun in its
       // markup — overwriting it with an action phrase here would make screen


### PR DESCRIPTION
Closes HIPO-4 (deferred from the PR #270 review, findings 7 and 9).

## What

**theme-color meta (`Head.astro`).** The single SSR meta was hardcoded dark and patched at runtime, so a light-OS visitor briefly got a dark chrome bar, and a no-JS light-OS visitor kept it permanently. Now two media-scoped metas (light `#efe4ce`, dark `#1f1812`) let the browser pick pre-script. The head script's stored-choice override writes both metas' content, since a localStorage preference cannot be expressed in a media query. Known seam, noted in a comment: a no-JS light-OS visitor now gets a light chrome bar over the dark no-JS page rendering (the documented tokens.css trade-off); accepted because the OS-matching bar is right for the common JS-enabled load.

**favicon.svg.** Was hardcoded to the light paper ground. It now carries an embedded `@media (prefers-color-scheme: dark)` block mirroring the tokens.css `--paper`/`--ink` pairs per scheme. Favicons cannot read the site's stored toggle, so OS scheme is the best available signal.

## Verification

- `astro check`, `vitest` (31 tests), full site build: green
- Built `dist/index.html` carries both media-scoped metas; `dist/favicon.svg` carries the dark-scheme block
