### PR TITLE
fix(brain): surface auto-resolved fraction in capture-alarm lesson summaries

### DIFF
--- a/brain/src/hippo_brain/capture_alarm_lessons.py
+++ b/brain/src/hippo_brain/capture_alarm_lessons.py
@@ -7,6 +7,15 @@ so hippo's own capture failures surface via ``get_lessons`` after the usual
 
 Processed alarm ids are tracked in ``capture_alarm_lesson_cursor`` (brain-owned
 auxiliary table, created idempotently on first sync).
+
+Auto-resolved alarms (``capture_alarms.resolved_at`` set by the watchdog once an
+invariant has stayed clean for 2 consecutive ticks) are not excluded from
+graduation — a self-clearing flap still counts toward ``occurrences``. Instead,
+the auto-resolved fraction and median resolution time are computed from the
+full alarm history for each cluster and folded into the lesson summary text, so
+a consumer of ``get_lessons`` can tell "flaps constantly but always clears
+itself" apart from "fires and stays red" without inferring health from a raw
+occurrence count alone (issue #264).
 """
 
 from __future__ import annotations
@@ -14,7 +23,9 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+import statistics
 import time
+from dataclasses import dataclass
 
 from hippo_brain.lessons import ClusterKey, upsert_cluster
 from hippo_brain.source_filters import table_exists
@@ -33,22 +44,44 @@ INSERT OR IGNORE INTO capture_alarm_lesson_cursor (id, last_alarm_id) VALUES (1,
 """
 
 
+@dataclass(frozen=True)
+class FlapStats:
+    """Auto-resolution statistics for a capture-alarm cluster (invariant + source)."""
+
+    total: int
+    auto_resolved: int
+    median_resolution_ms: int | None
+
+    @property
+    def auto_resolved_fraction(self) -> float:
+        return self.auto_resolved / self.total if self.total else 0.0
+
+
+def _extract_source(details_json: str) -> str:
+    """Best-effort extraction of the ``source`` field from an alarm's details_json."""
+    try:
+        payload = json.loads(details_json)
+    except json.JSONDecodeError:
+        return ""
+    if isinstance(payload, dict):
+        raw_source = payload.get("source")
+        if raw_source is not None:
+            return str(raw_source)
+    return ""
+
+
 def cluster_key_for_alarm(
     repo: str,
     invariant_id: str,
     details_json: str,
 ) -> ClusterKey:
     """Derive a stable lesson cluster key from a watchdog alarm row."""
-    source = ""
     try:
-        payload = json.loads(details_json)
-        if isinstance(payload, dict):
-            raw_source = payload.get("source")
-            if raw_source is not None:
-                source = str(raw_source)
+        json.loads(details_json)
     except json.JSONDecodeError:
         logger.debug("capture_alarm_lessons: unparseable details_json for %s", invariant_id)
 
+    source = _extract_source(details_json)
     tool = f"hippo-capture:{source}" if source else "hippo-watchdog"
     return ClusterKey(
         repo=repo,
@@ -58,11 +91,70 @@ def cluster_key_for_alarm(
     )
 
 
-def _summary_for_key(key: ClusterKey) -> str:
+def _source_for_key(key: ClusterKey) -> str:
+    if key.tool.startswith("hippo-capture:"):
+        return key.tool.removeprefix("hippo-capture:")
+    return ""
+
+
+def _format_duration_ms(duration_ms: int) -> str:
+    """Render a millisecond duration as a short human-readable string."""
+    if duration_ms < 1_000:
+        return f"{duration_ms}ms"
+    seconds = duration_ms / 1_000
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{minutes:.0f}m"
+    hours = minutes / 60
+    if hours < 24:
+        return f"{hours:.1f}h"
+    days = hours / 24
+    return f"{days:.1f}d"
+
+
+def _flap_stats_for_key(conn: sqlite3.Connection, invariant_id: str, source: str) -> FlapStats:
+    """Aggregate auto-resolution stats across the full capture_alarms history for
+    this (invariant_id, source) cluster — not just the alarms in the current sync
+    batch, so the fraction stays accurate as older alarms keep resolving."""
+    rows = conn.execute(
+        "SELECT raised_at, resolved_at, details_json FROM capture_alarms WHERE invariant_id = ?",
+        (invariant_id,),
+    ).fetchall()
+
+    total = 0
+    auto_resolved = 0
+    resolution_times: list[int] = []
+    for raised_at, resolved_at, details_json in rows:
+        if _extract_source(details_json or "{}") != source:
+            continue
+        total += 1
+        if resolved_at is not None:
+            auto_resolved += 1
+            resolution_times.append(int(resolved_at) - int(raised_at))
+
+    median_resolution_ms = int(statistics.median(resolution_times)) if resolution_times else None
+    return FlapStats(
+        total=total, auto_resolved=auto_resolved, median_resolution_ms=median_resolution_ms
+    )
+
+
+def _summary_for_key(key: ClusterKey, stats: FlapStats | None = None) -> str:
     if key.tool.startswith("hippo-capture:"):
         source = key.tool.removeprefix("hippo-capture:")
-        return f"Capture invariant {key.rule_id} violated for source {source!r}"
-    return f"Capture invariant {key.rule_id} violated (see docs/capture/)"
+        base = f"Capture invariant {key.rule_id} violated for source {source!r}"
+    else:
+        base = f"Capture invariant {key.rule_id} violated (see docs/capture/)"
+
+    if stats is None or stats.total == 0:
+        return base
+
+    pct = round(stats.auto_resolved_fraction * 100)
+    if stats.median_resolution_ms is not None:
+        duration = _format_duration_ms(stats.median_resolution_ms)
+        return f"{base} ({pct}% auto-resolved, median resolution {duration})"
+    return f"{base} ({pct}% auto-resolved)"
 
 
 def _fix_hint_for_key(_key: ClusterKey) -> str:
@@ -115,6 +207,9 @@ def sync_capture_alarms_to_lessons(
 
     processed = 0
     fallback_now = now_ms if now_ms is not None else int(time.time() * 1000)
+    # Clusters touched this sync, in first-seen order — their lesson summary
+    # gets refreshed once at the end from the full alarm history, not per row.
+    touched_keys: dict[ClusterKey, None] = {}
 
     for alarm_id, invariant_id, raised_at, details_json in alarm_rows:
         key = cluster_key_for_alarm(repo, invariant_id, details_json or "{}")
@@ -137,6 +232,8 @@ def sync_capture_alarms_to_lessons(
             )
             break
 
+        touched_keys[key] = None
+
         conn = sqlite3.connect(db_path)
         try:
             conn.execute(
@@ -148,4 +245,38 @@ def sync_capture_alarms_to_lessons(
             conn.close()
         processed += 1
 
+    if touched_keys:
+        _refresh_flap_summaries(db_path, touched_keys)
+
     return processed
+
+
+def _refresh_flap_summaries(db_path: str, keys: dict[ClusterKey, None]) -> None:
+    """Recompute and persist the auto-resolved-fraction summary for each
+    touched cluster's lesson row (a no-op for clusters still pending below
+    ``min_occurrences``, since no lesson row exists for them yet).
+
+    ``upsert_cluster`` only invokes ``summary_fn`` on the alarm that triggers
+    graduation, so without this the summary would freeze at whatever fraction
+    was true at graduation time (often just 2 occurrences) even as hundreds
+    more alarms accumulate — this keeps it current on every sync.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        for key in keys:
+            source = _source_for_key(key)
+            stats = _flap_stats_for_key(conn, key.rule_id, source)
+            conn.execute(
+                """UPDATE lessons SET summary = ?
+                   WHERE repo = ? AND tool = ? AND rule_id = ? AND path_prefix = ?""",
+                (
+                    _summary_for_key(key, stats),
+                    key.repo,
+                    key.tool,
+                    key.rule_id,
+                    key.path_prefix,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()

--- a/brain/tests/test_capture_alarm_lessons.py
+++ b/brain/tests/test_capture_alarm_lessons.py
@@ -41,17 +41,29 @@ def _insert_alarm(
     *,
     source: str = "shell",
     raised_at: int = 1_000,
+    resolved_at: int | None = None,
 ) -> int:
     conn = sqlite3.connect(db_path)
     try:
         cur = conn.execute(
-            "INSERT INTO capture_alarms (invariant_id, raised_at, details_json) VALUES (?, ?, ?)",
-            (invariant_id, raised_at, f'{{"source":"{source}"}}'),
+            """INSERT INTO capture_alarms (invariant_id, raised_at, details_json, resolved_at)
+               VALUES (?, ?, ?, ?)""",
+            (invariant_id, raised_at, f'{{"source":"{source}"}}', resolved_at),
         )
         conn.commit()
         return int(cur.lastrowid)
     finally:
         conn.close()
+
+
+def _lesson_summary(db_path: str, rule_id: str) -> str:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute("SELECT summary FROM lessons WHERE rule_id = ?", (rule_id,)).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    return str(row[0])
 
 
 def test_cluster_key_uses_invariant_and_source() -> None:
@@ -117,3 +129,86 @@ def test_sync_is_idempotent_for_processed_alarms(db_path: str) -> None:
     finally:
         conn.close()
     assert occurrences == 2
+
+
+def test_summary_surfaces_auto_resolved_fraction_when_all_flaps_clear(
+    db_path: str,
+) -> None:
+    """A cluster of alarms that always auto-resolve should read as a flap, not a
+    stuck failure — the summary must carry the resolved fraction, not just a raw
+    occurrence count (issue #264)."""
+    _insert_alarm(db_path, "I-1", raised_at=1_000, resolved_at=1_000 + 1_320_000)
+    _insert_alarm(db_path, "I-1", raised_at=2_000, resolved_at=2_000 + 1_320_000)
+
+    assert sync_capture_alarms_to_lessons(db_path) == 2
+
+    summary = _lesson_summary(db_path, "I-1")
+    assert "100% auto-resolved" in summary
+    assert "median resolution 22m" in summary
+
+
+def test_summary_shows_zero_percent_for_alarms_that_never_resolve(db_path: str) -> None:
+    """Alarms that stay open (resolved_at IS NULL) must not be conflated with
+    auto-resolving flaps — a stuck failure should read as 0% auto-resolved."""
+    _insert_alarm(db_path, "I-1", raised_at=1_000)
+    _insert_alarm(db_path, "I-1", raised_at=2_000)
+
+    assert sync_capture_alarms_to_lessons(db_path) == 2
+
+    summary = _lesson_summary(db_path, "I-1")
+    assert "0% auto-resolved" in summary
+    assert "median resolution" not in summary
+
+
+def test_summary_reflects_mixed_resolution_fraction(db_path: str) -> None:
+    _insert_alarm(db_path, "I-1", raised_at=1_000, resolved_at=1_500)
+    _insert_alarm(db_path, "I-1", raised_at=2_000, resolved_at=2_500)
+    _insert_alarm(db_path, "I-1", raised_at=3_000, resolved_at=3_500)
+    _insert_alarm(db_path, "I-1", raised_at=4_000)
+
+    assert sync_capture_alarms_to_lessons(db_path) == 4
+
+    summary = _lesson_summary(db_path, "I-1")
+    assert "75% auto-resolved" in summary
+
+
+def test_summary_stays_fresh_as_more_alarms_arrive_after_graduation(
+    db_path: str,
+) -> None:
+    """The summary must reflect the CURRENT auto-resolved fraction, not the
+    fraction as of the alarm that triggered graduation — otherwise a lesson
+    frozen at "100% auto-resolved" after 2 occurrences would mislead once 1000
+    more occurrences arrive with a different mix (issue #264)."""
+    _insert_alarm(db_path, "I-1", raised_at=1_000, resolved_at=1_500)
+    _insert_alarm(db_path, "I-1", raised_at=2_000, resolved_at=2_500)
+    assert sync_capture_alarms_to_lessons(db_path) == 2
+    assert "100% auto-resolved" in _lesson_summary(db_path, "I-1")
+
+    # Two more alarms land, neither resolves — the fraction should drop.
+    _insert_alarm(db_path, "I-1", raised_at=3_000)
+    _insert_alarm(db_path, "I-1", raised_at=4_000)
+    assert sync_capture_alarms_to_lessons(db_path) == 2
+
+    summary = _lesson_summary(db_path, "I-1")
+    assert "50% auto-resolved" in summary
+
+
+def test_flap_stats_scoped_per_source_not_shared_across_invariant(db_path: str) -> None:
+    """Two sources sharing an invariant_id must not blend their resolution
+    stats — a firefox flap resolving shouldn't mask a stuck shell failure."""
+    _insert_alarm(db_path, "I-1", source="shell", raised_at=1_000)
+    _insert_alarm(db_path, "I-1", source="shell", raised_at=2_000)
+    _insert_alarm(db_path, "I-1", source="browser", raised_at=1_000, resolved_at=1_500)
+    _insert_alarm(db_path, "I-1", source="browser", raised_at=2_000, resolved_at=2_500)
+
+    assert sync_capture_alarms_to_lessons(db_path) == 4
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT tool, summary FROM lessons WHERE rule_id = 'I-1'").fetchall()
+    finally:
+        conn.close()
+
+    summaries = {tool: summary for tool, summary in rows}
+    assert "0% auto-resolved" in summaries["hippo-capture:shell"]
+    assert "100% auto-resolved" in summaries["hippo-capture:browser"]


### PR DESCRIPTION
## What

`sync_capture_alarms_to_lessons` (`brain/src/hippo_brain/capture_alarm_lessons.py`) now computes each cluster's auto-resolved fraction and median resolution time from the full `capture_alarms` history and folds them into the lesson's `summary` text on every sync, scoped per `(invariant_id, source)` cluster. Occurrence counting and the `min_occurrences=2` graduation threshold are unchanged: auto-resolved alarms still count toward `occurrences`, they are just labeled so `get_lessons` no longer reads a self-clearing flap the same way it reads a stuck failure.

The summary is refreshed after every sync call, not just at the alarm that triggers graduation, because `lessons.upsert_cluster` only calls `summary_fn` once (on the graduating occurrence) and afterward only bumps `occurrences`/`last_seen_at`. Without a fresh recompute, a lesson's summary would freeze at whatever fraction was true at 2 occurrences even as hundreds more alarms accumulate with a different mix.

## Why

Evidence from the issue and a fresh review of `capture_alarm_lessons.py` before this change:

- `brain/src/hippo_brain/capture_alarm_lessons.py:101-109` (pre-fix): `sync_capture_alarms_to_lessons` SELECTed `id, invariant_id, raised_at, details_json` from `capture_alarms` and never read `resolved_at` (or `acked_at`).
- `capture_alarms` has a `resolved_at` column that the watchdog sets on auto-resolve; `lessons.py:56 upsert_cluster` increments `occurrences` unconditionally, so a fast-resolving flap and a stuck failure graduate identically.
- The issue's example: a `hippo-capture:shell` / `I-1` lesson with `occurrences: 1047` read as "capture has been broken for shell for months, still happening," while `hippo alarms list` showed every one of those raises auto-resolving within minutes to hours and `hippo doctor` green.

This implements fix option 3 from the issue (surface the auto-resolved fraction and median resolution time in the summary) rather than option 1 (exclude resolved alarms from graduation) or option 2 (separate lesson categories), since silently excluding resolved rows risks hiding a genuinely intermittent failure that happens to auto-resolve. Both `lessons.py` (the shared `upsert_cluster`/`ClusterKey` used by the GitHub Actions annotation lesson path too) and the `lessons`/`capture_alarms` schema are untouched; `resolved_at` already existed in the schema, so this is a brain-only change.

## Verification

TDD: five new tests were added to `brain/tests/test_capture_alarm_lessons.py` first and confirmed failing against the pre-fix code, then the implementation was added and the same tests confirmed passing.

New tests:
- `test_summary_surfaces_auto_resolved_fraction_when_all_flaps_clear`
- `test_summary_shows_zero_percent_for_alarms_that_never_resolve`
- `test_summary_reflects_mixed_resolution_fraction`
- `test_summary_stays_fresh_as_more_alarms_arrive_after_graduation`
- `test_flap_stats_scoped_per_source_not_shared_across_invariant`

Commands run from the worktree (per the repo's `uv run --project brain pytest` worktree-resolves-main-checkout gotcha, tests were run directly against the worktree's own venv after `uv sync --project brain`):

```
uv sync --project brain
brain/.venv/bin/python -m pytest brain/tests -v
# 1316 passed, 1 xfailed, 1 warning (pre-existing, unrelated to this change)

uv run --project brain ruff check brain/
# All checks passed!

uv run --project brain ruff format --check brain/
# 183 files already formatted
```
